### PR TITLE
docs(skill): handle classifier denials on cli.mjs calls

### DIFF
--- a/skills/alien-agent-id/SKILL.md
+++ b/skills/alien-agent-id/SKILL.md
@@ -47,7 +47,7 @@ If the manifest is `version: 2` and carries `api.operations[]`, render it as mar
 node CLI capabilities --url https://example.com
 ```
 
-Falls back: if `operations[]` is absent but `api.specUrl` is present, fetch the spec and read it before any side-effecting call. Side-effecting endpoints (POST/PUT/DELETE) are often irreversible — do not probe field names by trial-and-error against a live service; a wrong-shape POST may still persist a row under your owner identity.
+Falls back: if `operations[]` is absent but `api.specUrl` is present, fetch the spec and read it before any side-effecting call. Side-effecting endpoints are often irreversible — do not probe field names by trial-and-error against a live service; a wrong-shape POST may still persist a row under your owner identity.
 
 Make signed requests with `call` (one-shot: handles both DPoP headers and the single-use `jti`):
 
@@ -61,6 +61,10 @@ Never hand-roll DPoP headers; never call an Alien-aware service with plain `fetc
 Output is JSON: `{ ok, status, contentType, body }`.
 
 If you need to drive `curl` yourself, see [reference/services.md](reference/services.md) for `auth-header` usage and the two-header pattern.
+
+### If the classifier denies a `cli.mjs` call
+
+Show the full command, name what the subcommand does (Command reference below), and for `call` include the resolved method, URL, and body. Ask before retrying. Don't fall back to `curl` — DPoP requires the CLI.
 
 ### Trust boundary
 


### PR DESCRIPTION
## Summary

Adds a short SKILL.md subsection telling the agent how to react when Claude Code's auto-mode classifier denies a `cli.mjs call --url` invocation.

The classifier judges Bash calls heuristically and occasionally blocks a routine GET it can't categorize from the URL alone (e.g. `node CLI call --url https://agent-sso.alien.org/api/subaliens`). Without explicit guidance the agent silently dropped the probe or fell back to a plain `curl`, which 401s because DPoP requires the CLI.

The new rule: on denial, show the user the full command, name what the subcommand does (Command reference table is the source of truth), and for `call` include the resolved method, URL, and body. Ask before retrying. No `curl` fallback.

Also trims a redundant `(POST/PUT/DELETE)` parenthetical from the `operations[]` fallback sentence — `annotations.destructiveHint` on the per-operation manifest is the canonical signal now, not the HTTP verb.

## Why not a hook

An earlier draft of this change shipped a plugin-level `PreToolUse` hook that pre-approved safe `cli.mjs` subcommands (including `call:*`) so the classifier was bypassed entirely. Rejected: blanket `call:*` approval is broader than the classifier's per-URL judgement, takes the classifier out-of-loop, and grants trust the agent should be earning explicitly each time. The right shape is "explain to Claude Code what the CLI does and how to handle a deny," not "engineer around the deny."

## Test plan

- [x] `git diff` is the +5/−1 shown
- [ ] Render SKILL.md locally and sanity-check the new subsection sits between `## Authenticate with services` and `### Trust boundary`
- [ ] On next session-load, confirm the agent now surfaces classifier denials to the user instead of silently dropping probes or falling back to `curl`

## Notes

- Docs-only; no `cli.mjs` / `lib.mjs` behavior change
- Branch follows the post-`feat/manifest-v2-operations` (PR #28) main HEAD
