### PR TITLE
feat: key_fingerprint id_token binding for forgery prevention

### DIFF
--- a/skills/alien-agent-id/cli.mjs
+++ b/skills/alien-agent-id/cli.mjs
@@ -229,12 +229,17 @@ async function cmdBind(flags) {
   });
   stderr("Authorization received. Exchanging tokens...");
 
+  // Read agent key fingerprint for id_token binding
+  const agentKey = await readJsonFile(paths.mainKey, null);
+  const keyFingerprint = agentKey?.fingerprint || null;
+
   // Exchange code for tokens
   const tokens = await exchangeAuthorizationCode({
     ssoBaseUrl: pending.ssoBaseUrl,
     providerAddress: pending.providerAddress,
     authorizationCode: poll.authorizationCode,
     codeVerifier: pending.codeVerifier,
+    keyFingerprint,
   });
 
   // Verify id_token
@@ -611,7 +616,28 @@ async function cmdGitCommit(flags) {
   let proofAttached = false;
   if (owner?.binding) {
     try {
-      const ownerSession = await readJsonFile(paths.ownerSession, null);
+      let ownerSession = await readJsonFile(paths.ownerSession, null);
+
+      // Auto-upgrade: if the stored id_token lacks key_fingerprint, refresh to get one
+      if (ownerSession?.idToken && ownerSession?.refreshToken) {
+        try {
+          const tokenParts = ownerSession.idToken.split(".");
+          const claims = JSON.parse(Buffer.from(tokenParts[1], "base64url").toString());
+          if (!claims.key_fingerprint) {
+            stderr("Upgrading id_token with key_fingerprint binding...");
+            const engine = new SignatureEngine({ baseDir: stateDir });
+            await engine.init();
+            const upgraded = await engine.ensureValidSession({ bufferSec: Infinity });
+            if (upgraded?.idToken && upgraded.idToken !== ownerSession.idToken) {
+              ownerSession = upgraded;
+              stderr("id_token upgraded successfully.");
+            }
+          }
+        } catch {
+          // Non-fatal — use existing token
+        }
+      }
+
       const rawIdToken = ownerSession?.idToken || null;
       const proofBundle = {
         version: 2,
@@ -864,6 +890,21 @@ async function cmdGitVerify(flags) {
         `SSO server signature valid (issuer: ${tokenResult.issuer}, sub: ${tokenResult.payload.sub})`,
       );
       result.ssoSignatureValid = true;
+
+      // Step 9: Verify key_fingerprint claim binds this agent
+      const tokenKeyFp = tokenResult.payload.key_fingerprint;
+      if (tokenKeyFp) {
+        if (tokenKeyFp === trailerFingerprint) {
+          result.provenance.push("id_token key_fingerprint matches agent");
+        } else {
+          result.warnings.push(
+            `id_token key_fingerprint mismatch: token=${tokenKeyFp.slice(0, 16)}... agent=${trailerFingerprint.slice(0, 16)}...`,
+          );
+          result.ok = false;
+        }
+      } else {
+        result.warnings.push("id_token missing key_fingerprint claim — token predates key binding");
+      }
     } catch (err) {
       result.warnings.push(`id_token signature verification: ${err instanceof Error ? err.message : String(err)}`);
       result.ssoSignatureValid = false;
@@ -874,9 +915,14 @@ async function cmdGitVerify(flags) {
   }
 
   // Build summary
-  if (result.provenance.length >= 3 && result.sshSignatureValid) {
+  const keyBound = result.provenance.some((p) => p.includes("key_fingerprint matches"));
+  if (result.provenance.length >= 3 && result.sshSignatureValid && keyBound) {
     const ownerLabel = result.ownerSessionSub || "unknown";
     result.summary = `Commit ${resolvedHash.slice(0, 12)} was signed by agent ${trailerFingerprint.slice(0, 16)}... owned by ${ownerLabel}`;
+  } else if (result.provenance.length >= 3 && result.sshSignatureValid && !keyBound) {
+    const ownerLabel = result.ownerSessionSub || "unknown";
+    result.summary = `Commit ${resolvedHash.slice(0, 12)} was signed by agent ${trailerFingerprint.slice(0, 16)}... owned by ${ownerLabel} (unbound key — id_token missing key_fingerprint)`;
+    result.ok = false;
   } else {
     result.summary = `Commit ${resolvedHash.slice(0, 12)} — provenance chain incomplete (see warnings)`;
     result.ok = result.sshSignatureValid && result.provenance.length > 0;

--- a/skills/alien-agent-id/lib.mjs
+++ b/skills/alien-agent-id/lib.mjs
@@ -515,6 +515,9 @@ export async function exchangeAuthorizationCode(params) {
   body.set("code", params.authorizationCode);
   body.set("client_id", params.providerAddress);
   body.set("code_verifier", params.codeVerifier);
+  if (params.keyFingerprint) {
+    body.set("key_fingerprint", params.keyFingerprint);
+  }
 
   const out = await fetchJson(`${base}/oauth/token`, {
     method: "POST",
@@ -535,6 +538,9 @@ export async function refreshSession(params) {
   body.set("grant_type", "refresh_token");
   body.set("refresh_token", params.refreshToken);
   body.set("client_id", params.providerAddress);
+  if (params.keyFingerprint) {
+    body.set("key_fingerprint", params.keyFingerprint);
+  }
 
   const out = await fetchJson(`${base}/oauth/token`, {
     method: "POST",
@@ -925,10 +931,12 @@ export class SignatureEngine {
     const ssoBaseUrl = session.ssoBaseUrl || session.issuer;
     if (!ssoBaseUrl) return null;
 
+    const mainKey = this.keys.get("main");
     const fresh = await refreshSession({
       ssoBaseUrl,
       refreshToken: session.refreshToken,
       providerAddress: session.providerAddress,
+      keyFingerprint: mainKey?.fingerprint || null,
     });
 
     // Verify the refreshed token still belongs to the same owner.

--- a/tests/test-key-fingerprint.mjs
+++ b/tests/test-key-fingerprint.mjs
@@ -1,0 +1,280 @@
+#!/usr/bin/env node
+
+// Tests for key_fingerprint claim in id_token binding.
+// Verifies that forged bindings with stolen id_tokens are rejected.
+// Run: node --test tests/test-key-fingerprint.mjs
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import crypto from "node:crypto";
+
+import {
+  SignatureEngine,
+  generateEd25519PemPair,
+  fingerprintPublicKeyPem,
+  exchangeAuthorizationCode,
+  refreshSession,
+  b64url,
+  canonicalJSONString,
+  sha256Hex,
+} from "../skills/alien-agent-id/lib.mjs";
+
+// Helpers to create a mock SSO server that issues JWTs with key_fingerprint
+
+function generateRsaKeyPair() {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: "spki", format: "pem" },
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  });
+  return { publicKey, privateKey };
+}
+
+function rsaSign(signingInput, privateKeyPem) {
+  const sign = crypto.createSign("RSA-SHA256");
+  sign.update(signingInput);
+  const sig = sign.sign(privateKeyPem);
+  return sig.toString("base64url");
+}
+
+function createIdToken(rsaPrivateKeyPem, kid, issuer, sub, aud, keyFingerprint) {
+  const header = { alg: "RS256", typ: "JWT", kid };
+  const payload = {
+    iss: issuer,
+    sub,
+    aud: [aud],
+    exp: Math.floor(Date.now() / 1000) + 3600,
+    iat: Math.floor(Date.now() / 1000),
+    auth_time: Math.floor(Date.now() / 1000),
+  };
+  if (keyFingerprint) {
+    payload.key_fingerprint = keyFingerprint;
+  }
+
+  const headerB64 = b64url(JSON.stringify(header));
+  const payloadB64 = b64url(JSON.stringify(payload));
+  const signingInput = `${headerB64}.${payloadB64}`;
+  const signature = rsaSign(signingInput, rsaPrivateKeyPem);
+  return `${signingInput}.${signature}`;
+}
+
+function rsaPublicKeyToJwk(publicKeyPem, kid) {
+  const key = crypto.createPublicKey(publicKeyPem);
+  const jwk = key.export({ format: "jwk" });
+  return {
+    kty: "RSA",
+    use: "sig",
+    alg: "RS256",
+    kid,
+    n: jwk.n,
+    e: jwk.e,
+  };
+}
+
+describe("key_fingerprint id_token claim", () => {
+  let rsaKeys;
+  let kid;
+  let mockServer;
+  let mockBaseUrl;
+  const issuer = "https://test-sso.example.com";
+  const providerAddress = "0000000604000000000036159b3c0f15";
+  const ownerSub = "0000000701000000000027dfbf386c25";
+
+  before(async () => {
+    rsaKeys = generateRsaKeyPair();
+    kid = "test-kid-001";
+
+    // Mock SSO server serving OIDC discovery + JWKS + token exchange
+    mockServer = http.createServer((req, res) => {
+      if (req.url === "/.well-known/openid-configuration") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({
+          issuer: mockBaseUrl,
+          jwks_uri: `${mockBaseUrl}/oauth/jwks`,
+        }));
+        return;
+      }
+
+      if (req.url === "/oauth/jwks") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({
+          keys: [rsaPublicKeyToJwk(rsaKeys.publicKey, kid)],
+        }));
+        return;
+      }
+
+      if (req.url === "/oauth/token" && req.method === "POST") {
+        let body = "";
+        req.on("data", (chunk) => { body += chunk; });
+        req.on("end", () => {
+          const params = new URLSearchParams(body);
+          const grantType = params.get("grant_type");
+          const keyFp = params.get("key_fingerprint") || "";
+
+          const response = {
+            access_token: "mock-access-token",
+            token_type: "Bearer",
+            expires_in: 3600,
+            refresh_token: "mock-refresh-token",
+          };
+
+          if (grantType === "authorization_code") {
+            response.id_token = createIdToken(
+              rsaKeys.privateKey, kid, mockBaseUrl, ownerSub, providerAddress, keyFp || undefined,
+            );
+          } else if (grantType === "refresh_token" && keyFp) {
+            response.id_token = createIdToken(
+              rsaKeys.privateKey, kid, mockBaseUrl, ownerSub, providerAddress, keyFp,
+            );
+          }
+
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify(response));
+        });
+        return;
+      }
+
+      res.writeHead(404);
+      res.end("Not found");
+    });
+
+    await new Promise((resolve) => {
+      mockServer.listen(0, "127.0.0.1", () => {
+        const addr = mockServer.address();
+        mockBaseUrl = `http://127.0.0.1:${addr.port}`;
+        resolve();
+      });
+    });
+  });
+
+  after(async () => {
+    mockServer.close();
+  });
+
+  it("token exchange includes key_fingerprint when provided", async () => {
+    const fingerprint = "abcd1234".repeat(8);
+
+    const result = await exchangeAuthorizationCode({
+      ssoBaseUrl: mockBaseUrl,
+      providerAddress,
+      authorizationCode: "mock-code",
+      codeVerifier: "mock-verifier",
+      keyFingerprint: fingerprint,
+    });
+
+    assert.ok(result.id_token, "should have id_token");
+
+    // Decode and check the claim
+    const parts = result.id_token.split(".");
+    const payload = JSON.parse(Buffer.from(parts[1], "base64url").toString());
+    assert.equal(payload.key_fingerprint, fingerprint, "key_fingerprint should be in token");
+  });
+
+  it("token exchange without key_fingerprint produces token without claim", async () => {
+    const result = await exchangeAuthorizationCode({
+      ssoBaseUrl: mockBaseUrl,
+      providerAddress,
+      authorizationCode: "mock-code",
+      codeVerifier: "mock-verifier",
+    });
+
+    const parts = result.id_token.split(".");
+    const payload = JSON.parse(Buffer.from(parts[1], "base64url").toString());
+    assert.equal(payload.key_fingerprint, undefined, "key_fingerprint should be absent");
+  });
+
+  it("forged binding with stolen id_token has wrong key_fingerprint", async () => {
+    // Simulate: victim agent gets an id_token with their fingerprint
+    const victimKeys = generateEd25519PemPair();
+    const victimFingerprint = fingerprintPublicKeyPem(victimKeys.publicKeyPem);
+
+    const victimToken = createIdToken(
+      rsaKeys.privateKey, kid, mockBaseUrl, ownerSub, providerAddress, victimFingerprint,
+    );
+
+    // Attacker generates their own key
+    const attackerKeys = generateEd25519PemPair();
+    const attackerFingerprint = fingerprintPublicKeyPem(attackerKeys.publicKeyPem);
+
+    // Attacker creates a binding using victim's stolen id_token
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "agent-id-test-"));
+    const engine = new SignatureEngine({ baseDir: tmpDir });
+    await engine.init();
+
+    await engine.bindOwnerSession({
+      issuer: mockBaseUrl,
+      ssoBaseUrl: mockBaseUrl,
+      providerAddress,
+      ownerSessionSub: ownerSub,
+      ownerAudience: [providerAddress],
+      idToken: victimToken,
+      accessToken: "stolen-access-token",
+      refreshToken: null,
+      ownerSessionProof: null,
+    });
+
+    // Decode the id_token and check: the key_fingerprint is the VICTIM's, not the ATTACKER's
+    const parts = victimToken.split(".");
+    const payload = JSON.parse(Buffer.from(parts[1], "base64url").toString());
+
+    assert.equal(payload.key_fingerprint, victimFingerprint,
+      "stolen id_token should have victim's fingerprint");
+    assert.notEqual(payload.key_fingerprint, attackerFingerprint,
+      "stolen id_token should NOT match attacker's fingerprint");
+    assert.notEqual(victimFingerprint, attackerFingerprint,
+      "victim and attacker must have different fingerprints");
+
+    // Clean up
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("id_token with matching key_fingerprint passes verification", async () => {
+    const agentKeys = generateEd25519PemPair();
+    const agentFingerprint = fingerprintPublicKeyPem(agentKeys.publicKeyPem);
+
+    const token = createIdToken(
+      rsaKeys.privateKey, kid, mockBaseUrl, ownerSub, providerAddress, agentFingerprint,
+    );
+
+    const parts = token.split(".");
+    const payload = JSON.parse(Buffer.from(parts[1], "base64url").toString());
+
+    assert.equal(payload.key_fingerprint, agentFingerprint,
+      "token key_fingerprint should match agent's fingerprint");
+  });
+
+  it("refresh with key_fingerprint returns id_token with claim", async () => {
+    const fingerprint = "beef0123".repeat(8);
+
+    const result = await refreshSession({
+      ssoBaseUrl: mockBaseUrl,
+      providerAddress,
+      refreshToken: "mock-refresh-token",
+      keyFingerprint: fingerprint,
+    });
+
+    assert.ok(result.access_token, "should have access_token");
+    assert.ok(result.id_token, "should have id_token on refresh with fingerprint");
+
+    const parts = result.id_token.split(".");
+    const payload = JSON.parse(Buffer.from(parts[1], "base64url").toString());
+    assert.equal(payload.key_fingerprint, fingerprint,
+      "refreshed id_token should contain the fingerprint");
+  });
+
+  it("refresh without key_fingerprint returns no id_token", async () => {
+    const result = await refreshSession({
+      ssoBaseUrl: mockBaseUrl,
+      providerAddress,
+      refreshToken: "mock-refresh-token",
+    });
+
+    assert.ok(result.access_token, "should have access_token");
+    assert.equal(result.id_token, undefined,
+      "should NOT have id_token on refresh without fingerprint");
+  });
+});


### PR DESCRIPTION
## Summary

- Agent sends `key_fingerprint` during SSO token exchange and refresh, so the id_token embeds it as a claim
- `git-verify` checks the claim matches the agent's key — mismatch or missing claim → `ok: false`
- At `git-commit` time, auto-upgrades the stored id_token via refresh if the claim is missing
- Adds 6 tests covering exchange, refresh, forgery detection, and backward compatibility

## Motivation

id_tokens from `refs/notes/agent-id` can be stolen and reused to forge agent-id bindings. The root cause: the id_token proves "human X authenticated" but says nothing about which agent key it was issued for. Any agent can create a self-attested binding with a stolen token.

The fix: the SSO now embeds `key_fingerprint` in the id_token (see alien-id/sso#47). Verification checks that the claim matches the proof bundle's key.

## Upgrade path (zero human interaction)

1. Deploy SSO server (backward-compatible)
2. Deploy updated agent-id client
3. On next commit, agent detects old id_token → auto-refreshes → gets key-bound token
4. New proof bundles contain the upgraded id_token

## Changes

| File | Change |
|------|--------|
| `skills/alien-agent-id/lib.mjs` | `exchangeAuthorizationCode` and `refreshSession` send `key_fingerprint`; `ensureValidSession` passes agent fingerprint |
| `skills/alien-agent-id/cli.mjs` | `cmdBind` reads key before exchange; `cmdGitVerify` checks the claim (mismatch = hard fail, missing = `ok: false`); `cmdGitCommit` auto-upgrades old tokens via refresh |
| `tests/test-key-fingerprint.mjs` | 6 new tests: exchange with/without fingerprint, refresh with/without fingerprint, forgery detection, claim matching |

## Test plan

- [ ] All 24 tests pass (`node --test tests/test-key-fingerprint.mjs tests/test-refresh.mjs`)
- [ ] `git-verify` on forged commits returns `ok: false` with "unbound key" warning
- [ ] `git-verify` on legitimate commits with old tokens returns `ok: false` with "missing key_fingerprint" warning
- [ ] After refresh, new commits verify with `ok: true`
- [ ] Depends on alien-id/sso#47