### PR TITLE
Change plugin name to alien-agent-id

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "agent-id",
+  "name": "alien-agent-id",
   "version": "2.0.2",
   "description": "Verifiable cryptographic identity for AI agents — SSH-signed git commits, owner binding via Alien Network SSO, and hash-chained audit logs",
   "owner": {
@@ -11,7 +11,7 @@
   },
   "plugins": [
     {
-      "name": "agent-id",
+      "name": "alien-agent-id",
       "description": "Obtain a verifiable Agent ID linked to a human owner via Alien Network SSO. Sign git commits so every line of agent-written code is cryptographically attributable.",
       "version": "2.0.2",
       "source": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "agent-id",
+  "name": "alien-agent-id",
   "description": "Verifiable cryptographic identity for AI agents — SSH-signed git commits, owner binding via Alien Network SSO, and hash-chained audit logs",
   "version": "2.0.2"
 }

--- a/skills/alien-agent-id/SKILL.md
+++ b/skills/alien-agent-id/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: agent-id
+name: alien-agent-id
 description: Obtain a verifiable Agent ID linked to a human owner via Alien Network SSO. Authenticate with Alien-aware services. Store and retrieve credentials for external services (GitHub, Slack, AWS, etc.). Sign git commits so every line of agent-written code is cryptographically attributable.
 license: Proprietary (internal use only)
 compatibility: Any AI agent with shell access and Node.js 18+ (Claude Code, OpenClaw, etc.)


### PR DESCRIPTION
Updated config files to change plugin name from `agent-id` to `alien-agent-id`.