### PR TITLE
ci: use audit egress on the version-pr job (fix changelog GraphQL)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,14 +63,12 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
-          egress-policy: block
-          allowed-endpoints: >
-            registry.npmjs.org:443
-            github.com:443
-            api.github.com:443
-            objects.githubusercontent.com:443
-            release-assets.githubusercontent.com:443
-            uploads.github.com:443
+          # audit (not block) here: this job holds no id-token (OIDC) — only
+          # contents/pull-requests write — so it isn't an OIDC-exfil target,
+          # and `changeset version` needs GitHub's GraphQL API for
+          # @changesets/changelog-github, which block mode severs ("Premature
+          # close"). The publish job (which DOES hold id-token) keeps block.
+          egress-policy: audit
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,9 +50,12 @@ assumes the layers below it have failed.
 - A read-only `detect` job decides what each push should do from ground truth
   (changeset files for the Version PR, registry state for the publish), so
   nothing reaches the publish gate without a pending release.
-- **`step-security/harden-runner`** on every job: `audit` mode on CI, `block`
-  mode on release jobs with allowlists limited to npmjs, sigstore (publish job
-  only), and github.com.
+- **`step-security/harden-runner`** on every job. `block` mode on the `detect`
+  and `publish` release jobs (publish is the only one holding `id-token`), with
+  allowlists limited to npmjs, sigstore (publish only), and github.com. `audit`
+  mode on CI and on the `version-pr` job — it holds no OIDC token, and block
+  mode severs the GitHub GraphQL call `@changesets/changelog-github` makes
+  during `changeset version` ("Premature close").
 - **GitHub Environment `npm-publish`** gates only the publish job — required
   reviewers configured in repo settings. The Version PR is created without
   environment gating so reviewers see the proposed bumps first.


### PR DESCRIPTION
## Summary
The `chore: release 7.1.0` Version PR job fails at `changeset version`:

```
🦋 error Invalid response body while trying to fetch https://api.github.com/graphql: Premature close
```

`@changesets/changelog-github` queries GitHub's GraphQL API to enrich changelog entries. harden-runner's `egress-policy: block` (even with `api.github.com` allowlisted) severs that connection — `Premature close` is a connection kill, not auth (the token is present). **Confirmed** by running `changeset version` locally with no harden-runner: it bumps core/vault → 7.1.0 cleanly.

## Fix
Relax **only the `version-pr` job** to `egress-policy: audit`. It holds **no `id-token`** (only `contents`/`pull-requests` write), so it isn't an OIDC-exfiltration target. `detect` and `publish` keep `block` (publish is the one holding `id-token`). `SECURITY.md` updated to document this.

## Test plan
- [x] `changeset version` succeeds locally (no harden-runner) → confirms CI sandbox is the cause
- [x] `release.yml` valid YAML; egress now detect=block, version-pr=audit, publish=block
- [ ] On merge, the Release run's version-pr job succeeds and opens the Version PR (the publish step still waits on the `npm-publish` environment — being set up separately)

## Notes
This unblocks **Version PR creation** for the in-flight 7.1.0. Publishing core/vault@7.1.0 still requires the `npm-publish` GitHub Environment (operator setup, in progress).

Co-Authored-By: Skrrt Bot <bot@skrrt.sh>