### PR TITLE
feat: default-provider auto-use + owner_proof opt-in for first-try registration

### DIFF
--- a/skills/alien-agent-id/SKILL.md
+++ b/skills/alien-agent-id/SKILL.md
@@ -44,33 +44,15 @@ node CLI status
 
 If `"bound": true` — you already have an Alien Agent ID. Skip to **Section 6**.
 
-### Step 2: Choose provider and start authentication
+### Step 2: Start authentication
 
-**IMPORTANT: You MUST ask the user before proceeding. Never silently read `default-provider.txt` and use it without asking. The user must explicitly choose their provider.**
+Use the default Alien provider — `bootstrap` resolves it from `default-provider.txt` automatically, so first-try registration works without prompting:
 
-Ask the user: **"Would you like to use the default Alien provider (recommended), or set up your own?"**
+```bash
+node CLI bootstrap
+```
 
-- **Default provider**: Only after the user confirms, read the file `default-provider.txt` in the same directory as this skill file (next to `cli.mjs`) to get the address. Proceed to the `auth` command below.
-- **Set up your own**: Show the user this QR code and link to create a SSO provider. Wait for them to provide the address before proceeding.
-  > Scan or open to set up your provider: https://dev.alien.org/dashboard/sso
-  > ```
-  > ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
-  > █ ▄▄▄▄▄ █▄▄████▀ ▄▀ ▄▄█ ▄▄▄▄▄ █
-  > █ █   █ █ ▀█ ▄▄▄▄█▀█▀▄█ █   █ █
-  > █ █▄▄▄█ █▄ ▄▄▀▄▀██▄█  █ █▄▄▄█ █
-  > █▄▄▄▄▄▄▄█▄▀▄▀▄▀ ▀ ▀ ▀▄█▄▄▄▄▄▄▄█
-  > █▄▄  ▀▀▄▀▄▀███▄▄▄ ▄▄ ▀ ▀▀ ▄▄█ █
-  > █ ▄▀▄█▀▄ ▀██▀▀▀ ▀ █▀█▄▀▀  █▄▄▀█
-  > ██▀▄██ ▄█ ▄▀ █▀█  ▄█▀▄█▀▀█▄ ▀▀█
-  > ██▀▀▄▀█▄▀▄ ▄█ ▀▄███▀   █▀ █▄ ▄█
-  > ██  ▄ ▀▄█▄ █▄▀▀█▀▄█▄▄ ▄█▀▄ ▀ ██
-  > █▄█▀▀ ▄▄▄█▄ ▄ ██   ▄▀█ ▄▄▄█ ███
-  > ██▄▄▄██▄▄  █▄  ▀▄▄  █ ▄▄▄   ▀▀█
-  > █ ▄▄▄▄▄ ██  ▄▄▄████   █▄█  █ ██
-  > █ █   █ █▀  ▀ █  ▀ ██▄ ▄  ▀▄▄▀█
-  > █ █▄▄▄█ █ █▄ █▄▀█▄███ ██▄▀▀▄▀▄█
-  > █▄▄▄▄▄▄▄█▄███▄█▄█▄█▄▄▄▄█████▄██
-  > ```
+If the user explicitly asks to use their own provider, they can pass `--provider-address <addr>` (or set `ALIEN_PROVIDER_ADDRESS`); to create one they go to https://dev.alien.org/dashboard/sso. Don't volunteer this unless they bring it up.
 
 Then run:
 
@@ -308,7 +290,7 @@ This returns JSON containing a `deepLink` and a `qrCode` (Unicode text). Output 
 
 ### Step 3: Wait for approval
 ```bash
-node CLI bind --no-require-owner-proof
+node CLI bind
 ```
 
 Blocks for up to 5 minutes while the user scans the QR code with Alien App.

--- a/skills/alien-agent-id/cli.mjs
+++ b/skills/alien-agent-id/cli.mjs
@@ -210,7 +210,10 @@ async function cmdBind(flags) {
   const stateDir = resolveStateDir(flags);
   const timeoutSec = Number(flags["timeout-sec"] || 300);
   const pollIntervalMs = Number(flags["poll-interval-ms"] || 3000);
-  const requireOwnerProof = flags["require-owner-proof"] !== false;
+  // owner_proof is opt-in: SSO server-side support (key derivation, proof
+  // construction) and the matching Alien App "confirm linking" UI are not
+  // shipped yet. Pass --require-owner-proof to enforce once both land.
+  const requireOwnerProof = flags["require-owner-proof"] === true;
 
   const paths = statePaths(stateDir);
   const pending = await readJsonFile(paths.pendingAuth, null);
@@ -249,7 +252,8 @@ async function cmdBind(flags) {
   if (requireOwnerProof && !poll.ownerProof) {
     outputError(
       "OAuth poll did not return owner key proof (owner_proof). " +
-        "Upgrade SSO server or pass --no-require-owner-proof.",
+        "The SSO server and Alien App owner-proof support are not deployed yet — " +
+        "drop --require-owner-proof to bind without it.",
     );
     return;
   }
@@ -1281,7 +1285,7 @@ Auth flags:
 Bind flags:
   --timeout-sec <n>          Poll timeout (default: 300)
   --poll-interval-ms <n>     Poll interval (default: 3000)
-  --no-require-owner-proof   Don't require owner session proof
+  --require-owner-proof      Require owner session proof (default: off, opt-in once SSO + App support lands)
 
 Sign flags:
   --type <type>              Operation type (e.g., TOOL_CALL, MESSAGE_SEND)


### PR DESCRIPTION
## Summary

Two UX defaults that unblock first-try agent-id registration against the production SSO + Alien App stack today, while the deeper changes (owner_proof, DPoP, pseudonyms) work their way through their own release windows.

1. **Default provider auto-use.** `bootstrap` already resolves the default provider from `default-provider.txt`; the SKILL.md previously instructed agents to ask the user "default or your own?" first, which was friction with no security benefit (the file is shipped with the skill, the user already trusts whatever package they installed). Skill now uses the default automatically; custom providers stay supported via `--provider-address` / `ALIEN_PROVIDER_ADDRESS`.
2. **owner_proof is now opt-in.** `cmdBind` defaulted to *requiring* owner_proof in the poll response. The SSO server-side proof writes are uncommitted/undeployed, and the matching Alien App "confirm linking" UI doesn't exist yet — so the default broke binding for real users, who had to discover and pass `--no-require-owner-proof`. This PR flips the default; pass `--require-owner-proof` to enforce once the SSO + App stack catches up.

Net diff: +17 / −31. Removes the ~17-line embedded QR-code block from SKILL.md (saves ~600 bytes of agent context).

## Why this is safe / why now

- Both changes are pure UX defaults; no protocol changes, no breaking wire format.
- The CLI flags still exist — anyone wanting the old behavior passes `--require-owner-proof` (or never uses the new defaults).
- The verifier ([`@alien-id/sso-agent-id`](https://www.npmjs.com/package/@alien-id/sso-agent-id)) already treats \`ownerSessionProof\` as **optional** in \`verifyAgentTokenWithOwner\` (sso-sdk-js, packages/agent-id/src/index.ts:271–309). Tokens without owner_proof verify successfully with \`ownerVerified: false\` — services that today verify Alien Agent ID tokens already handle this gracefully.

## What this does NOT change

- **owner_proof and DPoP work continue independently.** When SSO redeploy + Alien App "confirm linking" UI ship, just stop passing the flag (or revert this PR's default). Agents will then enforce owner_proof again.
- **agent-id 3.0.0 (DPoP cutover)** is a separate PR (#14) on \`feat/dpop-rfc-fixes-v2\`.

## Test plan

- [x] \`node --test tests/*.mjs\` — 18/18 pass on this branch.
- [x] Syntax check both files (\`node --check\`).
- [ ] Manual: \`bootstrap\` with no args succeeds against production SSO using the default provider (no prompt for provider choice).
- [ ] Manual: \`bind\` succeeds without \`--no-require-owner-proof\` against current SSO that doesn't yet return owner_proof.

## Related branches / PRs

- #16 — well-known JSON service manifest (independent, ship in any order)
- #14 — DPoP/cnf cutover (waits for SSO DPoP deploy)
- alien-id/sso #49 — SSO-side DPoP RFC fixes (independent of this PR)
- alien-id/sso uncommitted owner_proof work (gated on Alien App confirmation UX)