### PR TITLE
fix(skill): pin gpg.ssh.program=ssh-keygen for git-commit + git-verify

### DIFF
--- a/skills/alien-agent-id/cli.mjs
+++ b/skills/alien-agent-id/cli.mjs
@@ -598,9 +598,12 @@ async function cmdGitCommit(flags) {
     await setPrivateFilePermissions(privateKeyPath);
   }
 
-  // Pass signing config inline — no git config changes needed
+  // Pass signing config inline — no git config changes needed.
+  // gpg.ssh.program pinned to ssh-keygen so a user's globally-configured custom SSH
+  // signer (e.g. 1Password's op-ssh-sign) doesn't intercept signing with the agent key.
   const commitArgs = [
     "-c", "gpg.format=ssh",
+    "-c", "gpg.ssh.program=ssh-keygen",
     "-c", `user.signingkey=${privateKeyPath}`,
     "commit", "-S", "-m", fullMessage,
   ];
@@ -855,6 +858,7 @@ async function cmdGitVerify(flags) {
     const verifyResult = await execFile(
       "git",
       [
+        "-c", "gpg.ssh.program=ssh-keygen",
         "-c", `gpg.ssh.allowedSignersFile=${tmpSignersPath}`,
         "verify-commit", resolvedHash,
       ],


### PR DESCRIPTION
## Summary

- Pin `gpg.ssh.program=ssh-keygen` inline on the `git` invocations inside `cmdGitCommit` and `cmdGitVerify` so the CLI signs and verifies with the agent-id key regardless of what SSH signer the user has configured globally.
- Discovered during the v3.1.0 release flow: with 1Password's git integration enabled, `git config --global gpg.ssh.program` points at `/Applications/1Password.app/Contents/MacOS/op-ssh-sign`. `op-ssh-sign` only signs with keys 1Password manages, so the agent-id key was rejected with `1Password: invalid ssh public key` and `git-commit` failed mid-release. Same hazard applies to `git-verify` (most custom signers don't implement `ssh-keygen -Y verify` mode).

## Why this is safe for non-1Password users

`ssh-keygen` is git's documented default for SSH signing and verifying. Any machine where this CLI worked before today already had `ssh-keygen` on PATH — git's implicit default for `gpg.ssh.program` resolves to it. Pinning it explicitly is a **no-op for users without a custom signer** and a **fix for users who set their own signer globally** (1Password, gpg-agent shim, hardware-backed signer, etc.).

The intent of the agent-id skill is to sign commits with the *agent's* key, not the user's. Honoring a user's global SSH signer would defeat that purpose, so the override is correct in scope.

## Implementation

Two two-line edits in `skills/alien-agent-id/cli.mjs`:

- `cmdGitCommit` (line 601-608): added `-c gpg.ssh.program=ssh-keygen` alongside the existing `-c gpg.format=ssh` and `-c user.signingkey=...` inline flags.
- `cmdGitVerify` (line 854-862): same pin on the `git verify-commit` call.

Both rely on git's `-c key=value` mechanism, which scopes the override to a single invocation — no `~/.gitconfig` or `.git/config` mutation, consistent with the v2.0.3 design that removed all persistent git-config side effects.

## Test plan

- [x] Unit suite passes: `node --test tests/test-*.mjs` → **184/184 pass**.
- [x] End-to-end self-test: this PR's commit (`2297c64`) was created via `node skills/alien-agent-id/cli.mjs git-commit` **without** the `GIT_CONFIG_COUNT` env-var workaround that was needed for the v3.1.0 release commit. With `gpg.ssh.program=op-ssh-sign` globally, the bare invocation now succeeds.
- [x] End-to-end self-test: `node skills/alien-agent-id/cli.mjs git-verify --commit 2297c64a9fa6` returns `ok: true` and a valid summary, confirming the symmetric fix on the verify path also works under 1Password.
- [ ] Reviewer with a stock setup (no custom `gpg.ssh.program`) confirms `git-commit` + `git-verify` still work — sanity check that pinning to `ssh-keygen` doesn't regress the default case.

## Notes

- This is a behavior fix to the CLI's existing public surface (`git-commit`, `git-verify`); no API changes, no version bump in this PR. A follow-up release commit can land a 3.1.1 patch with this fix included.
- The agent-id signing key (`~/.agent-id/ssh/agent-id`) is unchanged; only the program that consumes it is now pinned.

Co-Authored-By: Skrrt Bot <bot@skrrt.sh>
