### PR TITLE
fix(release): propagate internal dep ranges into plugin manifests

### DIFF
--- a/.changeset/plugin-dep-version-ranges.md
+++ b/.changeset/plugin-dep-version-ranges.md
@@ -1,0 +1,13 @@
+---
+"@alien-id/agent-id-core": patch
+"@alien-id/agent-id-vault": patch
+---
+
+Fix stale cross-plugin dependency pins in the marketplace manifests. Each
+`plugin.json` `dependencies[].version` was a bare exact pin (`7.0.0`), which
+Claude Code treats as an exact semver constraint — so an installed `7.1.0`
+failed it (`Requires "agent-id-core" 7.0.0, installed 7.1.0`). `sync-plugin-versions`
+now also propagates the internal dependency range from each `package.json`
+(e.g. `^7.1.0`, maintained by changesets) into `plugin.json`, keeping the
+ranges in lockstep with the versions changesets bumps. The CI drift check
+guards them going forward.

--- a/plugins/agent-id-auth/.claude-plugin/plugin.json
+++ b/plugins/agent-id-auth/.claude-plugin/plugin.json
@@ -14,7 +14,7 @@
   "dependencies": [
     {
       "name": "agent-id-core",
-      "version": "7.0.0"
+      "version": "^7.1.0"
     }
   ]
 }

--- a/plugins/agent-id-browser/.claude-plugin/plugin.json
+++ b/plugins/agent-id-browser/.claude-plugin/plugin.json
@@ -15,11 +15,11 @@
   "dependencies": [
     {
       "name": "agent-id-core",
-      "version": "7.0.0"
+      "version": "^7.1.0"
     },
     {
       "name": "agent-id-vault",
-      "version": "7.0.0"
+      "version": "^7.1.0"
     }
   ]
 }

--- a/plugins/agent-id-git/.claude-plugin/plugin.json
+++ b/plugins/agent-id-git/.claude-plugin/plugin.json
@@ -14,7 +14,7 @@
   "dependencies": [
     {
       "name": "agent-id-core",
-      "version": "7.0.0"
+      "version": "^7.1.0"
     }
   ]
 }

--- a/plugins/agent-id-proxy/.claude-plugin/plugin.json
+++ b/plugins/agent-id-proxy/.claude-plugin/plugin.json
@@ -14,11 +14,11 @@
   "dependencies": [
     {
       "name": "agent-id-core",
-      "version": "7.0.0"
+      "version": "^7.1.0"
     },
     {
       "name": "agent-id-vault",
-      "version": "7.0.0"
+      "version": "^7.1.0"
     }
   ]
 }

--- a/plugins/agent-id-vault/.claude-plugin/plugin.json
+++ b/plugins/agent-id-vault/.claude-plugin/plugin.json
@@ -13,7 +13,7 @@
   "dependencies": [
     {
       "name": "agent-id-core",
-      "version": "7.0.0"
+      "version": "^7.1.0"
     }
   ]
 }

--- a/scripts/lib/sync.ts
+++ b/scripts/lib/sync.ts
@@ -1,0 +1,98 @@
+// Pure planning core for `sync-plugin-versions`. Given parsed manifests (no
+// I/O), compute what each plugin's `.claude-plugin/plugin.json` and the
+// marketplace catalog SHOULD contain, plus a human-readable change log. The
+// entry script is a thin shell that reads files, calls these, and writes back.
+
+export type PluginPkg = {
+  shortName: string; // plugin.json "name"
+  pkgName: string; // package.json "name"
+  version: string; // package.json "version"
+  pkgDependencies: Record<string, string>; // package.json "dependencies"
+};
+
+export type PluginManifest = {
+  name: string;
+  version?: string;
+  dependencies?: { name: string; version: string }[];
+  [k: string]: unknown;
+};
+
+// Compute the desired plugin.json: its own version (from package.json) and each
+// cross-plugin dependency's range (the depended plugin's package.json range,
+// mapped from npm name to plugin shortName via `pkgNameToShort`). Returns a new
+// manifest and the changes applied. Throws when the manifest declares a
+// dependency that package.json doesn't — that range can't be resolved.
+export function planPluginManifest(
+  pkg: PluginPkg,
+  manifest: PluginManifest,
+  pkgNameToShort: Map<string, string>,
+): { manifest: PluginManifest; changes: string[] } {
+  const next: PluginManifest = { ...manifest };
+  const changes: string[] = [];
+
+  if (next.version !== pkg.version) {
+    next.version = pkg.version;
+    changes.push(`plugin.json  ${pkg.shortName} -> ${pkg.version}`);
+  }
+
+  // Internal dependency shortName -> range, resolved from package.json deps.
+  const rangeByShort = new Map<string, string>();
+  for (const [depPkgName, range] of Object.entries(pkg.pkgDependencies)) {
+    const depShort = pkgNameToShort.get(depPkgName);
+    if (depShort) rangeByShort.set(depShort, range);
+  }
+
+  if (Array.isArray(next.dependencies)) {
+    next.dependencies = next.dependencies.map((dep) => {
+      const range = rangeByShort.get(dep.name);
+      if (!range) {
+        throw new Error(
+          `${pkg.shortName} plugin.json declares dependency "${dep.name}" with no ` +
+            `matching entry in package.json "dependencies"`,
+        );
+      }
+      if (dep.version !== range) {
+        changes.push(`plugin.json  ${pkg.shortName} dep ${dep.name} -> ${range}`);
+      }
+      return { ...dep, version: range };
+    });
+  }
+
+  return { manifest: next, changes };
+}
+
+export type Marketplace = {
+  plugins: { name: string; version?: string }[];
+  [k: string]: unknown;
+};
+
+// Propagate each plugin's version into its marketplace catalog entry. Pure.
+// Throws on drift either way: a catalog entry with no matching plugin, or a
+// plugin absent from the catalog (which would otherwise silently ship stale).
+export function planMarketplace(
+  marketplace: Marketplace,
+  versions: Map<string, string>,
+): { marketplace: Marketplace; changes: string[] } {
+  const changes: string[] = [];
+  const seen = new Set<string>();
+
+  const plugins = marketplace.plugins.map((entry) => {
+    seen.add(entry.name);
+    const version = versions.get(entry.name);
+    if (!version) {
+      throw new Error(`marketplace entry "${entry.name}" has no matching plugin package.json`);
+    }
+    if (entry.version !== version) {
+      changes.push(`marketplace   ${entry.name} -> ${version}`);
+    }
+    return { ...entry, version };
+  });
+
+  for (const shortName of versions.keys()) {
+    if (!seen.has(shortName)) {
+      throw new Error(`plugin "${shortName}" has no entry in the marketplace catalog`);
+    }
+  }
+
+  return { marketplace: { ...marketplace, plugins }, changes };
+}

--- a/scripts/sync-plugin-versions.ts
+++ b/scripts/sync-plugin-versions.ts
@@ -1,21 +1,35 @@
 #!/usr/bin/env bun
 
-// Propagate each plugin's package.json version (the source of truth changesets
-// bumps) into the two manifests the marketplace reads but changesets ignores:
+// Propagate each plugin's package.json (the source of truth changesets bumps)
+// into the two manifests the marketplace reads but changesets ignores:
 // plugins/<name>/.claude-plugin/plugin.json and .claude-plugin/marketplace.json.
-// Run by `ci:version`. Idempotent; exits non-zero on drift so CI catches it.
+// Two things flow through:
+//   1. the plugin's own `version`
+//   2. each internal dependency RANGE from package.json `dependencies`
+//      (e.g. "@alien-id/agent-id-core": "^7.1.0", maintained by changesets'
+//      updateInternalDependencies) -> plugin.json `dependencies[].version`
+// Without (2), plugin.json's cross-plugin pins are maintained by nobody and
+// drift stale (a bare "7.0.0" is an EXACT semver constraint to Claude Code, so
+// an installed 7.1.0 fails it). The planning logic lives in ./lib/sync.ts;
+// this is the I/O shell. Run by `ci:version`. Idempotent; the CI drift check
+// (`git diff --exit-code`) catches any manifest that fell behind.
 
 import { readFile, readdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import {
+  type Marketplace,
+  type PluginManifest,
+  type PluginPkg,
+  planMarketplace,
+  planPluginManifest,
+} from './lib/sync';
 
 const REPO_ROOT = new URL('..', import.meta.url).pathname;
 const PLUGINS_DIR = join(REPO_ROOT, 'plugins');
 const MARKETPLACE = join(REPO_ROOT, '.claude-plugin', 'marketplace.json');
 
-type Json = Record<string, unknown>;
-
-async function readJson(path: string): Promise<Json> {
-  return JSON.parse(await readFile(path, 'utf8')) as Json;
+async function readJson<T>(path: string): Promise<T> {
+  return JSON.parse(await readFile(path, 'utf8')) as T;
 }
 
 // Write JSON with a trailing newline so the manifests round-trip cleanly through
@@ -28,67 +42,55 @@ async function main() {
   const entries = await readdir(PLUGINS_DIR, { withFileTypes: true });
   const dirs = entries.filter((e) => e.isDirectory()).map((e) => e.name);
 
-  // shortName (plugin.json `name`) -> version, collected from package.json.
+  // Collect every plugin's package.json + plugin.json, then build the cross-plugin
+  // name map the planner needs to resolve dependency ranges.
+  const collected: { path: string; pkg: PluginPkg; manifest: PluginManifest }[] = [];
+  const pkgNameToShort = new Map<string, string>();
   const versions = new Map<string, string>();
 
   for (const dir of dirs) {
-    const pkgPath = join(PLUGINS_DIR, dir, 'package.json');
-    const pkg = await readJson(pkgPath).catch(() => null);
-    if (!pkg || typeof pkg.version !== 'string') continue;
-    const version = pkg.version;
+    const pkg = await readJson<Record<string, unknown>>(join(PLUGINS_DIR, dir, 'package.json')).catch(
+      () => null,
+    );
+    if (!pkg || typeof pkg.version !== 'string' || typeof pkg.name !== 'string') continue;
 
-    const pluginJsonPath = join(PLUGINS_DIR, dir, '.claude-plugin', 'plugin.json');
-    const plugin = await readJson(pluginJsonPath).catch((err) => {
+    const path = join(PLUGINS_DIR, dir, '.claude-plugin', 'plugin.json');
+    const manifest = await readJson<PluginManifest>(path).catch((err) => {
       throw new Error(
-        `${pluginJsonPath} is missing or unreadable (every plugin needs a ` +
-          `.claude-plugin/plugin.json): ${err instanceof Error ? err.message : err}`,
+        `${path} is missing or unreadable (every plugin needs a .claude-plugin/plugin.json): ` +
+          `${err instanceof Error ? err.message : err}`,
       );
     });
-    const shortName = plugin.name;
-    if (typeof shortName !== 'string') {
-      throw new Error(`${pluginJsonPath} has no string "name"`);
-    }
+    if (typeof manifest.name !== 'string') throw new Error(`${path} has no string "name"`);
 
-    if (plugin.version !== version) {
-      plugin.version = version;
-      await writeJson(pluginJsonPath, plugin);
-      console.log(`plugin.json  ${shortName} -> ${version}`);
-    }
-    versions.set(shortName, version);
+    pkgNameToShort.set(pkg.name, manifest.name);
+    versions.set(manifest.name, pkg.version);
+    collected.push({
+      path,
+      pkg: {
+        shortName: manifest.name,
+        pkgName: pkg.name,
+        version: pkg.version,
+        pkgDependencies: (pkg.dependencies as Record<string, string> | undefined) ?? {},
+      },
+      manifest,
+    });
   }
 
-  const marketplace = await readJson(MARKETPLACE);
-  const plugins = marketplace.plugins;
-  if (!Array.isArray(plugins)) {
-    throw new Error(`${MARKETPLACE} has no "plugins" array`);
-  }
-
-  const marketplaceNames = new Set<string>();
-  let changed = false;
-  for (const entry of plugins as Json[]) {
-    const name = entry.name;
-    if (typeof name !== 'string') continue;
-    marketplaceNames.add(name);
-    const version = versions.get(name);
-    if (!version) {
-      throw new Error(`marketplace entry "${name}" has no matching plugin package.json`);
-    }
-    if (entry.version !== version) {
-      entry.version = version;
-      changed = true;
-      console.log(`marketplace   ${name} -> ${version}`);
+  for (const { path, pkg, manifest } of collected) {
+    const planned = planPluginManifest(pkg, manifest, pkgNameToShort);
+    if (planned.changes.length > 0) {
+      await writeJson(path, planned.manifest);
+      planned.changes.forEach((c) => console.log(c));
     }
   }
 
-  // Reverse check: every plugin must appear in the marketplace, or a plugin
-  // dropped from marketplace.json would silently pass (drift the other way).
-  for (const shortName of versions.keys()) {
-    if (!marketplaceNames.has(shortName)) {
-      throw new Error(`plugin "${shortName}" has no entry in ${MARKETPLACE}`);
-    }
+  const marketplace = await readJson<Marketplace>(MARKETPLACE);
+  const plannedMarketplace = planMarketplace(marketplace, versions);
+  if (plannedMarketplace.changes.length > 0) {
+    await writeJson(MARKETPLACE, plannedMarketplace.marketplace);
+    plannedMarketplace.changes.forEach((c) => console.log(c));
   }
-
-  if (changed) await writeJson(MARKETPLACE, marketplace);
 
   console.log('sync-plugin-versions: done');
 }

--- a/scripts/tests/sync.test.ts
+++ b/scripts/tests/sync.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from 'bun:test';
+import { planMarketplace, planPluginManifest, type PluginPkg } from '../lib/sync';
+
+// Two-plugin world: a dependent (vault) that depends on a library (core).
+const CORE: PluginPkg = {
+  shortName: 'agent-id-core',
+  pkgName: '@alien-id/agent-id-core',
+  version: '7.1.0',
+  pkgDependencies: {},
+};
+const VAULT: PluginPkg = {
+  shortName: 'agent-id-vault',
+  pkgName: '@alien-id/agent-id-vault',
+  version: '7.1.0',
+  pkgDependencies: { '@alien-id/agent-id-core': '^7.1.0' },
+};
+const PKG_NAME_TO_SHORT = new Map([
+  [CORE.pkgName, CORE.shortName],
+  [VAULT.pkgName, VAULT.shortName],
+]);
+
+describe('planPluginManifest', () => {
+  test('propagates the package.json version into the manifest', () => {
+    const { manifest } = planPluginManifest(
+      CORE,
+      { name: 'agent-id-core', version: '7.0.0' },
+      PKG_NAME_TO_SHORT,
+    );
+    expect(manifest.version).toBe('7.1.0');
+  });
+
+  test('propagates the internal dependency range from package.json', () => {
+    // The bug: a bare "7.0.0" pin is an exact semver constraint, so an
+    // installed 7.1.0 fails it. The range must mirror package.json's "^7.1.0".
+    const { manifest } = planPluginManifest(
+      VAULT,
+      {
+        name: 'agent-id-vault',
+        version: '7.1.0',
+        dependencies: [{ name: 'agent-id-core', version: '7.0.0' }],
+      },
+      PKG_NAME_TO_SHORT,
+    );
+    expect(manifest.dependencies).toEqual([{ name: 'agent-id-core', version: '^7.1.0' }]);
+  });
+
+  test('leaves an already-correct manifest unchanged with no change log', () => {
+    const { manifest, changes } = planPluginManifest(
+      VAULT,
+      {
+        name: 'agent-id-vault',
+        version: '7.1.0',
+        dependencies: [{ name: 'agent-id-core', version: '^7.1.0' }],
+      },
+      PKG_NAME_TO_SHORT,
+    );
+    expect(changes).toEqual([]);
+    expect(manifest.dependencies).toEqual([{ name: 'agent-id-core', version: '^7.1.0' }]);
+  });
+
+  test('throws when plugin.json declares a dependency package.json lacks', () => {
+    expect(() =>
+      planPluginManifest(
+        VAULT,
+        {
+          name: 'agent-id-vault',
+          version: '7.1.0',
+          dependencies: [{ name: 'agent-id-core', version: '^7.1.0' }, { name: 'ghost', version: '1.0.0' }],
+        },
+        PKG_NAME_TO_SHORT,
+      ),
+    ).toThrow(/ghost/);
+  });
+});
+
+describe('planMarketplace', () => {
+  const versions = new Map([
+    ['agent-id-core', '7.1.0'],
+    ['agent-id-vault', '7.1.0'],
+  ]);
+
+  test('propagates plugin versions into catalog entries', () => {
+    const { marketplace, changes } = planMarketplace(
+      {
+        plugins: [
+          { name: 'agent-id-core', version: '7.0.0' },
+          { name: 'agent-id-vault', version: '7.1.0' },
+        ],
+      },
+      versions,
+    );
+    expect(marketplace.plugins.map((p) => p.version)).toEqual(['7.1.0', '7.1.0']);
+    expect(changes).toEqual(['marketplace   agent-id-core -> 7.1.0']);
+  });
+
+  test('throws when a catalog entry has no matching plugin', () => {
+    expect(() =>
+      planMarketplace({ plugins: [{ name: 'ghost', version: '1.0.0' }] }, versions),
+    ).toThrow(/ghost/);
+  });
+
+  test('throws when a plugin is missing from the catalog', () => {
+    expect(() =>
+      planMarketplace({ plugins: [{ name: 'agent-id-core', version: '7.1.0' }] }, versions),
+    ).toThrow(/agent-id-vault/);
+  });
+});


### PR DESCRIPTION
## Summary

After the 7.1.0 release, Claude Code reports a plugin error:

```
agent-id-vault@alien-agent-id: Requires "agent-id-core@alien-agent-id" 7.0.0, installed 7.1.0
```

**Root cause.** Each plugin's `.claude-plugin/plugin.json` pinned its
cross-plugin dependencies at a bare exact version (`"7.0.0"`). Claude Code
treats that field as a semver range, and a bare version is an *exact*
constraint — so an installed `agent-id-core@7.1.0` no longer satisfied the
dependents' requirement.

**Why it drifted.** Nothing maintained those pins. Changesets updates only
`package.json` (the `version` and the `^range` internal deps), and
`sync-plugin-versions` propagated only the `version` field into the manifests —
never the dependency ranges. So the pins were hand-written once at `7.0.0` and
never moved.

**Fix.** `sync-plugin-versions` now also propagates each internal dependency
range from `package.json` (e.g. `^7.1.0`, maintained by changesets) into
`plugin.json` `dependencies[].version`, keeping the pins in lockstep with the
versions changesets bumps. The CI drift check (`git diff --exit-code`) guards
them going forward. All 7 cross-plugin pins are regenerated to `^7.1.0`.

The propagation logic is extracted into a pure, unit-tested module
(`scripts/lib/sync.ts` — `planPluginManifest` + `planMarketplace`, no I/O)
behind a thin shell, matching the repo's existing `lib`/`tests` convention.

A patch changeset bumps `@alien-id/agent-id-core` and `@alien-id/agent-id-vault`
so the corrected manifests ride a release.

## Test plan

- [x] New `scripts/tests/sync.test.ts` (7 cases): version propagation, dep-range
      propagation, idempotency, and the three drift/error guards
- [x] `bun test scripts/tests` — 45 pass
- [x] `bun run test` — 422 pass
- [x] Empirical: reset manifests to the buggy committed state, ran the script,
      confirmed it regenerates `^7.1.0` and is idempotent on re-run
- [x] Empirical: verified all 7 constraints satisfy installed `7.1.0` under the
      same semver engine Claude Code uses (`7.0.0` → fails, `^7.1.0` → passes)

## Notes

- No npm-published runtime code changed; this fixes the marketplace manifests +
  release tooling. Releasing is automatic — `changesets/action` will open the
  Version PR; no manual tags.

Co-Authored-By: Skrrt Bot <bot@skrrt.sh>
