### PR TITLE
Embed owner binding and id_token in auth-header tokens

### DIFF
--- a/skills/alien-agent-id/cli.mjs
+++ b/skills/alien-agent-id/cli.mjs
@@ -1214,12 +1214,15 @@ async function cmdAuthHeader(flags) {
   }
 
   const owner = await readJsonFile(paths.ownerBinding, null);
+  const session = await readJsonFile(paths.ownerSession, null);
 
   const token = createAgentToken({
     fingerprint: key.fingerprint,
     publicKeyPem: key.publicKeyPem,
     privateKeyPem: key.privateKeyPem,
     ownerSessionSub: owner?.binding?.payload?.ownerSessionSub || null,
+    ownerBinding: owner?.binding || null,
+    idToken: session?.idToken || null,
   });
 
   const header = `AgentID ${token}`;

--- a/skills/alien-agent-id/lib.mjs
+++ b/skills/alien-agent-id/lib.mjs
@@ -1337,7 +1337,14 @@ export function createAgentToken(params) {
   };
   const canonical = canonicalJSONString(payload);
   const signature = signEd25519Base64Url(canonical, params.privateKeyPem);
-  return b64url(JSON.stringify({ ...payload, sig: signature }));
+  const token = { ...payload, sig: signature };
+  if (params.ownerBinding) {
+    token.ownerBinding = params.ownerBinding;
+  }
+  if (params.idToken) {
+    token.idToken = params.idToken;
+  }
+  return b64url(JSON.stringify(token));
 }
 
 export function verifyAgentToken(tokenB64, opts = {}) {


### PR DESCRIPTION
Auth tokens now carry the full owner verification chain so services can verify who actually owns the agent.

What changed

- `createAgentToken` in `lib.mjs` now attaches `ownerBinding` and `idToken` to the token after signing
- `cmdAuthHeader` in `cli.mjs` reads `owner-binding.json` and `owner-session.json` and passes them through

The signature still covers only the core fields — the proof chain is appended after signing and verified separately by the consuming service via `@alien-id/sso-agent-id`.

Why

Without this, the `owner` field in tokens was self-asserted. Any process could generate a keypair and claim any owner. Now services that use `verifyAgentTokenWithOwner()` can verify the full chain: agent key → owner binding → id_token → Alien SSO JWKS → verified human.