### PR TITLE
Add audience binding to auth-header tokens

### DIFF
--- a/skills/alien-agent-id/SKILL.md
+++ b/skills/alien-agent-id/SKILL.md
@@ -75,18 +75,29 @@ Ask the user: **"Would you like to use the default Alien provider (recommended),
 Then run:
 
 ```bash
-node CLI auth-header
+# Bind the token to the target service origin to prevent cross-service replay
+node CLI auth-header --aud https://service.example.com
 ```
 
 This returns JSON with a `token` field. Use it in HTTP requests:
 
 ```bash
 # Get the auth header for curl
-AUTH=$(node CLI auth-header --raw)
+AUTH=$(node CLI auth-header --aud https://service.example.com --raw)
 curl -H "$AUTH" https://service.example.com/api/whoami
 ```
 
-The token is a self-contained Ed25519-signed assertion containing your fingerprint, public key, owner identity, owner proof chain, and a timestamp. Tokens are valid for 5 minutes. Services verify tokens using [`@alien-id/sso-agent-id`](https://www.npmjs.com/package/@alien-id/sso-agent-id).
+Always pass `--aud` set to the service's origin (scheme + host + port,
+no path). A token without `--aud` is a bearer credential that any
+Alien-aware service can replay against any other within the 5-minute
+window — only omit it if the service's docs say unbound tokens are
+expected.
+
+The token is a self-contained Ed25519-signed assertion containing your
+fingerprint, public key, owner identity, owner proof chain, audience
+(when bound), and a timestamp. Tokens are valid for 5 minutes. Services
+verify tokens using
+[`@alien-id/sso-agent-id`](https://www.npmjs.com/package/@alien-id/sso-agent-id).
 
 ### Discovering service authentication
 

--- a/skills/alien-agent-id/cli.mjs
+++ b/skills/alien-agent-id/cli.mjs
@@ -1216,6 +1216,31 @@ async function cmdAuthHeader(flags) {
   const owner = await readJsonFile(paths.ownerBinding, null);
   const session = await readJsonFile(paths.ownerSession, null);
 
+  let aud = null;
+  if (flags.aud !== undefined) {
+    if (typeof flags.aud !== "string" || flags.aud === "") {
+      outputError("--aud requires a URL value (e.g. --aud https://api.example.com)");
+      return;
+    }
+    if (!URL.canParse(flags.aud)) {
+      outputError(`--aud is not a valid URL: ${flags.aud}`);
+      return;
+    }
+    const parsed = new URL(flags.aud);
+    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+      outputError(`--aud must use http:// or https://, got: ${parsed.protocol}//`);
+      return;
+    }
+    if (parsed.origin !== flags.aud) {
+      outputError(
+        `--aud must be a bare origin (scheme + host + port, no path/query/fragment). ` +
+          `Did you mean: ${parsed.origin}?`,
+      );
+      return;
+    }
+    aud = flags.aud;
+  }
+
   const token = createAgentToken({
     fingerprint: key.fingerprint,
     publicKeyPem: key.publicKeyPem,
@@ -1223,6 +1248,7 @@ async function cmdAuthHeader(flags) {
     ownerSessionSub: owner?.binding?.payload?.ownerSessionSub || null,
     ownerBinding: owner?.binding || null,
     idToken: session?.idToken || null,
+    aud,
   });
 
   const header = `AgentID ${token}`;
@@ -1301,6 +1327,9 @@ Git-verify flags:
 
 Auth-header flags:
   --raw                      Output raw header (not JSON) for use with curl
+  --aud <origin>             Bind token to an audience (e.g. https://api.example.com).
+                             Services must reject tokens whose aud != their own origin
+                             to prevent cross-service replay. Omit for an unbound token.
 
 Vault flags:
   --service <name>           Service name (required for store/get/remove)

--- a/skills/alien-agent-id/lib.mjs
+++ b/skills/alien-agent-id/lib.mjs
@@ -1332,6 +1332,7 @@ export function createAgentToken(params) {
     fingerprint: params.fingerprint,
     publicKeyPem: params.publicKeyPem,
     owner: params.ownerSessionSub || null,
+    aud: params.aud || null,
     timestamp: nowMs(),
     nonce: randomBytes(16).toString("hex"),
   };


### PR DESCRIPTION
Adds audience binding to agent auth tokens to prevent cross-service replay. Today an Alien Agent ID token issued for service A can be replayed against service B for up to 5 minutes - services receiving a token effectively act as bearer agents on behalf of the user across the entire Agent ID ecosystem. This PR closes that gap.
- New --aud <origin> flag on auth-header that binds the token to a specific service origin.
- `aud` is now part of the signed token payload, so it cannot be tampered with by intermediaries.
- CLI validates --aud with URL.canParse: requires a parseable URL with http:// or https:// scheme, and a bare origin (no path / query / fragment). Mistakes get a "Did you mean: …" suggestion.
- Updated SKILL.md so agents know to always pass --aud <service-origin> and understand the cross-service-replay risk of unbound tokens.
