### PR TITLE
docs(skill): scope Bash(node) allow rule to the CLI path only

### DIFF
--- a/skills/alien-agent-id/SKILL.md
+++ b/skills/alien-agent-id/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 metadata:
   author: Alien Wallet
   version: "3.0.2"
-allowed-tools: Bash(node:*) Bash(git:*) Bash(curl:*) Bash(jq:*) Read
+allowed-tools: Bash(node *alien-agent-id/cli.mjs:*) Bash(git:*) Bash(curl:*) Bash(jq:*) Read
 ---
 
 # Alien Agent ID


### PR DESCRIPTION
## Summary

Scopes the SKILL.md `allowed-tools` rule for `node` from `Bash(node:*)` (any `node ...` invocation) to `Bash(node *alien-agent-id/cli.mjs:*)` (only `node`-driven runs of this CLI). One-line change.

`*` matches the path prefix so the rule still picks up every install location: dev workspace checkout, ccs mount, and the plugin install dir under `~/.claude/plugins/...`. `:*` is the trailing-args wildcard (docs confirm it's equivalent to ` *`). Shell-operator splitting means a compound like `evil && node .../cli.mjs ...` still falls through to the classifier.

## Why

`Bash(node:*)` was wider than the skill actually needs — any `node script.js` invocation got the bypass while the skill was loaded. The CLI is the only `node` runner the skill cares about; narrowing the grant matches that.

Per the auto-mode-config docs, allow rules run before the classifier, so a precise pattern gives a cleaner short-circuit without granting more than necessary.

## Test plan

- [x] `git diff` is the one-line frontmatter change shown above
- [ ] In a fresh session, invoke the skill, run `node CLI status` and `node CLI call --url <some https URL>` — confirm neither produces a classifier `Allowed/Denied` line (allow rule short-circuits)
- [ ] Run a bare `node -e 'console.log(1)'` while the skill is loaded — confirm this still goes through the classifier (proves the grant no longer covers arbitrary `node` calls)

## Notes

- Follow-up to #29 — that PR added "what to do when the classifier denies a `cli.mjs` call"; this PR tightens the allow rule so denials of the CLI happen less often in the first place
- `Bash(git:*) Bash(curl:*) Bash(jq:*)` untouched; only the `node` entry changed
