### PR TITLE
release: agent-id 3.0.2 — doc cleanup + version stamp bump

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "alien-agent-id",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Verifiable cryptographic identity for AI agents — SSH-signed git commits, owner binding via Alien Network SSO, and hash-chained audit logs",
   "owner": {
     "name": "Alien",
@@ -13,7 +13,7 @@
     {
       "name": "alien-agent-id",
       "description": "Obtain a verifiable Agent ID linked to a human owner via Alien Network SSO. Sign git commits so every line of agent-written code is cryptographically attributable.",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "source": {
         "source": "url",
         "url": "https://github.com/alien-id/agent-id.git"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "alien-agent-id",
   "description": "Verifiable cryptographic identity for AI agents — SSH-signed git commits, owner binding via Alien Network SSO, and hash-chained audit logs",
-  "version": "3.0.1"
+  "version": "3.0.2"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 All notable changes are documented here.
 
-## Unreleased
+## [3.0.2] — 2026-05-12
+
+Patch release. No runtime behavior change. Documentation cleanup and version-stamp bump.
 
 ### Documentation
 
@@ -13,10 +15,21 @@ All notable changes are documented here.
 - Rewrote `docs/AGENT-SSO.md` to drop residual v2 "owner binding" prose; the SSO-signed
   `id_token` (with `cnf.jkt`, RFC 7800 §3.1) is the chain attestation in v3.
 - Converted ASCII diagrams in `docs/AGENT-SSO.md` and `docs/INTEGRATION.md` to Mermaid.
+- Fixed Mermaid parse errors: sequence-diagram messages and flowchart edge labels no longer
+  embed `<br/>` (GitHub's Mermaid lexer interprets it as a NEWLINE token mid-arrow). Flowchart
+  node labels still use `<br/>` where appropriate.
+- Restored the README's original centered-logo HTML header (`<p align="center">` / centered
+  `<h1>` / centered tagline) that a prior pass had converted to plain markdown.
 - Fact-checked claims against `skills/alien-agent-id/lib.mjs` and `cli.mjs`: corrected the
   `examples/demo-service.mjs` size reference, fixed a stale cross-repo path in `INTEGRATION.md`,
   and aligned the file-layout table in `AGENT-SSO.md` with the actual `skills/alien-agent-id/`
   tree.
+
+### Why a 3.0.2 instead of re-stamping 3.0.1
+
+The `v3.0.1` tag on origin points at an orphaned commit because a GitHub tag-protection rule
+blocked the rewrite when the underlying commit was re-signed. `3.0.2` cleanly supersedes it
+with the same intended content plus the doc cleanup above.
 
 ## [3.0.1] — 2026-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,12 +25,6 @@ Patch release. No runtime behavior change. Documentation cleanup and version-sta
   and aligned the file-layout table in `AGENT-SSO.md` with the actual `skills/alien-agent-id/`
   tree.
 
-### Why a 3.0.2 instead of re-stamping 3.0.1
-
-The `v3.0.1` tag on origin points at an orphaned commit because a GitHub tag-protection rule
-blocked the rewrite when the underlying commit was re-signed. `3.0.2` cleanly supersedes it
-with the same intended content plus the doc cleanup above.
-
 ## [3.0.1] — 2026-05-12
 
 Patch release. No runtime behavior change.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alien-agent-id",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Universal Agent ID - verifiable identity for AI agents linked to human owners via Alien Network SSO",
   "type": "module",
   "bin": {

--- a/skills/alien-agent-id/SKILL.md
+++ b/skills/alien-agent-id/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: Any AI agent with shell access and Node.js 18+ (Claude Code, OpenClaw, etc.)
 metadata:
   author: Alien Wallet
-  version: "3.0.1"
+  version: "3.0.2"
 allowed-tools: Bash(node:*) Bash(git:*) Bash(curl:*) Read
 ---
 


### PR DESCRIPTION
## Summary

Patch release. No runtime behavior change. Bumps the four manifest version stamps from `3.0.1`
→ `3.0.2` and promotes the `CHANGELOG.md` "Unreleased" section to `[3.0.2] — 2026-05-12`.

### Version stamps (3.0.1 → 3.0.2)

- `package.json`
- `.claude-plugin/plugin.json`
- `.claude-plugin/marketplace.json` (top-level + plugins[0])
- `skills/alien-agent-id/SKILL.md` (frontmatter)

### CHANGELOG.md

Promotes Unreleased → `[3.0.2]` with documentation entries covering:

- Trimmed `docs/` to `AGENT-SSO.md` + `INTEGRATION.md`; deleted `MIGRATION-DPOP.md`,
  `RELEASE-NOTES.md`, `TESTING.md`.
- Rewrote `AGENT-SSO.md` (dropped residual v2 "owner binding" prose; v3 chain via `cnf.jkt`).
- ASCII → Mermaid for all diagrams in `AGENT-SSO.md` and `INTEGRATION.md`.
- Fixed Mermaid `<br/>` parse errors in sequence messages and flowchart edge labels.
- Restored the README's original centered-HTML logo header.
- Fact-checked claims against `lib.mjs` / `cli.mjs` (demo-service LOC, file layout table).

## Test plan

- [x] `grep -H '"version"' package.json .claude-plugin/*.json` and SKILL.md frontmatter all show
      `3.0.2`.
- [x] `npm test` — 158/158.
- [x] Commits signed by Alien Agent ID (jkt `c_CqNfc7DDoc9dHRj9Zwatdm9qVPFodo7GdDw-l3xyE`); v3
      attestation bundles on `refs/notes/agent-id`.
- [ ] Merge this PR.
- [ ] Tag `v3.0.2` on the resulting `main` (annotated).
- [ ] `gh release create v3.0.2` with curated notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)