### PR TITLE
fix(plugins): marketplace install paths + skills compliance pass

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,15 +6,12 @@
     "name": "Alien",
     "email": "support@alien.org"
   },
-  "metadata": {
-    "pluginRoot": "./plugins"
-  },
   "plugins": [
     {
       "name": "agent-id-core",
       "description": "Shared library for Alien Agent ID: crypto primitives, v3 bundle format, universal verifier, SignatureEngine, OIDC, state I/O. Required by every other agent-id-* plugin.",
       "version": "7.0.0",
-      "source": "./agent-id-core",
+      "source": "./plugins/agent-id-core",
       "category": "identity",
       "keywords": [
         "agent-identity",
@@ -26,7 +23,7 @@
       "name": "agent-id-git",
       "description": "SSH-signed git commits with Agent-ID trailers and v3 proof notes; verify provenance on any commit.",
       "version": "7.0.0",
-      "source": "./agent-id-git",
+      "source": "./plugins/agent-id-git",
       "category": "identity",
       "keywords": [
         "git-signing",
@@ -38,7 +35,7 @@
       "name": "agent-id-vault",
       "description": "Portable encrypted credential vault with LUKS-style slots (passphrase + agent-key + phone/owner-approval) and typed/domain-scoped credential records.",
       "version": "7.0.0",
-      "source": "./agent-id-vault",
+      "source": "./plugins/agent-id-vault",
       "category": "identity",
       "keywords": [
         "credential-vault",
@@ -49,7 +46,7 @@
       "name": "agent-id-proxy",
       "description": "Local credential-injecting HTTP proxy. Agent calls http://<proxy>/<credname>/<upstream-host>/<path>; proxy materializes the credential by type, validates the host allowlist, and forwards over real HTTPS. Universal across services without TLS interception.",
       "version": "7.0.0",
-      "source": "./agent-id-proxy",
+      "source": "./plugins/agent-id-proxy",
       "category": "identity",
       "keywords": [
         "credential-injection",
@@ -61,7 +58,7 @@
       "name": "agent-id-auth",
       "description": "DPoP-signed calls to Alien-aware services: discovery, capabilities, one-shot signed requests.",
       "version": "7.0.0",
-      "source": "./agent-id-auth",
+      "source": "./plugins/agent-id-auth",
       "category": "identity",
       "keywords": [
         "dpop",
@@ -73,7 +70,7 @@
       "name": "agent-id-browser",
       "description": "Universal browser the agent drives fine-grained (click, type, fill forms, navigate, screenshot, run JS) via an accessibility snapshot with element refs, with the logged-in profile sealed in the agent vault. One-time headed login; headless thereafter. Drives the user's installed Chrome via patchright (installed at runtime into the plugin data dir on first session; no browser download). For authenticated sites that block API/OAuth/cookie approaches.",
       "version": "7.0.0",
-      "source": "./agent-id-browser",
+      "source": "./plugins/agent-id-browser",
       "category": "identity",
       "keywords": [
         "browser-automation",

--- a/examples/clean-room-demo/skills/alien-vault/SKILL.md
+++ b/examples/clean-room-demo/skills/alien-vault/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: alien-vault
 description: Access the owner's external services (Gmail, GitHub, APIs) that require a credential, by calling the local Alien Agent ID vault proxy — without ever seeing, requesting, or handling the secret. Use whenever you're asked to read the owner's email or call a service that needs an API key / token / login. Starts the proxy if it isn't running; the owner unlocks the vault once on their phone; you only ever name the credential.
+license: MIT
+metadata:
+  author: Alien Wallet
+  version: "7.0.0"
 allowed-tools: Bash(node *agent-id-proxy/bin/cli.mjs:*) Bash(curl:*) Bash(python3:*)
 ---
 

--- a/plugins/agent-id-auth/skills/agent-id-auth/SKILL.md
+++ b/plugins/agent-id-auth/skills/agent-id-auth/SKILL.md
@@ -21,7 +21,7 @@ Requires that `agent-id-setup bootstrap` has produced a keypair and bound an own
 
 ## Resolve the CLI
 
-`bin/cli.mjs` lives in this plugin's directory. Substitute `CLI` with the absolute path (e.g. `node /abs/path/to/plugins/agent-id-auth/bin/cli.mjs`) in the examples below.
+`bin/cli.mjs` lives in this plugin's directory. In the examples below, `CLI` is `${CLAUDE_PLUGIN_ROOT}/bin/cli.mjs` — the `${CLAUDE_PLUGIN_ROOT}` path is filled in for you when the skill loads.
 
 ## When the user gives you a URL on an Alien-aware service
 

--- a/plugins/agent-id-core/skills/agent-id-core/SKILL.md
+++ b/plugins/agent-id-core/skills/agent-id-core/SKILL.md
@@ -31,7 +31,7 @@ State directory layout (under `${AGENT_ID_STATE_DIR:-$HOME/.agent-id}`):
 
 ## Resolve the CLI
 
-`bin/cli.mjs` lives in this plugin's directory. Substitute `CLI` with the absolute path (e.g. `node /abs/path/to/plugins/agent-id-core/bin/cli.mjs`) in the examples below.
+`bin/cli.mjs` lives in this plugin's directory. In the examples below, `CLI` is `${CLAUDE_PLUGIN_ROOT}/bin/cli.mjs` — the `${CLAUDE_PLUGIN_ROOT}` path is filled in for you when the skill loads.
 
 ## At the start of a session
 

--- a/plugins/agent-id-git/skills/agent-id-git/SKILL.md
+++ b/plugins/agent-id-git/skills/agent-id-git/SKILL.md
@@ -22,7 +22,7 @@ Verification is universal: it does not require the agent's local state, only the
 
 ## Resolve the CLI
 
-`bin/cli.mjs` lives in this plugin's directory. Substitute `CLI` with the absolute path (e.g. `node /abs/path/to/plugins/agent-id-git/bin/cli.mjs`) in the examples below.
+`bin/cli.mjs` lives in this plugin's directory. In the examples below, `CLI` is `${CLAUDE_PLUGIN_ROOT}/bin/cli.mjs` — the `${CLAUDE_PLUGIN_ROOT}` path is filled in for you when the skill loads.
 
 ## Setup (one-time)
 

--- a/plugins/agent-id-proxy/skills/agent-id-proxy/SKILL.md
+++ b/plugins/agent-id-proxy/skills/agent-id-proxy/SKILL.md
@@ -14,9 +14,11 @@ The proxy holds the unlocked vault's master key in memory, accepts HTTP requests
 
 Requires `agent-id-vault init` to have produced a portable vault with at least one credential.
 
+> **Security note:** this skill pre-approves `Bash(curl:*)` so calls to the local proxy don't prompt each time. That grant also authorizes arbitrary outbound HTTP — a potential exfiltration channel. For higher-stakes use, drop the blanket `curl` grant and approve proxy calls per-invocation.
+
 ## Resolve the CLI
 
-`bin/cli.mjs` lives in this plugin's directory. Substitute `CLI` with the absolute path.
+`bin/cli.mjs` lives in this plugin's directory. In the examples below, `CLI` is `${CLAUDE_PLUGIN_ROOT}/bin/cli.mjs` — the `${CLAUDE_PLUGIN_ROOT}` path is filled in for you when the skill loads.
 
 ## Start the proxy
 

--- a/plugins/agent-id-vault/skills/agent-id-vault/SKILL.md
+++ b/plugins/agent-id-vault/skills/agent-id-vault/SKILL.md
@@ -30,7 +30,7 @@ Pairs with the agent-id-proxy plugin — the proxy unlocks the vault and injects
 
 ## Resolve the CLI
 
-`bin/cli.mjs` lives in this plugin's directory. Substitute `CLI` with the absolute path (e.g. `node /abs/path/to/plugins/agent-id-vault/bin/cli.mjs`).
+`bin/cli.mjs` lives in this plugin's directory. In the examples below, `CLI` is `${CLAUDE_PLUGIN_ROOT}/bin/cli.mjs` — the `${CLAUDE_PLUGIN_ROOT}` path is filled in for you when the skill loads.
 
 ## Initialize the vault — pick how it unlocks
 
@@ -192,38 +192,9 @@ path, never the contents — ideal for the `secret` type (SSH/RSA keys, PEMs).
   the vault — use the proxy to exercise those.
 - Unlock + `--state-dir` flags work as for any other subcommand.
 
-## Rekey: add/remove slots
+## Slot management, portability & migration
 
-```bash
-node CLI rekey add-passkey [--device-label NAME]                  # Touch ID / Face ID / security key
-node CLI rekey add-passphrase --new-passphrase-file /tmp/newpass   # DEV-mode vaults only
-node CLI rekey add-agent-key
-node CLI rekey add-mobile --device-pubkey HEX [--device-id NAME]   # phone (ECDH)
-node CLI rekey add-owner-approval [--sso-url URL]                  # Alien app
-node CLI rekey remove-slot --id 1
-```
-
-`rekey add-passphrase` only works on a **dev-mode** vault — on a user-mode vault it
-is refused (`PASSPHRASE_NOT_ALLOWED`), and there is no command to convert modes.
-The CLI also refuses to remove the last slot (vault would become unrecoverable).
-
-## Portability
-
-```bash
-node CLI export --out vault.enc        # already-encrypted; copy anywhere
-node CLI import --in vault.enc         # install on a new machine
-```
-
-After importing on machine B, run `rekey add-agent-key` to wire B's main key in for unattended unlock.
-
-## Migration from v4 (single-key-derived) vault
-
-```bash
-node CLI migrate                                # interactive passphrase prompt
-node CLI migrate --passphrase-file /tmp/pass    # automation
-```
-
-One-shot: the old `~/.agent-id/vault/` directory is renamed to `vault.bak/`. Migrated records get the placeholder allowlist `["UNCONFIGURED.invalid"]` — the proxy refuses to inject them until you attach real domains via `agent-id-vault add --name <N> --domains <H,…> --value-env <V>`.
+Less-common admin operations — adding/removing unlock slots (`rekey`), moving the vault between machines (`export`/`import`), and migrating a legacy v4 vault (`migrate`) — are documented in [reference.md](reference.md).
 
 ## Common flag
 

--- a/plugins/agent-id-vault/skills/agent-id-vault/reference.md
+++ b/plugins/agent-id-vault/skills/agent-id-vault/reference.md
@@ -1,0 +1,39 @@
+# Alien Agent ID — Vault: admin reference
+
+Less-common vault administration: managing unlock slots, moving the vault between
+machines, and migrating a legacy v4 vault. As in `SKILL.md`, `CLI` is
+`${CLAUDE_PLUGIN_ROOT}/bin/cli.mjs`, and `--state-dir <path>` (default
+`$AGENT_ID_STATE_DIR` then `~/.agent-id`) works on every subcommand below.
+
+## Rekey: add/remove slots
+
+```bash
+node CLI rekey add-passkey [--device-label NAME]                  # Touch ID / Face ID / security key
+node CLI rekey add-passphrase --new-passphrase-file /tmp/newpass   # DEV-mode vaults only
+node CLI rekey add-agent-key
+node CLI rekey add-mobile --device-pubkey HEX [--device-id NAME]   # phone (ECDH)
+node CLI rekey add-owner-approval [--sso-url URL]                  # Alien app
+node CLI rekey remove-slot --id 1
+```
+
+`rekey add-passphrase` only works on a **dev-mode** vault — on a user-mode vault it
+is refused (`PASSPHRASE_NOT_ALLOWED`), and there is no command to convert modes.
+The CLI also refuses to remove the last slot (vault would become unrecoverable).
+
+## Portability
+
+```bash
+node CLI export --out vault.enc        # already-encrypted; copy anywhere
+node CLI import --in vault.enc         # install on a new machine
+```
+
+After importing on machine B, run `rekey add-agent-key` to wire B's main key in for unattended unlock.
+
+## Migration from v4 (single-key-derived) vault
+
+```bash
+node CLI migrate                                # interactive passphrase prompt
+node CLI migrate --passphrase-file /tmp/pass    # automation
+```
+
+One-shot: the old `~/.agent-id/vault/` directory is renamed to `vault.bak/`. Migrated records get the placeholder allowlist `["UNCONFIGURED.invalid"]` — the proxy refuses to inject them until you attach real domains via `agent-id-vault add --name <N> --domains <H,…> --value-env <V>`.


### PR DESCRIPTION
## Summary

This branch carries two related plugin-hygiene changes:

1. **Marketplace install fix** — every plugin's `source` now points at its real location under `./plugins/<name>` so the marketplace is actually installable.
2. **Skills compliance pass** — all 7 agent-id skills brought in line with the current Claude Code skill/plugin authoring guidelines.

---

## 1. Marketplace install fix

### Problem
`/plugin install agent-id-git@alien-agent-id` (and every other plugin) failed with:

```
Failed to install: Source path does not exist: .../marketplaces/alien-agent-id/agent-id-git
```

The manifest declared sources at the repo root (`"./agent-id-git"`) while the plugins live under `plugins/`. It also set `metadata.pluginRoot: "./plugins"`, but per the Claude Code marketplace docs `pluginRoot` is **not** applied to `"./"`-prefixed sources — those resolve relative to the marketplace root. So Claude looked for `<repo>/agent-id-git`, which doesn't exist.

### Fix
- Set each plugin `source` to the explicit `./plugins/<name>` (canonical doc form, unambiguous regardless of `pluginRoot` support).
- Drop the now-redundant `metadata.pluginRoot`.
- Affects all six plugins: `agent-id-core`, `agent-id-git`, `agent-id-vault`, `agent-id-proxy`, `agent-id-auth`, `agent-id-browser`.

---

## 2. Skills compliance pass

Audited all 7 skills against the live Anthropic docs ([skill best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices) + [plugins reference](https://code.claude.com/docs/en/plugins-reference)). The skills were already strong (descriptions, trust boundaries, sizing, manifests all compliant); this fixes the gaps.

- **Path referencing (main fix):** the 5 plugin skills (`vault`, `proxy`, `auth`, `core`, `git`) now resolve their CLI via `${CLAUDE_PLUGIN_ROOT}/bin/cli.mjs` instead of instructing the model to invent a hardcoded absolute path. Per the docs, the variable is *"substituted inline anywhere [it] appears in skill content"* — so it resolves at load time, survives plugin updates (the install path changes on update), and still matches each skill's `allowed-tools` glob (no extra permission prompt). Brings them in line with the already-correct `browser` skill.
- **Progressive disclosure:** moved the `vault` skill's cold-path admin sections (rekey, portability, v4 migration) into a sibling `reference.md` with a one-level-deep pointer. Content preserved verbatim; trims the resident skill body (230 → 201 lines).
- **Security:** added a note to the `proxy` skill about its broad `Bash(curl:*)` grant (arbitrary-HTTP exfil surface) and how to harden it.
- **Spec compliance:** added `license` + `metadata` frontmatter to the clean-room example skill so all skills share an identical, valid field set.

Reviewed by an independent audit subagent against primary docs: all changes verified correct, content preserved verbatim, all 7 frontmatters valid.

## Test plan

- [x] `marketplace.json` parses; every `source` resolves to a dir containing `.claude-plugin/plugin.json` (all 6 ✓).
- [x] All 7 skills parse as valid YAML; `name` ≤64, `description` ≤1024 chars.
- [x] `vault/reference.md` content is byte-identical to the sections removed from `SKILL.md`.
- [ ] After merge: `/plugin marketplace update alien-agent-id` then `/plugin install agent-id-git@alien-agent-id` succeeds.
- [ ] Smoke-test a CLI invocation inside an installed plugin skill to confirm `${CLAUDE_PLUGIN_ROOT}` resolves and no permission prompt appears.

## Notes
- The marketplace bug broke installation for **every** consumer of the marketplace, not just a specific environment.
- Skills changes are docs/instruction-only — no executable code paths touched.

Co-Authored-By: Skrrt Bot <bot@skrrt.sh>
