### PR TITLE
Remove git config side effects

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "alien-agent-id",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Verifiable cryptographic identity for AI agents — SSH-signed git commits, owner binding via Alien Network SSO, and hash-chained audit logs",
   "owner": {
     "name": "Alien",
@@ -13,7 +13,7 @@
     {
       "name": "alien-agent-id",
       "description": "Obtain a verifiable Agent ID linked to a human owner via Alien Network SSO. Sign git commits so every line of agent-written code is cryptographically attributable.",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "source": {
         "source": "url",
         "url": "https://github.com/alien-id/agent-id.git"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "alien-agent-id",
   "description": "Verifiable cryptographic identity for AI agents — SSH-signed git commits, owner binding via Alien Network SSO, and hash-chained audit logs",
-  "version": "2.0.2"
+  "version": "2.0.3"
 }

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ All state is stored in `~/.agent-id/` (configurable via `--state-dir` or `AGENT_
 | `status` | Check if Agent ID exists and is bound |
 | `auth --provider-address <addr>` | Start OIDC auth, get QR page |
 | `bind` | Poll for user approval, create owner binding |
-| `git-setup` | Configure git SSH signing with agent key |
+| `git-setup` | Write SSH key files for commit signing |
 | `git-commit --message "..." [--push]` | Signed commit with trailers + audit log |
 | `git-verify [--commit <hash>]` | Verify provenance chain of a commit |
 | `sign --type T --action A --payload JSON` | Sign any operation |

--- a/cli.mjs
+++ b/cli.mjs
@@ -464,7 +464,6 @@ async function syncAndPushNotes(remote = "origin") {
 async function cmdGitSetup(flags) {
   const stateDir = resolveStateDir(flags);
   const paths = statePaths(stateDir);
-  const scope = flags.global ? "--global" : "--local";
 
   // Ensure we have a key
   const key = await readJsonFile(paths.mainKey, null);
@@ -496,31 +495,7 @@ async function cmdGitSetup(flags) {
   const signerLine = `${agentEmail} ${sshPubKey}`;
   await fs.writeFile(allowedSignersPath, signerLine + "\n", "utf8");
 
-  // Human committer email (for GitHub attribution)
-  const email = flags.email || agentEmail;
-
-  // Configure git
-  const gitConfigs = [
-    ["gpg.format", "ssh"],
-    ["user.signingkey", privateKeyPath],
-    ["gpg.ssh.allowedSignersFile", allowedSignersPath],
-    ["commit.gpgsign", "true"],
-  ];
-
-  for (const [k, v] of gitConfigs) {
-    const out = await execFile("git", ["config", scope, k, v]);
-    if (out.code !== 0) {
-      outputError(`git config ${scope} ${k} failed: ${out.stderr.trim()}`);
-      return;
-    }
-  }
-
-  // Set committer identity (human owner — for GitHub attribution)
-  const committerName = flags.name || "Agent";
-  await execFile("git", ["config", scope, "user.name", committerName]);
-  await execFile("git", ["config", scope, "user.email", email]);
-
-  stderr(`Git SSH signing configured (${scope.replace("--", "")}).`);
+  stderr(`SSH key files written.`);
   stderr(`Add this SSH public key to your GitHub account as a "Signing key":`);
   stderr(`  GitHub → Settings → SSH and GPG keys → New SSH key → Key type: Signing Key`);
   stderr(``);
@@ -528,14 +503,11 @@ async function cmdGitSetup(flags) {
 
   const result = {
     ok: true,
-    scope: scope.replace("--", ""),
     privateKeyPath,
     publicKeyPath,
     allowedSignersPath,
     sshPublicKey: sshPubKey,
     fingerprint: key.fingerprint,
-    email,
-    agentName: committerName,
   };
 
   if (owner?.binding) {
@@ -578,9 +550,26 @@ async function cmdGitCommit(flags) {
 
   const agentEmail = 'alienagentid@eti.co';
 
-  // Commit with SSH signature (uses git config from git-setup)
-  // Agent is the author (wrote the code), human committer is preserved from git config
-  const commitArgs = ["commit", "-S", "-m", fullMessage, "--author", `Alien Agent <${agentEmail}>`];
+  // Write SSH key files for signing
+  const sshDir = path.join(stateDir, "ssh");
+  await ensureDir(sshDir);
+  const privateKeyPath = path.join(sshDir, "agent-id");
+
+  // Ensure SSH key file exists (may already exist from git-setup or bootstrap)
+  try {
+    await fs.access(privateKeyPath);
+  } catch {
+    const opensshKey = ed25519PemToOpenSSHPrivateKey(key.privateKeyPem);
+    await fs.writeFile(privateKeyPath, opensshKey, { encoding: "utf8", mode: 0o600 });
+    await setPrivateFilePermissions(privateKeyPath);
+  }
+
+  // Pass signing config inline — no git config changes needed
+  const commitArgs = [
+    "-c", "gpg.format=ssh",
+    "-c", `user.signingkey=${privateKeyPath}`,
+    "commit", "-S", "-m", fullMessage, "--author", `Alien Agent <${agentEmail}>`,
+  ];
   if (flags["allow-empty"]) {
     commitArgs.push("--allow-empty");
   }
@@ -1261,7 +1250,7 @@ Commands:
   sign           Sign an operation and append to audit trail
   verify         Verify entire state chain integrity
   export-proof   Export proof bundle to stdout
-  git-setup      Configure git to sign commits with Agent ID key
+  git-setup      Write SSH key files for commit signing
   git-commit     Create a signed commit with Agent ID trailers
   git-verify     Verify provenance chain of a signed commit
   auth-header    Generate a signed authentication token for service calls
@@ -1294,9 +1283,6 @@ Sign flags:
   --agent-id <id>            Agent ID (default: main)
 
 Git flags:
-  --global                   Apply git config globally (default: local)
-  --email <email>            Committer email (default: agent-<fp>@agent-id.local)
-  --name <name>              Committer name (default: Agent)
   --message <msg>            Commit message (required for git-commit)
   --allow-empty              Allow empty commits
   --push                     Push commit and proof notes after committing

--- a/skills/alien-agent-id/SKILL.md
+++ b/skills/alien-agent-id/SKILL.md
@@ -5,7 +5,7 @@ license: Proprietary (internal use only)
 compatibility: Any AI agent with shell access and Node.js 18+ (Claude Code, OpenClaw, etc.)
 metadata:
   author: Alien Wallet
-  version: "2.0.2"
+  version: "2.0.3"
 allowed-tools: Bash(node:*) Bash(git:*) Bash(curl:*) Read
 ---
 
@@ -262,7 +262,7 @@ The `--push` flag pushes both the commit and proof notes (handling note ref merg
 
 ### Option B: Normal `git commit`
 
-Since `bootstrap` / `git-setup` sets `commit.gpgsign = true`, any `git commit` is SSH-signed. But it won't have Agent ID trailers or proof notes.
+Normal `git commit` will work but won't have Agent ID trailers, proof notes, or SSH signing. Use `git-commit` for full provenance.
 
 ### GitHub verified badge
 
@@ -320,15 +320,11 @@ node CLI bind --no-require-owner-proof
 
 Blocks for up to 5 minutes while the user scans the QR code with Alien App.
 
-### Step 4: Configure git signing
+### Step 4: Show SSH public key
 
-Before running git-setup, ask the user for their **GitHub email** so commits are associated with their GitHub account:
-
-> "What email should I use for commits? This should match your GitHub account email (you can find it at GitHub → Settings → Emails). A GitHub noreply email like `user@users.noreply.github.com` works too."
-
-```bash
-node CLI git-setup --email <USER_GITHUB_EMAIL>
-```
+After bootstrap (or `git-setup`), tell the user to add the SSH public key to GitHub for verified badges.
+The key is shown in the command output. No git config changes are needed — `git-commit` passes
+signing config inline.
 
 ## 8) Command reference
 
@@ -344,7 +340,7 @@ node CLI git-setup --email <USER_GITHUB_EMAIL>
 | `init` | Generate keypair | No |
 | `auth --provider-address <addr>` | Start OIDC auth, get QR code | No |
 | `bind` | Poll for approval, create owner binding | **Yes** (up to 5 min) |
-| `git-setup [--global] [--email E]` | Configure git SSH signing | No |
+| `git-setup` | Write SSH key files for commit signing | No |
 | `git-commit --message "..." [--push]` | Signed commit + trailers + proof note | No |
 | `git-verify [--commit <hash>]` | Verify provenance chain | No |
 | `sign --type T --action A --payload JSON` | Sign operation for audit trail | No |
@@ -360,9 +356,6 @@ node CLI git-setup --email <USER_GITHUB_EMAIL>
 | `--sso-url <url>` | `https://sso.alien-api.com` | SSO base URL |
 | `--raw` | — | Output raw text instead of JSON (auth-header) |
 | `--timeout-sec <n>` | `300` | Poll timeout for `bind` |
-| `--global` | — | Apply git config globally instead of per-repo |
-| `--name <name>` | `Agent` | Git committer name (human owner) |
-| `--email <email>` | auto-generated | Git committer email (human owner's GitHub email) |
 | `--allow-empty` | — | Allow empty commits with `git-commit` |
 | `--push` | — | Push commit and proof notes after `git-commit` |
 | `--remote <name>` | `origin` | Remote to push to (with `--push`) |

--- a/tests/test-refresh.mjs
+++ b/tests/test-refresh.mjs
@@ -2,7 +2,7 @@
 
 // Tests for SSO session refresh flow.
 // Uses Node.js built-in test runner and a mock HTTP server.
-// Run: node --test test-refresh.mjs
+// Run: node --test tests/test-refresh.mjs
 
 import { describe, it, before, after, beforeEach } from "node:test";
 import assert from "node:assert/strict";
@@ -28,7 +28,7 @@ import {
   signEd25519Base64Url,
   canonicalJSONString,
   sha256Hex,
-} from "./lib.mjs";
+} from "../lib.mjs";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────────
 
@@ -662,7 +662,7 @@ describe("CLI refresh command (integration)", () => {
       const { promisify } = await import("node:util");
       const exec = promisify(execFile);
 
-      const cliPath = new URL("./cli.mjs", import.meta.url).pathname;
+      const cliPath = new URL("../cli.mjs", import.meta.url).pathname;
       const { stdout } = await exec("node", [cliPath, "refresh", "--state-dir", stateDir]);
 
       const result = JSON.parse(stdout);
@@ -700,7 +700,7 @@ describe("CLI refresh command (integration)", () => {
     const { promisify } = await import("node:util");
     const exec = promisify(execFile);
 
-    const cliPath = new URL("./cli.mjs", import.meta.url).pathname;
+    const cliPath = new URL("../cli.mjs", import.meta.url).pathname;
 
     try {
       await exec("node", [cliPath, "refresh", "--state-dir", stateDir]);


### PR DESCRIPTION
Stop git-setup from touching git config
                                                                                                                                                                                        
`git-setup` and `git-commit` used to write signing settings (`gpg.format`, `user.signingkey`, `commit.gpgsign`) and override user.name/user.email in git config. Now git-commit passes signing config inline via -c flags, and git-setup just writes the SSH key files.                                      
                  
