### PR TITLE
fix: use caret ranges for inter-plugin dependency pins

### DIFF
--- a/.changeset/plugin-dep-caret-ranges.md
+++ b/.changeset/plugin-dep-caret-ranges.md
@@ -1,0 +1,12 @@
+---
+"@alien-id/agent-id-vault": patch
+---
+
+Use a caret range (`^7.0.0`) instead of an exact `7.0.0` pin for the
+`agent-id-core` marketplace dependency in `.claude-plugin/plugin.json`. The exact
+pin made Claude Code's plugin resolver reject any cross-minor update ("7.1.0 does
+not satisfy 7.0.0"), so `claude plugin update` could not move the plugin from
+7.0.0 to 7.1.0 while a dependent was installed. The range mirrors the npm
+`package.json` dependency semantics and lets in-range updates resolve. The same
+fix is applied to the private `auth`/`git`/`proxy`/`browser` plugin manifests
+(not release-tracked).

--- a/plugins/agent-id-auth/.claude-plugin/plugin.json
+++ b/plugins/agent-id-auth/.claude-plugin/plugin.json
@@ -14,7 +14,7 @@
   "dependencies": [
     {
       "name": "agent-id-core",
-      "version": "7.0.0"
+      "version": "^7.0.0"
     }
   ]
 }

--- a/plugins/agent-id-browser/.claude-plugin/plugin.json
+++ b/plugins/agent-id-browser/.claude-plugin/plugin.json
@@ -15,11 +15,11 @@
   "dependencies": [
     {
       "name": "agent-id-core",
-      "version": "7.0.0"
+      "version": "^7.0.0"
     },
     {
       "name": "agent-id-vault",
-      "version": "7.0.0"
+      "version": "^7.0.0"
     }
   ]
 }

--- a/plugins/agent-id-git/.claude-plugin/plugin.json
+++ b/plugins/agent-id-git/.claude-plugin/plugin.json
@@ -14,7 +14,7 @@
   "dependencies": [
     {
       "name": "agent-id-core",
-      "version": "7.0.0"
+      "version": "^7.0.0"
     }
   ]
 }

--- a/plugins/agent-id-proxy/.claude-plugin/plugin.json
+++ b/plugins/agent-id-proxy/.claude-plugin/plugin.json
@@ -14,11 +14,11 @@
   "dependencies": [
     {
       "name": "agent-id-core",
-      "version": "7.0.0"
+      "version": "^7.0.0"
     },
     {
       "name": "agent-id-vault",
-      "version": "7.0.0"
+      "version": "^7.0.0"
     }
   ]
 }

--- a/plugins/agent-id-vault/.claude-plugin/plugin.json
+++ b/plugins/agent-id-vault/.claude-plugin/plugin.json
@@ -13,7 +13,7 @@
   "dependencies": [
     {
       "name": "agent-id-core",
-      "version": "7.0.0"
+      "version": "^7.0.0"
     }
   ]
 }


### PR DESCRIPTION
## Problem

The six plugins' marketplace manifests (`.claude-plugin/plugin.json`) declared
their inter-plugin dependencies with an **exact** version pin:

```json
"dependencies": [{ "name": "agent-id-core", "version": "7.0.0" }]
```

Claude Code's plugin resolver treats a bare `"7.0.0"` as an exact match, so after
the 7.1.0 release `claude plugin update` refused to move `agent-id-core` /
`agent-id-vault` from 7.0.0 → 7.1.0:

```
✔ Skipped — agent-id-vault, agent-id-proxy, agent-id-auth, agent-id-browser,
  agent-id-git requires agent-id-core at a version range that 7.1.0 does not satisfy
```

The dependent plugins update fine, but core/vault get stuck at the old version
label whenever any dependent is installed — a deadlock that recurs on every
future minor/patch bump. The npm `package.json` manifests already use `^7.0.0`;
only the marketplace `plugin.json` manifests were pinned exact.

## Fix

Switch every inter-plugin `dependencies[].version` in `plugin.json` from `7.0.0`
to the caret range `^7.0.0`, mirroring the npm `package.json` dependency
semantics. In-range updates now resolve, so the resolver no longer blocks
cross-version plugin updates.

Files: `plugin.json` for `vault`, `auth`, `git`, `proxy`, `browser`
(`core` has no dependencies block).

A `patch` changeset is included for `@alien-id/agent-id-vault` — its npm tarball
ships `.claude-plugin/`, so the manifest change is a published-package change. The
four private plugins are `ignore`d by changesets and need none.

> Note: `scripts/sync-plugin-versions.ts` does not manage `dependencies[].version`
> (only each plugin's own `version` + the marketplace entry), so this edit
> introduces no version-sync drift. A possible follow-up is to have that script
> also own/validate the dependency ranges so they can't drift to exact pins again.

## Testing

- `bun run test` — 422 pass / 0 fail
- `bun test scripts/tests` — 38 pass / 0 fail
- `bun run sync-plugin-versions` + `git diff --exit-code` — clean (no drift)
- `claude plugin validate` — passes with `^7.0.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
