### PR TITLE
feat: add setup-owner-session CLI command (fixes #14 docs/code mismatch)

### DIFF
--- a/skills/alien-agent-id/cli.mjs
+++ b/skills/alien-agent-id/cli.mjs
@@ -3,7 +3,7 @@
 // Alien Agent ID — CLI tool for agent identity management.
 // Usage: node cli.mjs <command> [flags]
 //
-// Commands: bootstrap, init, auth, bind, status, sign, verify, export-proof,
+// Commands: bootstrap, setup-owner-session, init, auth, bind, status, sign, verify, export-proof,
 //           git-setup, git-commit, git-verify, vault-store, vault-get, vault-list,
 //           vault-remove, auth-header, refresh
 
@@ -916,6 +916,72 @@ async function cmdBootstrap(flags) {
   });
 }
 
+// ─── Setup Owner Session — DPoP/cnf rebind ─────────────────────────────────────
+
+// Force a fresh OAuth flow that produces a DPoP-bound, cnf-carrying id_token.
+// Used to migrate pre-3.0 agents whose existing bindings carry cnf-less
+// id_tokens that the 3.0 verifier rejects. Keys are preserved; only the
+// owner-session and binding state files are cleared so cmdBind can rewrite.
+async function cmdSetupOwnerSession(flags) {
+  const stateDir = resolveStateDir(flags);
+  const paths = statePaths(stateDir);
+
+  const verbose = flags.verbose === true;
+
+  // Clear only the session/binding/pending-auth state. The keypair stays put —
+  // re-binding under DPoP just adds cnf.jkt for the SAME key the agent already
+  // has; rotating the key would gratuitously invalidate every signed commit.
+  let cleared = false;
+  for (const p of [paths.ownerBinding, paths.ownerSession, paths.pendingAuth]) {
+    try {
+      await fs.unlink(p);
+      cleared = true;
+    } catch (err) {
+      if (err && err.code !== "ENOENT") throw err;
+    }
+  }
+  if (cleared) {
+    stderr("Cleared existing owner-session and binding for re-bind.");
+  }
+
+  const providerAddress = await resolveProviderAddress(flags);
+  if (!providerAddress) {
+    outputError(
+      "No provider address. Set --provider-address, ALIEN_PROVIDER_ADDRESS env, or create default-provider.txt next to the CLI.",
+    );
+    return;
+  }
+  if (verbose) stderr(`Provider address: ${providerAddress}`);
+
+  // Init (no-op if keypair exists; generates one otherwise).
+  const agentKey = await cmdInit({ ...flags, _quiet: true });
+  if (verbose && agentKey?.fingerprint) {
+    stderr(`Agent fingerprint: ${agentKey.fingerprint}`);
+  }
+
+  const authResult = await cmdAuth({
+    ...flags,
+    "provider-address": providerAddress,
+    _noOutput: true,
+  });
+  stderr(`Open this link with your Alien App: ${authResult.deepLink}`);
+  if (verbose) stderr(`Polling code: ${authResult.pollingCode}`);
+
+  const bindResult = await cmdBind({ ...flags, _noOutput: true });
+
+  await cmdGitSetup({ ...flags, _quiet: true });
+
+  outputJson({
+    ok: true,
+    rebound: true,
+    fingerprint: bindResult?.fingerprint,
+    ownerSessionSub: bindResult?.ownerSessionSub,
+    bindingId: bindResult?.bindingId,
+    providerAddress,
+    stateDir,
+  });
+}
+
 // ─── Vault ──────────────────────────────────────────────────────────────────────
 
 function safeServiceName(name) {
@@ -1190,6 +1256,7 @@ Usage: node cli.mjs <command> [flags]
 
 Commands:
   bootstrap      One-command identity setup (init + auth + bind + git-setup)
+  setup-owner-session  Re-bind an existing agent (DPoP/cnf migration; preserves keypair)
   init           Generate Ed25519 keypair and initialize state directory
   auth           Start OIDC authorization (returns deep link + QR page)
   bind           Poll for user approval and create owner binding
@@ -1260,6 +1327,7 @@ All commands output JSON to stdout. Progress and errors go to stderr.
 
 const commands = {
   bootstrap: cmdBootstrap,
+  "setup-owner-session": cmdSetupOwnerSession,
   init: cmdInit,
   auth: cmdAuth,
   bind: cmdBind,


### PR DESCRIPTION
**Stacked on top of #14.** Targets \`feat/dpop-rfc-fixes-v2\`, not \`main\`.

\`docs/MIGRATION-DPOP.md\` instructs operators to run:

\`\`\`bash
alien-agent-id setup-owner-session
alien-agent-id setup-owner-session --verbose
\`\`\`

…but the command was never added to \`cli.mjs\` on the branch. \`bootstrap\` short-circuits when an existing binding is present (\`cli.mjs:861\`), so a pre-3.0 user following the migration guide either hits \`Unknown command\` or runs \`bootstrap\` and watches no rebind happen — both fail-modes leave them with cnf-less id_tokens that the 3.0 verifier rejects.

This adds the command exactly as documented:

- Clears \`owner-binding.json\`, \`owner-session.json\`, and \`pending-auth.json\` so \`cmdBind\` rewrites a fresh DPoP-bound binding.
- **Preserves the keypair on disk.** The agent's identity (and signed commit history) survives the rebind; DPoP adds \`cnf.jkt\` for the same key the agent already holds.
- Re-runs init + auth + bind + git-setup against the configured provider.
- \`--verbose\` prints the agent fingerprint and polling code, matching what MIGRATION-DPOP.md says about debugging cnf mismatches.

## Test plan

- [x] \`node --check\` syntax pass.
- [x] \`node cli.mjs --help\` lists the new command.
- [x] \`node --test tests/*.mjs\` — 62/62 pass on this branch.
- [ ] Manual rebind against a DPoP-aware SSO once one is deployed.

## Why merge into #14 not main

#14 already commits to the BREAKING 3.0.0 cutover and ships the migration guide. Merging this commit into #14 keeps the cutover complete in one PR, rather than landing a public migration guide that points at a missing command and following up with a fix.