### PR TITLE
base64url-encode id_token in proof bundles (v2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "alien-agent-id",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Verifiable cryptographic identity for AI agents — SSH-signed git commits, owner binding via Alien Network SSO, and hash-chained audit logs",
   "owner": {
     "name": "Alien",
@@ -13,7 +13,7 @@
     {
       "name": "alien-agent-id",
       "description": "Obtain a verifiable Agent ID linked to a human owner via Alien Network SSO. Sign git commits so every line of agent-written code is cryptographically attributable.",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "source": {
         "source": "url",
         "url": "https://github.com/alien-id/agent-id.git"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "alien-agent-id",
   "description": "Verifiable cryptographic identity for AI agents — SSH-signed git commits, owner binding via Alien Network SSO, and hash-chained audit logs",
-  "version": "2.1.1"
+  "version": "2.1.2"
 }

--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ Anyone can trace: **this code** → **this agent** (fingerprint) → **this huma
 → **verified AlienID holder**.
 
 Each `git-commit` also attaches a **proof bundle** as a git note (`refs/notes/agent-id`)
-containing the agent's public key, owner binding, and SSO id_token — everything needed for
-anyone to verify the provenance chain without access to the agent's local state.
+containing the agent's public key, owner binding, and base64url-encoded SSO id_token — everything
+needed for anyone to verify the provenance chain without access to the agent's local state.
 
 ---
 
@@ -150,7 +150,8 @@ node skills/alien-agent-id/cli.mjs git-verify --commit HEAD
 ```
 
 Verification is **self-contained** — `git-commit` attaches a proof bundle as a git note
-(`refs/notes/agent-id`) containing the agent's public key, owner binding, and SSO id_token. Anyone
+(`refs/notes/agent-id`) containing the agent's public key, owner binding, and base64url-encoded
+SSO id_token. Anyone
 who clones the repo and fetches the notes can verify the full chain without access to the agent's
 machine.
 

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -566,7 +566,7 @@ The proof bundle contains:
 
 ```json
 {
-  "version": 1,
+  "version": 2,
   "agent": {
     "fingerprint": "f5d9fac4...",
     "publicKeyPem": "-----BEGIN PUBLIC KEY-----\n..."
@@ -584,7 +584,7 @@ The proof bundle contains:
     "payloadHash": "sha256-of-canonical-payload",
     "signature": "Ed25519-base64url"
   },
-  "idToken": "eyJ...",
+  "idToken": "<base64url-encoded-id-token>",
   "ssoBaseUrl": "https://sso.alien-api.com"
 }
 ```
@@ -596,9 +596,10 @@ Verification steps:
 2. proof.ownerBinding.payload — canonical JSON matches payloadHash
 3. proof.ownerBinding.signature — Ed25519 verify with proof.agent.publicKeyPem
 4. proof.ownerBinding.payload.agentInstance.publicKeyFingerprint == token fingerprint
-5. sha256(proof.idToken) == proof.ownerBinding.payload.idTokenHash
-6. Fetch SSO JWKS from proof.ssoBaseUrl + "/.well-known/openid-configuration"
-7. Verify proof.idToken RS256 signature against JWKS
+5. Decode proof.idToken from base64url (v2) or use raw (v1)
+6. sha256(decoded idToken) == proof.ownerBinding.payload.idTokenHash
+7. Fetch SSO JWKS from proof.ssoBaseUrl + "/.well-known/openid-configuration"
+8. Verify decoded idToken RS256 signature against JWKS
 ```
 
 If all checks pass, you have cryptographic proof that:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alien-agent-id",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Universal Agent ID - verifiable identity for AI agents linked to human owners via Alien Network SSO",
   "type": "module",
   "bin": {

--- a/skills/alien-agent-id/SKILL.md
+++ b/skills/alien-agent-id/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: Any AI agent with shell access and Node.js 18+ (Claude Code, OpenClaw, etc.)
 metadata:
   author: Alien Wallet
-  version: "2.1.1"
+  version: "2.1.2"
 allowed-tools: Bash(node:*) Bash(git:*) Bash(curl:*) Read
 ---
 

--- a/skills/alien-agent-id/cli.mjs
+++ b/skills/alien-agent-id/cli.mjs
@@ -612,14 +612,15 @@ async function cmdGitCommit(flags) {
   if (owner?.binding) {
     try {
       const ownerSession = await readJsonFile(paths.ownerSession, null);
+      const rawIdToken = ownerSession?.idToken || null;
       const proofBundle = {
-        version: 1,
+        version: 2,
         agent: {
           fingerprint: key.fingerprint,
           publicKeyPem: key.publicKeyPem,
         },
         ownerBinding: owner.binding,
-        idToken: ownerSession?.idToken || null,
+        idToken: rawIdToken ? Buffer.from(rawIdToken).toString("base64url") : null,
         ssoBaseUrl: ownerSession?.issuer
           ? ownerSession.issuer
           : "https://sso.alien-api.com",
@@ -733,11 +734,13 @@ async function cmdGitVerify(flags) {
   let idToken = null;
   let ssoBaseUrl = flags["sso-url"] || "https://sso.alien-api.com";
 
-  if (proof?.version === 1 && proof.ownerBinding) {
+  if ((proof?.version === 1 || proof?.version === 2) && proof.ownerBinding) {
     source = "git-note";
     agentPublicKeyPem = proof.agent?.publicKeyPem || null;
     binding = proof.ownerBinding;
-    idToken = proof.idToken || null;
+    idToken = proof.idToken
+      ? (proof.version >= 2 ? Buffer.from(proof.idToken, "base64url").toString() : proof.idToken)
+      : null;
     ssoBaseUrl = proof.ssoBaseUrl || ssoBaseUrl;
   } else {
     const paths = statePaths(stateDir);


### PR DESCRIPTION
Base64url-encode the id_token in git note proof bundles (v2) so GitHub's secret scanner won't falsely flag the id_token JWT. Backwards-compatible, v1 notes still verify correctly.