### PR TITLE
fix: handle RFC 9449 §9 resource-server nonce challenge

### DIFF
--- a/skills/alien-agent-id/lib.mjs
+++ b/skills/alien-agent-id/lib.mjs
@@ -801,30 +801,56 @@ export async function getUserInfo(params) {
 const dpopNonceCache = new Map();
 
 // fetchWithDPoPNonce executes a request, pre-attaching any cached nonce
-// for `url`. If the server returns 400 + use_dpop_nonce + DPoP-Nonce
-// (RFC 9449 §8/§9), it retries ONCE with the supplied nonce echoed in a
-// freshly built proof and updates the cache. Subsequent responses bearing
-// a DPoP-Nonce header (success or failure) refresh the cache so the
-// server's rotation policy stays sticky.
+// for `url`. Two challenge shapes are recognized per RFC 9449:
+//
+//   §8 (authorization server, e.g. /oauth/token):
+//     400 + JSON body `{"error":"use_dpop_nonce"}` + `DPoP-Nonce` header.
+//
+//   §9 (resource server, e.g. /oauth/userinfo):
+//     401 + `WWW-Authenticate: DPoP error="use_dpop_nonce"` + `DPoP-Nonce`.
+//
+// In either case the helper retries ONCE with the supplied nonce echoed in
+// a freshly built proof and updates the cache. Subsequent responses
+// bearing a DPoP-Nonce header (success or failure) refresh the cache so
+// the server's rotation policy stays sticky.
 async function fetchWithDPoPNonce(url, init, buildHeaders) {
   const cached = dpopNonceCache.get(url);
   let res = await fetch(url, { ...init, headers: buildHeaders(cached) });
   rememberNonce(url, res.headers.get("dpop-nonce"));
 
-  if (res.status !== 400) {
+  if (res.status !== 400 && res.status !== 401) {
     return res;
   }
   const issuedNonce = res.headers.get("dpop-nonce");
   if (!issuedNonce) {
     return res;
   }
-  let body;
-  try {
-    body = await res.clone().json();
-  } catch {
-    return res;
+
+  // Detect the challenge in the right place per status code: §8 puts it in
+  // the JSON body, §9 puts it in WWW-Authenticate.
+  let challenged = false;
+  if (res.status === 400) {
+    try {
+      const body = await res.clone().json();
+      challenged = body && body.error === "use_dpop_nonce";
+    } catch {
+      challenged = false;
+    }
+  } else {
+    const wwwAuth = res.headers.get("www-authenticate") || "";
+    // RFC 6749 §3 / RFC 7235 §2.2: WWW-Authenticate parameter values are
+    // either token or quoted-string. Match the `error` parameter
+    // structurally so that the literal string "use_dpop_nonce" appearing
+    // inside some other parameter's value (e.g. realm) does not
+    // false-positive into a spurious retry.
+    const m = wwwAuth.match(/\berror\s*=\s*(?:"([^"]*)"|([^,\s]+))/i);
+    if (m) {
+      const value = m[1] !== undefined ? m[1] : m[2];
+      challenged = value.toLowerCase() === "use_dpop_nonce";
+    }
   }
-  if (body && body.error === "use_dpop_nonce") {
+
+  if (challenged) {
     res = await fetch(url, { ...init, headers: buildHeaders(issuedNonce) });
     rememberNonce(url, res.headers.get("dpop-nonce"));
   }

--- a/tests/test-dpop.mjs
+++ b/tests/test-dpop.mjs
@@ -359,6 +359,85 @@ describe("getUserInfo client", () => {
       mock.server.close();
     }
   });
+
+  it("does NOT retry when 'use_dpop_nonce' appears outside the error parameter (RFC 9449 §9 strict)", async () => {
+    // Loose substring matching on WWW-Authenticate would false-positive
+    // here: "use_dpop_nonce" sits inside `realm`, not as the error code.
+    // A conformant client must scope the match to `error="use_dpop_nonce"`.
+    let calls = 0;
+    const mock = await createMockServer((_req, res) => {
+      calls++;
+      if (calls === 1) {
+        res.writeHead(401, {
+          "Content-Type": "application/json",
+          "WWW-Authenticate":
+            `DPoP realm="use_dpop_nonce blocklist", error="invalid_token"`,
+          "DPoP-Nonce": "would-be-nonce-if-this-were-a-real-challenge",
+        });
+        res.end(JSON.stringify({ error: "Invalid token" }));
+        return;
+      }
+      // If we ever reach here, the client erroneously retried.
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ sub: "should-not-reach" }));
+    });
+
+    try {
+      const pair = generateEd25519PemPair();
+      await assert.rejects(
+        () =>
+          getUserInfo({
+            ssoBaseUrl: mock.baseUrl,
+            accessToken: "at",
+            agentPrivateKeyPem: pair.privateKeyPem,
+          }),
+        /401|invalid_token/i,
+      );
+      assert.equal(calls, 1,
+        "must NOT retry: use_dpop_nonce is not the error code");
+    } finally {
+      mock.server.close();
+    }
+  });
+
+  it("retries on 401 + use_dpop_nonce challenge from resource server (RFC 9449 §9)", async () => {
+    let calls = 0;
+    let secondProofPayload = null;
+    const SERVER_NONCE = "rs-userinfo-nonce-789";
+    const mock = await createMockServer((req, res) => {
+      calls++;
+      const dpop = req.headers["dpop"];
+      if (calls === 1) {
+        // §9 challenge shape: 401 + WWW-Authenticate carrying error code +
+        // DPoP-Nonce header. Distinct from §8's 400 + JSON-body shape.
+        res.writeHead(401, {
+          "Content-Type": "application/json",
+          "WWW-Authenticate": `DPoP error="use_dpop_nonce", algs="EdDSA"`,
+          "DPoP-Nonce": SERVER_NONCE,
+        });
+        res.end(JSON.stringify({ error: "use a fresh nonce" }));
+        return;
+      }
+      secondProofPayload = JSON.parse(fromB64url(dpop.split(".")[1]).toString("utf8"));
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ sub: "user-456" }));
+    });
+
+    try {
+      const pair = generateEd25519PemPair();
+      const claims = await getUserInfo({
+        ssoBaseUrl: mock.baseUrl,
+        accessToken: "the-access-token",
+        agentPrivateKeyPem: pair.privateKeyPem,
+      });
+      assert.deepEqual(claims, { sub: "user-456" });
+      assert.equal(calls, 2, "must retry once after §9 nonce challenge");
+      assert.equal(secondProofPayload.nonce, SERVER_NONCE,
+        "retry proof must echo the server-issued nonce");
+    } finally {
+      mock.server.close();
+    }
+  });
 });
 
 // ─── beginOidcAuthorization wires dpop_jkt ────────────────────────────────────────


### PR DESCRIPTION
Follow-up to #20 surfacing during a Codex review pass.

## What's wrong without this

The client's `fetchWithDPoPNonce` helper only recognized the §8 (authorization-server) nonce-challenge shape:

> 400 + JSON body `{"error":"use_dpop_nonce"}` + `DPoP-Nonce` header.

Per RFC 9449 §9, resource servers signal the same condition with a different envelope:

> 401 + `WWW-Authenticate: DPoP error="use_dpop_nonce"` + `DPoP-Nonce` header.

So if a DPoP-aware userinfo / capability / introspection endpoint ever rotated nonces, the agent would not retry — it would just propagate the 401.

## Fix

`fetchWithDPoPNonce` now branches on status code:

- **400** → look for `error: "use_dpop_nonce"` in the JSON body (§8, unchanged).
- **401** → parse the `error` parameter from `WWW-Authenticate` per RFC 7235 §2.2 (token-or-quoted-string), test for `use_dpop_nonce`.

The §9 path uses a structured regex scoped to the `error=` parameter rather than a substring scan. This avoids a class of false-positive where the literal string `use_dpop_nonce` appears inside another parameter's value (e.g. `realm="use_dpop_nonce_blocklist"`) and would otherwise trigger a spurious retry.

The retry path itself is unchanged — one round trip, fresh proof with the server-supplied nonce echoed in the `nonce` claim, cache the new nonce per URL.

## Test plan

Added (TDD) in `tests/test-dpop.mjs`:

- [x] **GREEN — positive §9 retry**: 401 + `WWW-Authenticate: DPoP error="use_dpop_nonce"` + `DPoP-Nonce` → retries with the supplied nonce echoed in the proof.
- [x] **GREEN — negative §9 strictness**: 401 + `WWW-Authenticate: DPoP realm="use_dpop_nonce blocklist", error="invalid_token"` + `DPoP-Nonce` → does NOT retry; the original 401 propagates.

Existing §8 (400-path) nonce tests stay green. Full agent-id suite: 64/64 pass.

## Server side note

The companion server-side fixes from the same Codex review (case-sensitive `htm` matching) live separately on the SSO repo's `develop` branch. The strict-`typ` recommendation from that review was rejected — accepting both `dpop+jwt` and `application/dpop+jwt` is required by RFC 7515 §4.1.9 ("recipient MUST treat any typ value not containing a '/' as if 'application/' were prepended").

🤖 Generated with [Claude Code](https://claude.com/claude-code)