### PR TITLE
docs: fix regressions from 54148d5 (README header + Mermaid diagrams)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
-![Alien Agent ID](.github/assets/logo.png)
+<p align="center">
+  <img src=".github/assets/logo.png" alt="Alien Agent ID" width="128">
+</p>
 
-# Alien Agent ID
+<h1 align="center">Alien Agent ID</h1>
 
-Verifiable cryptographic identity for AI agents, linked to human owners via [Alien Network][alien] SSO.
+<p align="center">
+  Verifiable cryptographic identity for AI agents, linked to human owners<br>
+  via <a href="https://alien.org">Alien Network</a> SSO.
+</p>
 
 When an AI agent has an Alien Agent ID, every git commit it makes is SSH-signed and carries trailers that trace back
 to the specific agent and the human who authorized it. The provenance chain is fully verifiable:

--- a/docs/AGENT-SSO.md
+++ b/docs/AGENT-SSO.md
@@ -37,7 +37,7 @@ flowchart TD
     Human -- "1. Scan QR via Alien App" --> SSO
     SSO -- "2. id_token + access_token + refresh_token" --> Agent
     Agent --- State
-    Agent -- "Authorization: DPoP &lt;at&gt;<br/>DPoP: &lt;proof&gt;" --> Service
+    Agent -- "DPoP-bound request" --> Service
     Agent -- "Stored API key / OAuth token" --> External
 ```
 
@@ -127,7 +127,7 @@ sequenceDiagram
     participant H as Human (Alien App)
 
     A->>A: Generate Ed25519 keypair (~/.agent-id/keys/main.json)
-    A->>SSO: GET /oauth/authorize<br/>client_id=provider, dpop_jkt, PKCE
+    A->>SSO: GET /oauth/authorize (client_id, dpop_jkt, PKCE)
     SSO-->>A: deep_link, polling_code, expires_at
     A->>H: Show QR / deep link
     H->>SSO: Approve in Alien App
@@ -135,9 +135,9 @@ sequenceDiagram
         A->>SSO: POST /oauth/poll
     end
     SSO-->>A: authorization_code
-    A->>SSO: POST /oauth/token<br/>code + PKCE + DPoP proof
+    A->>SSO: POST /oauth/token (code + PKCE + DPoP proof)
     SSO-->>A: id_token (RS256, with cnf.jkt) + access_token + refresh_token
-    A->>A: Verify id_token signature against SSO JWKS<br/>(iss, sub, cnf.jkt match agent JWK)
+    A->>A: Verify id_token signature against SSO JWKS (iss, sub, cnf.jkt match agent JWK)
     A->>A: Persist owner-session.json (0600)
     A->>A: Configure git SSH signing
 ```

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -13,7 +13,7 @@ sequenceDiagram
     participant Service as Your Service
 
     Agent->>Agent: Mint per-request DPoP proof JWT (Ed25519, signed by agent key)
-    Agent->>Service: HTTP request<br/>Authorization: DPoP &lt;access_token&gt;<br/>DPoP: &lt;proof JWT&gt;
+    Agent->>Service: HTTP request with Authorization + DPoP headers
     Service->>Service: Verify proof signature (RFC 9449 §4.3)
     Service->>Service: Check htm / htu / iat / jti
     Service->>Service: Verify access_token (RFC 9068)


### PR DESCRIPTION
Two small fixes for the docs commit `54148d5` that landed on `main` earlier today.

## 1. Restore README centered HTML header

The previous commit converted the top-of-file HTML block
(`<p align="center"><img …></p>` + `<h1 align="center">` + centered tagline) to plain markdown when
applying the md-writer "no inline HTML" rule. That rule is appropriate for knowledge-base docs but
not for README files — md-writer's own skip-list exempts README / CHANGELOG / etc. precisely because
they follow universal conventions (centered logo, badge rows, etc.). Restoring as-was.

Commit: `ad54c5b`.

## 2. Fix Mermaid parse errors

GitHub's Mermaid parser rejects `<br/>` inside sequence-diagram message text and inside flowchart
edge labels — the lexer interprets `<br/>` as a NEWLINE token mid-arrow and fails the parse with:

```
Parse error on line 7: ... &lt;access_token&gt;<br/>DPoP: &lt;proo
Expecting … got 'NEWLINE'
```

Affected diagrams (all introduced in `54148d5`):

- `docs/INTEGRATION.md` sequenceDiagram — the multi-line HTTP-request message. Flattened to a
  single description; the full wire format is in the table below the diagram.
- `docs/AGENT-SSO.md` architecture flowchart — edge label between Agent and Service. Replaced
  with "DPoP-bound request".
- `docs/AGENT-SSO.md` bootstrap sequenceDiagram — three messages with `<br/>` carrying
  parenthetical detail on a second line. Folded into the same line using parentheses.

Flowchart NODE labels (`Node["foo<br/>bar"]`) render correctly on GitHub and were left as-is. Only
sequence messages and edge labels were touched.

Commit: `fdad28d`.

## Test plan

- [x] `head -14 README.md` shows the restored centered HTML block.
- [x] `grep '<br/?>' docs/*.md` shows no remaining `<br/>` in sequence messages or flowchart edge
      labels (only in flowchart node labels, which render correctly).
- [x] Both commits signed by Alien Agent ID (jkt `c_CqNfc7DDoc9dHRj9Zwatdm9qVPFodo7GdDw-l3xyE`);
      v3 attestation bundles attached to `refs/notes/agent-id`.
- [ ] Visual: confirm Mermaid diagrams render on the PR's GitHub diff page.
- [ ] Visual: confirm README header renders centered on the PR's GitHub diff page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)