### PR TITLE
fix: remove duplicate hooks reference from plugin manifests

### DIFF
--- a/plugins/agent-id-auth/.claude-plugin/plugin.json
+++ b/plugins/agent-id-auth/.claude-plugin/plugin.json
@@ -11,7 +11,6 @@
     "oidc",
     "agent-identity"
   ],
-  "hooks": "./hooks/hooks.json",
   "dependencies": [
     {
       "name": "agent-id-core",

--- a/plugins/agent-id-browser/.claude-plugin/plugin.json
+++ b/plugins/agent-id-browser/.claude-plugin/plugin.json
@@ -7,7 +7,6 @@
     "email": "support@alien.org"
   },
   "keywords": ["browser-automation", "patchright", "credential-vault", "agent-identity"],
-  "hooks": "./hooks/hooks.json",
   "dependencies": [
     {"name": "agent-id-core", "version": "7.0.0"},
     {"name": "agent-id-vault", "version": "7.0.0"}

--- a/plugins/agent-id-git/.claude-plugin/plugin.json
+++ b/plugins/agent-id-git/.claude-plugin/plugin.json
@@ -11,7 +11,6 @@
     "provenance",
     "agent-identity"
   ],
-  "hooks": "./hooks/hooks.json",
   "dependencies": [
     {
       "name": "agent-id-core",

--- a/plugins/agent-id-proxy/.claude-plugin/plugin.json
+++ b/plugins/agent-id-proxy/.claude-plugin/plugin.json
@@ -11,7 +11,6 @@
     "proxy",
     "agent-identity"
   ],
-  "hooks": "./hooks/hooks.json",
   "dependencies": [
     {
       "name": "agent-id-core",

--- a/plugins/agent-id-vault/.claude-plugin/plugin.json
+++ b/plugins/agent-id-vault/.claude-plugin/plugin.json
@@ -10,7 +10,6 @@
     "credential-vault",
     "agent-identity"
   ],
-  "hooks": "./hooks/hooks.json",
   "dependencies": [
     {
       "name": "agent-id-core",


### PR DESCRIPTION
## Summary
Installing the plugins failed with `Duplicate hooks file detected: ./hooks/hooks.json resolves to already-loaded file` on all five consuming plugins.

Claude Code **auto-loads** the standard `hooks/hooks.json`, so a `plugin.json` that *also* references `"hooks": "./hooks/hooks.json"` loads it twice and the plugin fails. (`manifest.hooks` should only point at *additional*, non-standard hook files.)

Fix: drop the redundant `"hooks"` field from `agent-id-{auth,browser,git,proxy,vault}/.claude-plugin/plugin.json`. The standard `hooks/hooks.json` still auto-loads, so the `SessionStart` `install-deps.sh` hook runs unchanged.

## Test plan
- [x] All 5 plugin.json parse; `hooks/hooks.json` files still present at the standard path
- [x] `sync-plugin-versions` no-op → version-sync drift check stays green
- [x] No published-package behavior change → no changeset needed
- [ ] Reinstall the plugins from the marketplace → no "Duplicate hooks" error (manual, on your side)

## Notes
Marketplace-only fix (plugin loading); the npm-published `core`/`vault` library behavior is unaffected, so versions are unchanged and no republish is triggered.

Co-Authored-By: Skrrt Bot <bot@skrrt.sh>