### PR TITLE
fix: RFC 9449 §5 token_type discard + cnf-verifier hermetic env

### DIFF
--- a/skills/alien-agent-id/lib.mjs
+++ b/skills/alien-agent-id/lib.mjs
@@ -728,6 +728,18 @@ async function tokenEndpointPost(tokenUrl, body, agentPrivateKeyPem) {
   if (!json || typeof json !== "object") {
     throw new Error(`Expected JSON response from ${tokenUrl}`);
   }
+  // RFC 9449 §5: when the client presents a DPoP proof, it MUST discard the
+  // response unless `token_type` is "DPoP" (case-insensitive per RFC 6749
+  // §5.1). Catches a downgrade or misbehaving AS that returns Bearer for a
+  // DPoP-bound request.
+  if (useDPoP) {
+    const tokenType = typeof json.token_type === "string" ? json.token_type : "";
+    if (tokenType.toLowerCase() !== "dpop") {
+      throw new Error(
+        `RFC 9449 §5: expected token_type="DPoP", got ${JSON.stringify(json.token_type)}`,
+      );
+    }
+  }
   return json;
 }
 

--- a/tests/test-cnf-verifier.mjs
+++ b/tests/test-cnf-verifier.mjs
@@ -38,7 +38,17 @@ import {
   nowMs,
 } from "../skills/alien-agent-id/lib.mjs";
 
-const exec = promisify(execFileCb);
+// Hermetic git env: ignore the developer's global/system config so tests
+// don't pick up `gpg.ssh.program`, `commit.gpgsign`, or other settings that
+// would invoke 1Password / a hardware signer for the test's ephemeral keys.
+const HERMETIC_GIT_ENV = {
+  ...process.env,
+  GIT_CONFIG_GLOBAL: "/dev/null",
+  GIT_CONFIG_SYSTEM: "/dev/null",
+};
+const execRaw = promisify(execFileCb);
+const exec = (file, args, opts = {}) =>
+  execRaw(file, args, { ...opts, env: { ...HERMETIC_GIT_ENV, ...(opts.env || {}) } });
 const CLI_PATH = new URL("../skills/alien-agent-id/cli.mjs", import.meta.url).pathname;
 
 // ─── Fixture helpers ─────────────────────────────────────────────────────────────

--- a/tests/test-dpop.mjs
+++ b/tests/test-dpop.mjs
@@ -422,6 +422,7 @@ describe("exchangeAuthorizationCode with DPoP", () => {
       res.end(
         JSON.stringify({
           access_token: "at",
+          token_type: "DPoP",
           id_token: "it",
           refresh_token: "rt",
         }),
@@ -472,7 +473,7 @@ describe("exchangeAuthorizationCode with DPoP", () => {
       }
       secondProofPayload = decodePart(dpop.split(".")[1]);
       res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ access_token: "at", id_token: "it", refresh_token: "rt" }));
+      res.end(JSON.stringify({ access_token: "at", token_type: "DPoP", id_token: "it", refresh_token: "rt" }));
     });
 
     try {
@@ -501,7 +502,7 @@ describe("refreshSession with DPoP", () => {
     const mock = await createMockServer((req, res) => {
       receivedDpop = req.headers["dpop"];
       res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ access_token: "new-at" }));
+      res.end(JSON.stringify({ access_token: "new-at", token_type: "DPoP" }));
     });
 
     try {
@@ -567,7 +568,7 @@ describe("refreshSession with DPoP", () => {
       }
       secondProofPayload = decodePart(dpop.split(".")[1]);
       res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ access_token: "new-at" }));
+      res.end(JSON.stringify({ access_token: "new-at", token_type: "DPoP" }));
     });
 
     try {
@@ -605,7 +606,7 @@ describe("refreshSession with DPoP", () => {
           "Content-Type": "application/json",
           "DPoP-Nonce": SERVER_NONCE,
         });
-        res.end(JSON.stringify({ access_token: "new-at" }));
+        res.end(JSON.stringify({ access_token: "new-at", token_type: "DPoP" }));
       } else {
         statuses.push(400);
         res.writeHead(400, {
@@ -686,6 +687,7 @@ describe("SignatureEngine.ensureValidSession() forwards DPoP key", () => {
       res.end(
         JSON.stringify({
           access_token: `${header}.${payload}.sig`,
+          token_type: "DPoP",
           refresh_token: "new-rt",
         }),
       );

--- a/tests/test-refresh.mjs
+++ b/tests/test-refresh.mjs
@@ -279,6 +279,7 @@ describe("SignatureEngine.ensureValidSession()", () => {
       res.end(
         JSON.stringify({
           access_token: newFreshToken,
+          token_type: "DPoP",
           refresh_token: "new-rt",
         }),
       );
@@ -318,6 +319,7 @@ describe("SignatureEngine.ensureValidSession()", () => {
       res.end(
         JSON.stringify({
           access_token: makeFreshJwt(),
+          token_type: "DPoP",
           refresh_token: "rotated-rt",
         }),
       );
@@ -353,6 +355,7 @@ describe("SignatureEngine.ensureValidSession()", () => {
       res.end(
         JSON.stringify({
           access_token: makeFreshJwt(),
+          token_type: "DPoP",
           // no refresh_token in response
         }),
       );
@@ -389,6 +392,7 @@ describe("SignatureEngine.ensureValidSession()", () => {
       res.end(
         JSON.stringify({
           access_token: makeFreshJwt(),
+          token_type: "DPoP",
           id_token: newIdToken,
         }),
       );
@@ -461,7 +465,7 @@ describe("SignatureEngine.ensureValidSession()", () => {
   it("treats opaque (non-JWT) access_token as expired and refreshes", async () => {
     const mock = await createMockSsoServer((req, res) => {
       res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ access_token: makeFreshJwt() }));
+      res.end(JSON.stringify({ access_token: makeFreshJwt(), token_type: "DPoP" }));
     });
 
     try {
@@ -515,7 +519,7 @@ describe("SignatureEngine.ensureValidSession()", () => {
     const mock = await createMockSsoServer((req, res) => {
       called = true;
       res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ access_token: makeFreshJwt() }));
+      res.end(JSON.stringify({ access_token: makeFreshJwt(), token_type: "DPoP" }));
     });
 
     try {
@@ -558,7 +562,7 @@ describe("Security hardening", () => {
 
     const mock = await createMockSsoServer((req, res) => {
       res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ access_token: wrongSubToken }));
+      res.end(JSON.stringify({ access_token: wrongSubToken, token_type: "DPoP" }));
     });
 
     try {
@@ -587,7 +591,7 @@ describe("Security hardening", () => {
 
     const mock = await createMockSsoServer((req, res) => {
       res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ access_token: correctSubToken }));
+      res.end(JSON.stringify({ access_token: correctSubToken, token_type: "DPoP" }));
     });
 
     try {
@@ -645,6 +649,7 @@ describe("CLI refresh command (integration)", () => {
       res.end(
         JSON.stringify({
           access_token: makeFreshJwt(),
+          token_type: "DPoP",
           refresh_token: "cli-new-rt",
         }),
       );


### PR DESCRIPTION
Two follow-ups to #14, surfaced by an RFC 9449 audit pass.

## Summary

- **`cd807ea` — RFC 9449 §5 client-side `token_type=DPoP` discard rule.** When the agent presents a DPoP proof at `/oauth/token`, it now MUST discard any response whose `token_type` is not `DPoP` (case-insensitive per RFC 6749 §5.1). Closes a downgrade vector where a misbehaving or compromised AS could return `Bearer` for a DPoP-bound request and the agent would silently consume an unbound token. Guard fires only when `useDPoP` is true, so the legacy non-DPoP path is byte-identical.

- **`fce7398` — make `tests/test-cnf-verifier.mjs` hermetic against the developer's global git config.** The test spawns `git commit -S` with an ephemeral Ed25519 key in a tmpdir; on machines where the user's global config sets `gpg.ssh.program` to a hardware signer (e.g., 1Password's `op-ssh-sign`), the spawned commit picked up that program and rejected the test's key. The wrapped `exec` now sets `GIT_CONFIG_GLOBAL=/dev/null` and `GIT_CONFIG_SYSTEM=/dev/null` per spawn, so the test honors only its own per-repo `user.signingkey` and `gpg.format ssh`.

DPoP test mocks in `test-dpop.mjs` and `test-refresh.mjs` were updated to return `token_type: "DPoP"`, matching what the SSO emits after the F-2 server fix. Mocks that explicitly assert the unbound fallback (`works without DPoP keys`) are unchanged.

## Compliance verdict

After this PR + the merged #14, the A-scope DPoP cutover (server + client wire protocol) meets every applicable RFC 9449 MUST. Server-issued nonces (§8/§9), PARs (§10.1), and per-client `dpop_bound_access_tokens` metadata remain deliberately deferred — all of those are `MAY`.

## Test plan

- [x] `node --test tests/*.mjs` — 62/62 pass on a clean machine.
- [x] cnf-verifier passes with a global `gpg.ssh.program=op-ssh-sign` configured.
- [ ] Manual smoke against staging once the SSO `feat/dpop-rfc-fixes-v3` lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)