### PR TITLE
docs(skill): add v3 migration reference + session-start detection

### DIFF
--- a/skills/alien-agent-id/SKILL.md
+++ b/skills/alien-agent-id/SKILL.md
@@ -29,7 +29,7 @@ Check whether an identity already exists:
 node CLI status
 ```
 
-If `"bound": true`, skip to Authenticate with services or Commit signed code.
+If `"bound": true`, check for pre-v3 state before proceeding: if `${AGENT_ID_STATE_DIR:-$HOME/.agent-id}/owner-binding.json` exists, the identity was bound under the v2 model and the v3 verifier will reject it — pause and run the migration in [reference/migrate-to-v3.md](reference/migrate-to-v3.md). Otherwise skip to Authenticate with services or Commit signed code.
 
 If not bound, start bootstrap immediately — do not ask "want me to start?" first; invoking this skill is the opt-in. The first user-facing message is the provider question (Step 1 below), not a confirmation prompt. The flow requires the user to scan a QR code in the Alien App, so the steps run individually (not the `bootstrap` command, which blocks before the QR can be shown). Full flow in [reference/bootstrap.md](reference/bootstrap.md).
 
@@ -148,3 +148,4 @@ Common flag: `--state-dir <path>` (defaults to `~/.agent-id`, or `AGENT_ID_STATE
 - [reference/vault.md](reference/vault.md) — secure credential storage and retrieval.
 - [reference/git-commits.md](reference/git-commits.md) — signed commit anatomy, GitHub *Verified* badge.
 - [reference/state-and-errors.md](reference/state-and-errors.md) — state-directory layout, error catalog, security guarantees.
+- [reference/migrate-to-v3.md](reference/migrate-to-v3.md) — detect pre-3.0 state and migrate (safe in-place vs. backup-and-rebootstrap).

--- a/skills/alien-agent-id/reference/migrate-to-v3.md
+++ b/skills/alien-agent-id/reference/migrate-to-v3.md
@@ -1,0 +1,52 @@
+# Migrate to agent-id 3.0.0+
+
+Pre-3.0 agents bound via the v2 owner-proof model carry cnf-less id_tokens and a `owner-binding.json` artifact that the v3 verifier rejects. Migrate before the next signed call.
+
+## Detect
+
+After `node CLI status`, check for the legacy artifact:
+
+```bash
+STATE_DIR="${AGENT_ID_STATE_DIR:-$HOME/.agent-id}"
+test -f "$STATE_DIR/owner-binding.json" && echo "pre-v3 state — migrate"
+```
+
+If the file exists, stop and surface the migration to the user. Do not proceed with `call`, `sign`, `git-commit`, or any operation that asserts identity until the migration is done.
+
+## Recommended — safe in-place migration
+
+Keeps the agent keypair, vault, and audit log. Re-runs OAuth under DPoP so the new id_token carries `cnf.jkt`. Previously signed commits stay verifiable because the keypair is unchanged.
+
+```bash
+node CLI setup-owner-session --provider-address <PROVIDER_ADDRESS>
+```
+
+The command clears only `owner-binding.json`, `owner-session.json`, and `pending-auth.json`, then walks through the same QR-code flow as bootstrap step 3-4. The user scans, the new owner-session is written, the migration is done.
+
+Resolve `<PROVIDER_ADDRESS>` exactly as in [bootstrap.md](bootstrap.md) step 1 — ask the user before reading `default-provider.txt`.
+
+## Fallback — back up and re-bootstrap
+
+Only if the safe path fails or the state directory is corrupt. Renames the existing directory aside instead of deleting it, so vault contents and the audit chain stay recoverable:
+
+```bash
+STATE_DIR="${AGENT_ID_STATE_DIR:-$HOME/.agent-id}"
+mv "$STATE_DIR" "${STATE_DIR}.pre-v3-backup-$(date +%Y%m%d-%H%M%S)"
+# then run the full bootstrap flow — see bootstrap.md
+node CLI init
+node CLI auth --provider-address <PROVIDER_ADDRESS>
+node CLI bind
+node CLI git-setup
+```
+
+What changes for the user:
+
+- new agent keypair — every commit previously signed by this agent loses its provenance link (the SSH signature still verifies as bytes, but `git-verify` will fail because the new key has a different thumbprint),
+- vault entries are not carried over — GitHub PATs, Slack tokens, AWS keys etc. live under `<backup-dir>/vault/` and must be re-stored via `vault-store` if needed,
+- the audit log chain restarts from sequence 0; the old chain is preserved under the backup directory for forensics.
+
+Surface every item above to the user before running the `mv`. The backup directory is the user's responsibility to remove once they confirm nothing was needed from it.
+
+## After migration
+
+Re-run `node CLI status` and confirm `bound: true` with a `jkt` value present. The next `node CLI call` will exercise the cnf.jkt-bound id_token; a 401 here usually means the SSO is still on a pre-v3 deploy, not that the migration failed.


### PR DESCRIPTION
## Summary

Adds a short migration reference and a session-start detection step so agents on pre-3.0 state don't blow up on the first signed call.

Pre-3.0 agents carry a `owner-binding.json` artifact and cnf-less id_tokens that the v3 verifier rejects. Today this surfaces as an opaque 401 mid-task. With this PR the skill detects the legacy artifact at session start and routes the user to a documented migration.

## What changed

- New: `skills/alien-agent-id/reference/migrate-to-v3.md` — three sections (detect, safe path, fallback path), under 60 lines.
  - Detect via `test -f "$STATE_DIR/owner-binding.json"` after `node CLI status`.
  - Recommended path: `node CLI setup-owner-session --provider-address <P>` — clears only the binding/session/pending-auth files, keeps the keypair + vault + audit chain. Previously signed commits stay verifiable because the keypair doesn't rotate.
  - Fallback path: `mv "$STATE_DIR" "${STATE_DIR}.pre-v3-backup-$(date +%Y%m%d-%H%M%S)"` then re-bootstrap. The backup preserves the old state in case the user later needs to recover a vault credential. (Uses `mv`, not `rm` — recoverable on second thought.)
- Edit: `skills/alien-agent-id/SKILL.md` (+2/-1)
  - After `bound: true`, check for `owner-binding.json` and route to the new reference doc if present.
  - Added the new reference to the docs list.

## Why this path over alternatives

`setup-owner-session` already exists in the CLI and is genuinely lossless — it re-runs OAuth under DPoP so the new id_token gets a `cnf.jkt` claim, but leaves the keypair, vault, and audit log untouched. The reference doc surfaces this as the primary migration so users don't reach for `rm -rf` and lose their vault.

The fallback path uses `mv` instead of `rm` so the data is recoverable if the user later realizes they needed something from the old state directory. Cleanup is the user's call once they've confirmed nothing was needed.

## Test plan

- [x] `git diff` shows only the two intended files
- [ ] In a session with a pre-v3 state dir, confirm the agent surfaces the migration prompt after `node CLI status` instead of attempting a signed call
- [ ] After running `setup-owner-session`, confirm `node CLI status` returns `bound: true` with a `jkt` value and no `owner-binding.json` remains
- [ ] Confirm previously signed commits still verify against the unchanged keypair under the safe migration path

## Notes

- The fallback path documents that the old keypair becomes inaccessible — previously signed commits will fail `git-verify` because the new key has a different thumbprint. This is called out in the doc.
- Memory says agent-id 3.0.0 changes accumulate on `release/3.0.0`; this PR targets `main` because the migration story is for users who upgrade to 3.0.x once it's stable. If the convention requires landing on `release/3.0.0` first, happy to retarget.
