### PR TITLE
feat(vault): per-credential access levels (read-only credentials)

### DIFF
--- a/.changeset/spicy-access-levels.md
+++ b/.changeset/spicy-access-levels.md
@@ -1,0 +1,14 @@
+---
+"@alien-id/agent-id-vault": minor
+---
+
+Per-credential access levels: records can carry `access: "ro" | "rw"` (default
+`rw`) plus ordered `accessRules` (`{effect, methods, hosts, path}`), evaluated
+by the new `lib/access.mjs` policy engine. Read-only credentials permit
+GET/HEAD/OPTIONS and POST-tunneled reads (GraphQL query, JMAP get/query,
+JSON-RPC non-submitting calls); `show` redacts and `exec` refuses their secret
+fields. New `set-access` CLI command changes the level — tightening applies
+immediately, widening requires the owner's out-of-band confirmation via the
+secure prompt, and `add`/`generate` refuse to widen an existing record.
+Enforcement happens in agent-id-proxy (structured `403 access_denied`) and
+agent-id-browser (network-layer route gate for sealed sessions).

--- a/.changeset/spicy-access-levels.md
+++ b/.changeset/spicy-access-levels.md
@@ -17,6 +17,10 @@ Hardening: body classification runs only for POST (a read-shaped body can't
 promote a DELETE/PUT/PATCH); JSON-RPC is default-deny (unrecognized methods are
 not treated as reads); rule reordering counts as a relaxation (owner ceremony);
 rule-restricted `rw` credentials are sealed and their browser sessions block
-WebSockets/service-workers too; multi-operation GraphQL documents are writes if
-they contain any mutation/subscription. The proxy closes the connection on
-early denials so an unconsumed request body can't corrupt the response status.
+service workers and WebSockets (at the network layer via `routeWebSocket`, so a
+Worker-opened socket can't evade it) too; multi-operation GraphQL documents are
+writes if they contain any mutation/subscription. The relaxation check is
+precedence-aware — only an allow rule moving ahead of an overlapping deny needs
+the owner ceremony, so ordinary tightenings still apply immediately. The proxy
+closes the connection on early denials so an unconsumed request body can't
+corrupt the response status.

--- a/.changeset/spicy-access-levels.md
+++ b/.changeset/spicy-access-levels.md
@@ -12,3 +12,11 @@ immediately, widening requires the owner's out-of-band confirmation via the
 secure prompt, and `add`/`generate` refuse to widen an existing record.
 Enforcement happens in agent-id-proxy (structured `403 access_denied`) and
 agent-id-browser (network-layer route gate for sealed sessions).
+
+Hardening: body classification runs only for POST (a read-shaped body can't
+promote a DELETE/PUT/PATCH); JSON-RPC is default-deny (unrecognized methods are
+not treated as reads); rule reordering counts as a relaxation (owner ceremony);
+rule-restricted `rw` credentials are sealed and their browser sessions block
+WebSockets/service-workers too; multi-operation GraphQL documents are writes if
+they contain any mutation/subscription. The proxy closes the connection on
+early denials so an unconsumed request body can't corrupt the response status.

--- a/plugins/agent-id-browser/bin/cli.mjs
+++ b/plugins/agent-id-browser/bin/cli.mjs
@@ -52,6 +52,17 @@ import { autoLogin } from "../lib/auto-login.mjs";
 import { looksLoggedOut } from "../lib/session.mjs";
 import { runSession, callSession } from "../lib/session-server.mjs";
 import { hasOwnerApproval, unlockViaOwnerApproval } from "../lib/unlock.mjs";
+import {
+  ACCESS_LEVELS,
+  effectiveAccess,
+  isAccessRelaxation,
+  strictestAccess,
+} from "@alien-id/agent-id-vault/lib/access.mjs";
+import {
+  applyAccessGuard,
+  contextOptionsForAccess,
+  guardDecision,
+} from "../lib/access-guard.mjs";
 
 // Bridge the plugin path vars into the environment. Claude Code SUBSTITUTES
 // ${CLAUDE_PLUGIN_DATA}/${CLAUDE_PLUGIN_ROOT} into skill text but only EXPORTS
@@ -215,7 +226,13 @@ async function withProfile({ flags, name, headless, action }) {
     try {
       await unsealProfile({ stateDir, file: cred.profileFile, dekHex: cred.dek, destDir: work });
       const useHeadless = headless != null ? headless : cred.headless !== false;
-      const ctx = await launchContext({ profileDir: work, headless: useHeadless });
+      const ctx = await launchContext({
+        profileDir: work,
+        headless: useHeadless,
+        contextOptions: contextOptionsForAccess(cred),
+      });
+      // Read-only profile → network gate on everything this context does.
+      await applyAccessGuard(ctx, cred, { log: (m) => stderr(m) });
       let result;
       try {
         result = await action(ctx, cred);
@@ -241,6 +258,10 @@ async function cmdLogin(flags) {
   const name = String(flags.name || DEFAULT_PROFILE);
   const stateDir = resolveStateDir(flags);
   const startUrl = flags.url ? String(flags.url) : "about:blank";
+  const access = flags.access != null ? String(flags.access) : null;
+  if (access && !ACCESS_LEVELS.includes(access)) {
+    return outputError(`--access must be one of ${ACCESS_LEVELS.join(", ")}`);
+  }
 
   let vault;
   try {
@@ -265,6 +286,14 @@ async function cmdLogin(flags) {
         await unsealProfile({ stateDir, file: existing.profileFile, dekHex: existing.dek, destDir: work });
       }
       const reuse = resuming ? existing : null;
+      // A login can create a restricted session or tighten one — never widen
+      // one. Widening is the owner's call: `agent-id-vault set-access`.
+      if (reuse && access && isAccessRelaxation(reuse, { ...reuse, access })) {
+        return outputError(
+          `session '${name}' has access level '${effectiveAccess(reuse)}' — a re-login cannot ` +
+            `widen it to '${access}'. The owner can: agent-id-vault set-access --name ${name} --access ${access}`,
+        );
+      }
       const file = reuse ? reuse.profileFile : `${name}.tar.enc`;
       const dek = reuse ? reuse.dek : newDek();
       const account = flags.account ? String(flags.account) : reuse?.account || null;
@@ -307,6 +336,9 @@ async function cmdLogin(flags) {
         // The DEK is generated in-vault and must never be shown to the agent —
         // `vault show` redacts sealed fields (incl. dek) for exportable:false.
         exportable: false,
+        // Tighten (or set on a fresh profile); the reuse spread already carries
+        // an existing restriction forward, and widening was refused above.
+        ...(access ? { access } : {}),
         ...(account ? { account } : {}),
         lastSyncedAt: Date.now(),
       });
@@ -318,6 +350,7 @@ async function cmdLogin(flags) {
         sealedBytes: bytes,
         resumed: !!resuming,
         account,
+        access: access || (reuse ? effectiveAccess(reuse) : "rw"),
         headlessDefault,
         message: resuming
           ? `Added to your existing '${name}' session — other logins kept.`
@@ -342,6 +375,10 @@ async function cmdAutoLogin(flags) {
   const credName = flags.cred ? String(flags.cred) : null;
   if (!credName) {
     return outputError("--cred <LOGIN_CRED> is required (the name of a `login` credential)");
+  }
+  const requestedAccess = flags.access != null ? String(flags.access) : null;
+  if (requestedAccess && !ACCESS_LEVELS.includes(requestedAccess)) {
+    return outputError(`--access must be one of ${ACCESS_LEVELS.join(", ")}`);
   }
   const stateDir = resolveStateDir(flags);
 
@@ -377,6 +414,29 @@ async function cmdAutoLogin(flags) {
     }
     const existing = vault.get(profileName);
     const reuse = existing && existing.type === "browser-profile" ? existing : null;
+
+    // The session's access level is the STRICTEST of: the login credential's
+    // (a read-only credential can only mint read-only sessions), the existing
+    // profile's (a re-login never widens), and the requested flag. An explicit
+    // request the ceiling forbids is an error, not a silent clamp.
+    const ceiling = effectiveAccess(cred);
+    if (requestedAccess === "rw" && ceiling === "ro") {
+      return outputError(
+        `login credential '${credName}' is read-only — sessions minted from it cannot be 'rw'. ` +
+          `The owner can widen it: agent-id-vault set-access --name ${credName} --access rw`,
+      );
+    }
+    if (reuse && requestedAccess && isAccessRelaxation(reuse, { ...reuse, access: requestedAccess })) {
+      return outputError(
+        `session '${profileName}' has access level '${effectiveAccess(reuse)}' — auto-login cannot ` +
+          `widen it. The owner can: agent-id-vault set-access --name ${profileName} --access ${requestedAccess}`,
+      );
+    }
+    const sessionAccess = strictestAccess(
+      strictestAccess(requestedAccess || "rw", ceiling),
+      reuse ? effectiveAccess(reuse) : "rw",
+    );
+
     const file = reuse ? reuse.profileFile : `${profileName}.tar.enc`;
     const dek = reuse ? reuse.dek : newDek();
     const headless = resolveHeadless(flags) ?? true;
@@ -420,6 +480,10 @@ async function cmdAutoLogin(flags) {
         profileFile: file,
         headless: reuse ? reuse.headless !== false : true,
         exportable: false,
+        ...(sessionAccess !== "rw" ? { access: sessionAccess } : {}),
+        // A fresh profile inherits the login credential's rules; an existing
+        // profile keeps its own (carried by the reuse spread).
+        ...(!reuse && Array.isArray(cred.accessRules) ? { accessRules: cred.accessRules } : {}),
         ...(reuse?.account || cred.username ? { account: reuse?.account || cred.username } : {}),
         lastSyncedAt: Date.now(),
       });
@@ -431,6 +495,7 @@ async function cmdAutoLogin(flags) {
         profile: profileName,
         outcome: result.outcome,
         finalUrl: result.finalUrl,
+        access: sessionAccess,
         sealedBytes: bytes,
         message: `Logged in and sealed session '${profileName}'. Reuse it: \`read --name ${profileName} --url …\`.`,
       });
@@ -504,7 +569,14 @@ async function cmdFetch(flags) {
       flags,
       name,
       headless: resolveHeadless(flags),
-      action: async (ctx) => {
+      action: async (ctx, cred) => {
+        // ctx.request bypasses route interception — check the policy directly.
+        const decision = guardDecision(cred, { method: "GET", url, postData: null });
+        if (!decision.allowed) {
+          throw new Error(
+            `access level '${effectiveAccess(cred)}' blocks GET ${url} (${decision.reason})`,
+          );
+        }
         const resp = await ctx.request.get(url, { timeout: 30000 });
         const httpStatus = resp.status();
         let body = "";
@@ -565,6 +637,7 @@ async function cmdStatus(flags) {
       profiles.push({
         name: m.name,
         account: m.account || null,
+        access: effectiveAccess(cred),
         headlessDefault: m.headless !== false,
         sealed: await sealedProfileExists(stateDir, cred.profileFile),
         lastSyncedAt: cred.lastSyncedAt || null,
@@ -592,6 +665,7 @@ async function cmdOpen(flags) {
   let dekHex;
   let profileFile;
   let headlessDefault;
+  let policy = null;
   try {
     const cred = vault.get(name);
     if (!cred || cred.type !== "browser-profile") {
@@ -607,6 +681,12 @@ async function cmdOpen(flags) {
     dekHex = cred.dek;
     profileFile = cred.profileFile;
     headlessDefault = cred.headless !== false;
+    if (cred.access != null || cred.accessRules != null) {
+      policy = {
+        ...(cred.access != null ? { access: cred.access } : {}),
+        ...(cred.accessRules != null ? { accessRules: cred.accessRules } : {}),
+      };
+    }
   } catch (err) {
     vault.lock();
     return handleErr(err);
@@ -619,10 +699,11 @@ async function cmdOpen(flags) {
     await fs.rm(workDir, { recursive: true, force: true });
     await unsealProfile({ stateDir, file: profileFile, dekHex, destDir: workDir });
     stderr(
-      `Session '${name}' starting (${headless ? "headless" : "headed"}). Keep this process ` +
+      `Session '${name}' starting (${headless ? "headless" : "headed"}` +
+        `${policy && effectiveAccess(policy) === "ro" ? ", READ-ONLY" : ""}). Keep this process ` +
         `running (background it); issue actions, then \`close --name ${name}\`.`,
     );
-    await runSession({ stateDir, name, headless, dekHex, profileFile, workDir }); // blocks until close
+    await runSession({ stateDir, name, headless, dekHex, profileFile, workDir, policy }); // blocks until close
   } catch (err) {
     await fs.rm(workDir, { recursive: true, force: true }).catch(() => {});
     handleErr(err);
@@ -723,12 +804,19 @@ runCli({
         "Google once, reuse it everywhere. `login` is ADDITIVE (re-run to add sites).\n" +
         "Use --name to open a SEPARATE isolated session; --fresh discards & restarts one.\n\n" +
         "Setup / one-shot ([--name N] optional; defaults to the shared 'main' session):\n" +
-        "  login   [--name N] [--url START] [--account LABEL] [--fresh]\n" +
+        "  login   [--name N] [--url START] [--account LABEL] [--fresh] [--access ro|rw]\n" +
         "          HEADED login; (re)seals the session into the vault (additive)\n" +
-        "  auto-login --cred LOGIN [--name N] [--headed]\n" +
+        "  auto-login --cred LOGIN [--name N] [--headed] [--access ro|rw]\n" +
         "          drive a service login from a vault `login` credential (username/\n" +
         "          password + 2FA via stored seed or the secure prompt); seals the\n" +
         "          session into profile N (default the cred's `profile`, else 'main')\n" +
+        "          --access ro seals a READ-ONLY session: every request the page\n" +
+        "          makes is classified in the session process; writes are blocked\n" +
+        "          at the wire (GET/HEAD/OPTIONS + GraphQL-query/JMAP-get/JSON-RPC\n" +
+        "          reads pass), WebSockets/service-workers are disabled, and\n" +
+        "          eval/fill-secret/fill-otp are refused. A ro login credential\n" +
+        "          only mints ro sessions; re-logins can tighten but never widen\n" +
+        "          (the owner widens via `agent-id-vault set-access`).\n" +
         "  read    [--name N] --url URL [--headed] [--max-chars K]\n" +
         "          one-shot: navigate (headless) → page text + final URL + sessionExpired\n" +
         "  fetch   [--name N] --url URL [--max-chars K]\n" +

--- a/plugins/agent-id-browser/lib/access-guard.mjs
+++ b/plugins/agent-id-browser/lib/access-guard.mjs
@@ -1,0 +1,104 @@
+// Alien Agent ID — Access-level guard for sealed browser sessions.
+//
+// A `browser-profile` record may carry `access: "ro"` (+ optional
+// `accessRules`, see @alien-id/agent-id-vault/lib/access.mjs). The guard makes
+// a read-only session hold at the NETWORK layer, inside the session-server
+// process (the agent only reaches the browser through the session socket's
+// fixed action vocabulary, so it cannot remove the guard):
+//
+//   - every request the page makes is classified by evaluateAccess() —
+//     GET/HEAD/OPTIONS pass; POST-tunneled reads (GraphQL query, JMAP get/
+//     query, JSON-RPC non-submitting) pass; everything else is aborted, so a
+//     click on "Send" fails at the wire even though clicking is allowed;
+//   - service workers are blocked (they would bypass route interception);
+//   - WebSockets are disabled via an init script (frames can't be inspected);
+//   - the un-auditable/secret-bearing actions (`eval`, `fill-secret`,
+//     `fill-otp`) are refused at the action layer (assertActionAllowed).
+//
+// The DOM stays fully interactive (navigate/click/type/scroll) — typing a
+// search query is a read — because the wire, not the widget, is the boundary.
+
+import { effectiveAccess, evaluateAccess } from "@alien-id/agent-id-vault/lib/access.mjs";
+
+// Actions refused on a read-only session. Everything observational or
+// DOM-interactive stays available; mutations die at the network gate.
+const RO_DENIED_ACTIONS = Object.freeze(["eval", "fill-secret", "fill-otp"]);
+
+// Pure — unit-tests without a browser. Throws on a denied action.
+export function assertActionAllowed(rec, action) {
+  if (effectiveAccess(rec) !== "ro") return;
+  if (RO_DENIED_ACTIONS.includes(action)) {
+    throw new Error(
+      `action '${action}' is not available on a read-only session — ` +
+        "the owner can widen it with `agent-id-vault set-access`",
+    );
+  }
+}
+
+// Extra context options for a restricted profile: service workers would
+// answer fetches without touching our route handler, so block them.
+export function contextOptionsForAccess(rec) {
+  return effectiveAccess(rec) === "ro" ? { serviceWorkers: "block" } : {};
+}
+
+// Decide one request. Exported for tests (no browser needed).
+export function guardDecision(rec, { method, url, postData }) {
+  let u;
+  try {
+    u = new URL(url);
+  } catch {
+    return { allowed: false, reason: "bad_url" };
+  }
+  // Non-HTTP(S) schemes (data:, blob:, chrome-extension:) carry no credentialed
+  // side effects upstream; let the browser handle them.
+  if (u.protocol !== "http:" && u.protocol !== "https:") {
+    return { allowed: true, reason: "non_http" };
+  }
+  return evaluateAccess(rec, {
+    method,
+    host: u.hostname,
+    path: u.pathname,
+    body: postData ?? null,
+  });
+}
+
+// Install the network gate on a (patchright) BrowserContext. No-op unless the
+// record is read-only or carries rules. Returns true when a guard is active.
+export async function applyAccessGuard(ctx, rec, { log = () => {} } = {}) {
+  const restricted = effectiveAccess(rec) === "ro" || Array.isArray(rec.accessRules);
+  if (!restricted) return false;
+
+  if (effectiveAccess(rec) === "ro") {
+    // WebSocket frames bypass route interception — deny the channel up front;
+    // sites degrade to HTTP polling, which the gate does inspect.
+    await ctx.addInitScript(() => {
+      try {
+        Object.defineProperty(window, "WebSocket", {
+          value: undefined,
+          writable: false,
+          configurable: false,
+        });
+      } catch {
+        /* already locked down */
+      }
+    });
+  }
+
+  await ctx.route("**/*", async (route) => {
+    const request = route.request();
+    const decision = guardDecision(rec, {
+      method: request.method(),
+      url: request.url(),
+      postData: request.postData(),
+    });
+    if (decision.allowed) {
+      await route.continue();
+      return;
+    }
+    log(
+      `access-guard: blocked ${request.method()} ${request.url().slice(0, 200)} (${decision.reason})`,
+    );
+    await route.abort("accessdenied");
+  });
+  return true;
+}

--- a/plugins/agent-id-browser/lib/access-guard.mjs
+++ b/plugins/agent-id-browser/lib/access-guard.mjs
@@ -18,7 +18,11 @@
 // The DOM stays fully interactive (navigate/click/type/scroll) — typing a
 // search query is a read — because the wire, not the widget, is the boundary.
 
-import { effectiveAccess, evaluateAccess } from "@alien-id/agent-id-vault/lib/access.mjs";
+import {
+  effectiveAccess,
+  evaluateAccess,
+  isAccessRestricted,
+} from "@alien-id/agent-id-vault/lib/access.mjs";
 
 // Actions refused on a read-only session. Everything observational or
 // DOM-interactive stays available; mutations die at the network gate.
@@ -36,9 +40,11 @@ export function assertActionAllowed(rec, action) {
 }
 
 // Extra context options for a restricted profile: service workers would
-// answer fetches without touching our route handler, so block them.
+// answer fetches without touching our route handler, so block them for ANY
+// active guard (ro OR rule-restricted) — a deny rule is otherwise bypassable
+// via a service-worker-replayed fetch.
 export function contextOptionsForAccess(rec) {
-  return effectiveAccess(rec) === "ro" ? { serviceWorkers: "block" } : {};
+  return isAccessRestricted(rec) ? { serviceWorkers: "block" } : {};
 }
 
 // Decide one request. Exported for tests (no browser needed).
@@ -65,24 +71,24 @@ export function guardDecision(rec, { method, url, postData }) {
 // Install the network gate on a (patchright) BrowserContext. No-op unless the
 // record is read-only or carries rules. Returns true when a guard is active.
 export async function applyAccessGuard(ctx, rec, { log = () => {} } = {}) {
-  const restricted = effectiveAccess(rec) === "ro" || Array.isArray(rec.accessRules);
+  const restricted = isAccessRestricted(rec);
   if (!restricted) return false;
 
-  if (effectiveAccess(rec) === "ro") {
-    // WebSocket frames bypass route interception — deny the channel up front;
-    // sites degrade to HTTP polling, which the gate does inspect.
-    await ctx.addInitScript(() => {
-      try {
-        Object.defineProperty(window, "WebSocket", {
-          value: undefined,
-          writable: false,
-          configurable: false,
-        });
-      } catch {
-        /* already locked down */
-      }
-    });
-  }
+  // WebSocket frames bypass route interception — deny the channel up front for
+  // ANY active guard (ro OR rule-restricted); sites degrade to HTTP polling,
+  // which the route gate does inspect. Gating this on `ro` alone would leave a
+  // deny-rule profile writable over a WebSocket.
+  await ctx.addInitScript(() => {
+    try {
+      Object.defineProperty(window, "WebSocket", {
+        value: undefined,
+        writable: false,
+        configurable: false,
+      });
+    } catch {
+      /* already locked down */
+    }
+  });
 
   await ctx.route("**/*", async (route) => {
     const request = route.request();

--- a/plugins/agent-id-browser/lib/access-guard.mjs
+++ b/plugins/agent-id-browser/lib/access-guard.mjs
@@ -74,11 +74,32 @@ export async function applyAccessGuard(ctx, rec, { log = () => {} } = {}) {
   const restricted = isAccessRestricted(rec);
   if (!restricted) return false;
 
-  // WebSocket frames bypass route interception — deny the channel up front for
-  // ANY active guard (ro OR rule-restricted); sites degrade to HTTP polling,
-  // which the route gate does inspect. Gating this on `ro` alone would leave a
-  // deny-rule profile writable over a WebSocket.
+  // WebSocket frames bypass HTTP route interception, so a restricted session
+  // must deny the channel or a page could drive a write over it. Block it at
+  // the NETWORK layer (routeWebSocket, CDP-level) — evasion-proof, unlike a JS
+  // shadow of window.WebSocket which a Web/Shared Worker (self.WebSocket) or a
+  // fresh realm can recover. Feature-detected for older patchright; the
+  // main-world override stays as defense-in-depth / fallback. Sites degrade to
+  // HTTP polling, which the route gate does inspect.
+  if (typeof ctx.routeWebSocket === "function") {
+    try {
+      await ctx.routeWebSocket("**/*", (ws) => {
+        // Neither connectToServer() nor onMessage handlers are attached, so the
+        // upstream socket is never opened; close the client side immediately.
+        try {
+          ws.close();
+        } catch {
+          /* route already resolved */
+        }
+      });
+    } catch {
+      /* routeWebSocket unavailable/removed — the init-script fallback covers it */
+    }
+  }
   await ctx.addInitScript(() => {
+    // Defense in depth (covers any engine/version where routeWebSocket is
+    // absent). Shadow the constructor in the main world AND, best-effort, in
+    // Workers via a patched Worker that prepends the same shadow.
     try {
       Object.defineProperty(window, "WebSocket", {
         value: undefined,

--- a/plugins/agent-id-browser/lib/launch.mjs
+++ b/plugins/agent-id-browser/lib/launch.mjs
@@ -92,7 +92,12 @@ function launchOptions(headless) {
 
 // Launch a persistent context on the given (already-unsealed) profile dir.
 // headless defaults to true; pass false for the one-time headed login.
-export async function launchContext({ profileDir, headless = true }) {
+// `contextOptions` merges extra Playwright context options (e.g. the access
+// guard's serviceWorkers:"block" for read-only profiles).
+export async function launchContext({ profileDir, headless = true, contextOptions = {} }) {
   const chromium = await loadChromium();
-  return chromium.launchPersistentContext(profileDir, launchOptions(headless));
+  return chromium.launchPersistentContext(profileDir, {
+    ...launchOptions(headless),
+    ...contextOptions,
+  });
 }

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -26,6 +26,11 @@ import { sealProfile } from "./profile-store.mjs";
 import { openVault, loadAgentPrivateKey } from "@alien-id/agent-id-vault/lib/vault.mjs";
 import { SECRET_FIELDS, hostMatchesAllowlist } from "@alien-id/agent-id-vault/lib/store.mjs";
 import { resolveOtp } from "./auto-login.mjs";
+import {
+  applyAccessGuard,
+  assertActionAllowed,
+  contextOptionsForAccess,
+} from "./access-guard.mjs";
 
 function sessionsDir(stateDir) {
   return path.join(stateDir, "browser-sessions");
@@ -125,8 +130,12 @@ export function assertFillAllowed(rec, host, field = null) {
   }
 }
 
-async function dispatch(page, msg) {
+async function dispatch(page, msg, policy = null) {
   const p = msg.params || {};
+  // Read-only sessions refuse the un-auditable/secret-bearing actions here;
+  // everything else stays available because the network gate (applyAccessGuard)
+  // is what actually stops mutations from reaching the service.
+  if (policy) assertActionAllowed(policy, msg.action);
   switch (msg.action) {
     case "info":
       return { url: page.url(), title: await page.title().catch(() => "") };
@@ -243,8 +252,27 @@ async function dispatch(page, msg) {
 }
 
 // Launch the session and serve actions until `close` (or a signal). Blocks.
-export async function runSession({ stateDir, name, headless, dekHex, profileFile, workDir }) {
-  const ctx = await launchContext({ profileDir: workDir, headless });
+// `policy` is the profile record's access policy ({access, accessRules}) —
+// enforced HERE, in the process holding the live cookies, not in the client.
+export async function runSession({
+  stateDir,
+  name,
+  headless,
+  dekHex,
+  profileFile,
+  workDir,
+  policy = null,
+}) {
+  const ctx = await launchContext({
+    profileDir: workDir,
+    headless,
+    contextOptions: policy ? contextOptionsForAccess(policy) : {},
+  });
+  if (policy) {
+    await applyAccessGuard(ctx, policy, {
+      log: (m) => process.stderr.write(`${m}\n`),
+    });
+  }
   const page = ctx.pages()[0] || (await ctx.newPage());
 
   // Single, idempotent shutdown: close the browser, RESEAL the refreshed profile,
@@ -281,7 +309,7 @@ export async function runSession({ stateDir, name, headless, dekHex, profileFile
       }
       msg._stateDir = stateDir;
       try {
-        const result = await dispatch(page, msg);
+        const result = await dispatch(page, msg, policy);
         sock.end(JSON.stringify({ ok: true, ...result }) + "\n");
       } catch (err) {
         sock.end(JSON.stringify({ ok: false, error: err.message || String(err) }) + "\n");

--- a/plugins/agent-id-browser/skills/agent-id-browser/SKILL.md
+++ b/plugins/agent-id-browser/skills/agent-id-browser/SKILL.md
@@ -158,6 +158,16 @@ If an action or page request fails with an access/read-only error, that's the
 granted level working — report it to the user instead of looking for another
 route to the same write.
 
+**Two practical notes for `ro` sessions:**
+- Since the gate default-denies any POST it can't prove is a read, a site that
+  loads content via **persisted-query GraphQL** (a hash, not the query text —
+  e.g. Reddit, X) has its reads collateral-blocked too. The server-rendered
+  page (the initial `GET`) reads fine; dynamically-loaded content may not
+  populate. That's the fail-safe tradeoff, not a bug.
+- Bot-hostile sites (Reddit especially) serve a challenge page to a **headless**
+  browser regardless of access level. That's the site, not the vault — drive
+  such a site with `open --headed`, not the one-shot headless `read`.
+
 ## 2) Interactive control (the main loop)
 
 Start a persistent session, then observe → act → observe. **Run `open` in the

--- a/plugins/agent-id-browser/skills/agent-id-browser/SKILL.md
+++ b/plugins/agent-id-browser/skills/agent-id-browser/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-id-browser
-description: Drive a real, logged-in browser whose session is sealed in the agent vault — fine-grained control (click, type, fill forms, press keys, select, hover, navigate, screenshot, run JS) via an accessibility snapshot with element refs, plus one-shot read/fetch. By default all sites share ONE session — sign into Google once and every "Sign in with Google" site reuses it; pass --name only for a separate isolated session. Two ways to log in: a HEADED Chrome login when a desktop browser is available, OR an agent-driven HEADLESS login from a stored `login` credential (auto-login, or snapshot + fill-secret/fill-otp) where the password and any 2FA code are entered over an abstracted secure-entry channel (browser form, mobile app, hosted harness, or CLI) — never via chat, never seen by the agent. Afterwards the agent drives the session HEADLESS. Use for authenticated sites that block API/OAuth/cookie access (e.g. Gmail/Workspace) or any task needing a real logged-in browser — the agent never sees a credential, it drives the browser.
+description: Drive a real, logged-in browser whose session is sealed in the agent vault — fine-grained control (click, type, fill forms, press keys, select, hover, navigate, screenshot, run JS) via an accessibility snapshot with element refs, plus one-shot read/fetch. By default all sites share ONE session — sign into Google once and every "Sign in with Google" site reuses it; pass --name only for a separate isolated session. Two ways to log in: a HEADED Chrome login when a desktop browser is available, OR an agent-driven HEADLESS login from a stored `login` credential (auto-login, or snapshot + fill-secret/fill-otp) where the password and any 2FA code are entered over an abstracted secure-entry channel (browser form, mobile app, hosted harness, or CLI) — never via chat, never seen by the agent. Afterwards the agent drives the session HEADLESS. Sessions can be sealed READ-ONLY (--access ro): the session process blocks write requests at the network layer, so the agent can read mail/feeds/messages but never send, post, or delete. Use for authenticated sites that block API/OAuth/cookie access (e.g. Gmail/Workspace) or any task needing a real logged-in browser — the agent never sees a credential, it drives the browser.
 license: MIT
 metadata:
   author: Alien Wallet
@@ -127,6 +127,36 @@ origin is **refused**, and a sealed in-vault-generated secret can never be typed
 into a page. SSO redirects credential entry to the identity provider, so set
 `domains` to cover it — a wildcard works: `--domains '*.acme.com'` allows
 `idp.acme.com`. The refusal error names the blocked host.
+
+## Read-only sessions (access levels)
+
+A session can be sealed **read-only**: the owner grants "the agent may read my
+mail / feed / messages, never act on them". Pass `--access ro` at login time:
+
+```bash
+CLI login --name gmail-ro --url https://mail.google.com/ --access ro   # headed
+CLI auto-login --cred acme --name acme-ro --access ro                  # headless
+```
+
+Enforcement lives in the **session process**, not in the client: every request
+the page makes is classified — `GET`/`HEAD`/`OPTIONS` and POST-tunneled reads
+(GraphQL `query`, JMAP `*/get`, JSON-RPC reads) pass; **writes are aborted at
+the wire**, so clicking "Send" fails harmlessly. WebSockets and service
+workers are disabled (they would bypass inspection), and `eval`,
+`fill-secret`, `fill-otp` are refused. Everything observational — `navigate`,
+`snapshot`, `click`, `type` (e.g. a search box), `page-text`, `screenshot`,
+`read`, `fetch` — works normally.
+
+Rules of the level:
+- A `login` credential with `access: "ro"` only ever mints ro sessions.
+- Re-`login`/`auto-login` can tighten a session's level, **never widen** it.
+- Widening is the owner's act: `agent-id-vault set-access --name <session> --access rw`
+  (confirmed by the owner on the secure form — don't retry, ask them).
+- `status` shows each session's `access`.
+
+If an action or page request fails with an access/read-only error, that's the
+granted level working — report it to the user instead of looking for another
+route to the same write.
 
 ## 2) Interactive control (the main loop)
 

--- a/plugins/agent-id-proxy/lib/proxy.mjs
+++ b/plugins/agent-id-proxy/lib/proxy.mjs
@@ -45,6 +45,7 @@ import {
   readMobileSlotChallenges,
   readOwnerApprovalChallenge,
 } from "@alien-id/agent-id-vault/lib/vault.mjs";
+import { effectiveAccess, evaluateAccess } from "@alien-id/agent-id-vault/lib/access.mjs";
 import { unsealFromPublicKey } from "@alien-id/agent-id-vault/lib/format.mjs";
 import { fingerprintOfCertPem, generateControlCert } from "./control-tls.mjs";
 import { appendJsonl } from "@alien-id/agent-id-core/lib/state.mjs";
@@ -75,6 +76,11 @@ function stripHopByHop(headers) {
 // is rarely larger; 1 MiB leaves generous headroom for batches while
 // bounding memory.
 const WALLET_MAX_BODY_BYTES = 1024 * 1024;
+
+// Non-read requests on an access-restricted ("ro") credential buffer the body
+// so POST-tunneled reads (GraphQL query / JMAP get / JSON-RPC calls) can be
+// classified before the write-block applies. Same bound as wallet bodies.
+const ACCESS_MAX_BODY_BYTES = 1024 * 1024;
 
 function readRequestBody(req, maxBytes) {
   return new Promise((resolve, reject) => {
@@ -653,6 +659,52 @@ export function createProxy({
     // First use of this (credential, host) pair? Ask for human consent.
     await requireGrant(cred.name, parsed.host);
 
+    // ── Access-level gate ────────────────────────────────────────────────────
+    // A restricted credential (access:"ro" and/or accessRules) is checked
+    // against method + host + pathname first; when only the body can decide
+    // (a POST that might be a tunneled read), buffer it and re-evaluate.
+    const bareHost = parsed.host.includes(":")
+      ? parsed.host.slice(0, parsed.host.indexOf(":"))
+      : parsed.host;
+    const reqPathname = parsed.restAndQuery.split("?")[0];
+    let accessBody = null; // set when the gate had to consume the request stream
+    let decision = evaluateAccess(cred, {
+      method: req.method,
+      host: bareHost,
+      path: reqPathname,
+    });
+    if (!decision.allowed && decision.needsBody) {
+      accessBody = await readRequestBody(req, ACCESS_MAX_BODY_BYTES);
+      decision = evaluateAccess(cred, {
+        method: req.method,
+        host: bareHost,
+        path: reqPathname,
+        body: accessBody.toString("utf8"),
+      });
+    }
+    if (!decision.allowed) {
+      logAccess({
+        event: "access_denied",
+        credential: cred.name,
+        host: parsed.host,
+        method: req.method,
+        path: reqPathname,
+        access: effectiveAccess(cred),
+        reason: decision.reason,
+      });
+      return structuredError(res, 403, {
+        error: "access_denied",
+        message:
+          `credential '${cred.name}' has access level '${effectiveAccess(cred)}' — ` +
+          `${req.method} ${reqPathname} on ${parsed.host} is not permitted (${decision.reason}). ` +
+          "Only the owner can raise it: `agent-id-vault set-access` (human-confirmed).",
+        credential: cred.name,
+        host: parsed.host,
+        access: effectiveAccess(cred),
+        reason: decision.reason,
+      });
+    }
+
     // oauth2 credentials refresh an access token here, then inject as a bearer.
     // Refresh failures throw an error carrying an HTTP status (mapped by the
     // top-level handler), so they short-circuit before we touch the upstream.
@@ -669,7 +721,7 @@ export function createProxy({
     // signature / tx hash that lands on chain anyway.
     let bodyOverride = null;
     if (cred.type === "solana-keypair" || cred.type === "evm-keypair") {
-      const raw = await readRequestBody(req, WALLET_MAX_BODY_BYTES);
+      const raw = accessBody ?? (await readRequestBody(req, WALLET_MAX_BODY_BYTES));
       if (raw.length > 0) {
         let result;
         let event;
@@ -700,6 +752,9 @@ export function createProxy({
       } else {
         bodyOverride = raw; // bodyless request (e.g. GET) — stream already consumed
       }
+    } else if (accessBody != null) {
+      // The access gate consumed the stream; forward what it buffered.
+      bodyOverride = accessBody;
     }
 
     // Build upstream URL (default https; credential may opt into http).
@@ -767,6 +822,42 @@ export function createProxy({
       credentialsUsed = credentialsUsed.concat(headerRewrite.used);
     } catch (err) {
       return handleStubError(res, err);
+    }
+
+    // Access-level gate (method/host/path only — legacy stub mode does not
+    // classify bodies, so a non-read method on an "ro" credential is denied
+    // unless an accessRule explicitly allows it; use URL-rewrite mode for
+    // POST-tunneled reads).
+    for (const u of credentialsUsed) {
+      const rec = lookup(u.name);
+      if (!rec) continue; // already resolved by the rewrite step
+      const decision = evaluateAccess(rec, {
+        method: req.method,
+        host: parsed.hostname,
+        path: parsed.pathname,
+        body: null,
+      });
+      if (!decision.allowed) {
+        logAccess({
+          event: "access_denied",
+          credential: u.name,
+          host: parsed.hostname,
+          method: req.method,
+          path: parsed.pathname,
+          access: effectiveAccess(rec),
+          reason: decision.reason,
+        });
+        return structuredError(res, 403, {
+          error: "access_denied",
+          message:
+            `credential '${u.name}' has access level '${effectiveAccess(rec)}' — ` +
+            `${req.method} ${parsed.pathname} on ${parsed.hostname} is not permitted (${decision.reason}).`,
+          credential: u.name,
+          host: parsed.hostname,
+          access: effectiveAccess(rec),
+          reason: decision.reason,
+        });
+      }
     }
 
     if (state.vault) {

--- a/plugins/agent-id-proxy/lib/proxy.mjs
+++ b/plugins/agent-id-proxy/lib/proxy.mjs
@@ -109,6 +109,12 @@ function structuredError(res, status, body) {
     "Content-Type": "application/json; charset=utf-8",
     "Content-Length": Buffer.byteLength(payload),
     "X-AgentVault-Proxy-Error": body.error || "unknown",
+    // These errors are returned BEFORE the request body is consumed (bad host,
+    // access denied, locked, …). On a keep-alive connection Node would parse
+    // the unread body as a pipelined request and reject it with a spurious 400,
+    // masking our status. Closing the connection discards the leftover body so
+    // the client sees this response cleanly.
+    Connection: "close",
   });
   res.end(payload);
 }
@@ -683,6 +689,9 @@ export function createProxy({
       });
     }
     if (!decision.allowed) {
+      // Drain any unconsumed request body (a write's payload) so the HTTP
+      // framing stays clean before we send the denial on this connection.
+      if (accessBody == null) req.resume();
       logAccess({
         event: "access_denied",
         credential: cred.name,

--- a/plugins/agent-id-proxy/skills/agent-id-proxy/SKILL.md
+++ b/plugins/agent-id-proxy/skills/agent-id-proxy/SKILL.md
@@ -89,6 +89,23 @@ The credential is materialized into the request based on its type:
 
 Upstream scheme defaults to **HTTPS**. Set `upstreamScheme: "http"` on the credential to opt into plain HTTP (legacy/internal services). The proxy rewrites the `Host` header and strips `Origin` / `Referer` before forwarding.
 
+## Access levels (read-only credentials)
+
+A credential added with `--access ro` (see the vault skill) is enforced here on
+every request: `GET`/`HEAD`/`OPTIONS` pass; a `POST`/`PUT`/`PATCH`/`DELETE` is
+allowed only if the credential's `accessRules` allow it or the body classifies
+as a tunneled read (GraphQL `query`, JMAP `*/get`/`*/query`, JSON-RPC calls
+that don't submit transactions — so `getBalance` works on a ro wallet but
+`sendTransaction` doesn't). Anything else:
+
+```json
+{ "ok": false, "error": "access_denied", "credential": "mail-ro", "access": "ro", "reason": "write_blocked" }
+```
+
+Don't retry a `403 access_denied` — the level is the owner's decision. Ask the
+owner to widen it (`agent-id-vault set-access`, human-confirmed). Denials are
+logged as `access_denied` events.
+
 ## Wallet credentials — transaction signing in the proxy
 
 `solana-keypair` / `evm-keypair` credentials (created with
@@ -170,6 +187,7 @@ node CLI start --idle-timeout never     # disable (unattended agents)
 { "ok": false, "error": "credential_not_found", "credential": "github-pat" }
 { "ok": false, "error": "host_not_allowed", "credential": "github-pat", "host": "evil.example.com", "allowed": ["*.github.com"] }
 { "ok": false, "error": "vault_locked", "reason": "idle_timeout" }
+{ "ok": false, "error": "access_denied", "credential": "mail-ro", "access": "ro", "reason": "write_blocked" }
 { "ok": false, "error": "bad_request", "message": "..." }
 ```
 
@@ -182,8 +200,11 @@ node CLI status
 node CLI stop
 ```
 
-## v1 limitations
+## Limitations
 
 - **HTTPS only at the upstream leg** in URL-rewrite mode. The agent-to-proxy leg is plain HTTP loopback by design.
-- **No consent prompt.** Host allowlist is the only authorization gate in v1.
-- **No in-process re-unlock.** Restart the proxy to re-unlock after idle lock.
+- Authorization gates: per-credential **host allowlist**, **access level**
+  (`ro`/`rw` + rules), and — when started with `--require-consent` — a
+  per-(credential, host) human consent grant.
+- Stub-injection mode (legacy) enforces access levels by method/host/path only
+  — POST-tunneled reads are not classified there; use URL-rewrite mode.

--- a/plugins/agent-id-proxy/skills/agent-id-proxy/SKILL.md
+++ b/plugins/agent-id-proxy/skills/agent-id-proxy/SKILL.md
@@ -106,6 +106,13 @@ Don't retry a `403 access_denied` — the level is the owner's decision. Ask the
 owner to widen it (`agent-id-vault set-access`, human-confirmed). Denials are
 logged as `access_denied` events.
 
+Classification needs the operation to be visible in the request. A POST whose
+body doesn't reveal a read — a **persisted-query** GraphQL (hash only, no query
+text), opaque binary RPC (gRPC-web/Connect), or an unknown JSON-RPC method —
+fails safe: it's denied, not allowed. So `ro` works cleanly on REST-with-verbs,
+inline GraphQL, JMAP, and known JSON-RPC, and over-blocks (reads too) on
+hash-only endpoints. See the vault skill's "Where `ro` works" table.
+
 ## Wallet credentials — transaction signing in the proxy
 
 `solana-keypair` / `evm-keypair` credentials (created with

--- a/plugins/agent-id-proxy/skills/agent-id-proxy/SKILL.md
+++ b/plugins/agent-id-proxy/skills/agent-id-proxy/SKILL.md
@@ -94,9 +94,10 @@ Upstream scheme defaults to **HTTPS**. Set `upstreamScheme: "http"` on the crede
 A credential added with `--access ro` (see the vault skill) is enforced here on
 every request: `GET`/`HEAD`/`OPTIONS` pass; a `POST`/`PUT`/`PATCH`/`DELETE` is
 allowed only if the credential's `accessRules` allow it or the body classifies
-as a tunneled read (GraphQL `query`, JMAP `*/get`/`*/query`, JSON-RPC calls
-that don't submit transactions — so `getBalance` works on a ro wallet but
-`sendTransaction` doesn't). Anything else:
+as a tunneled read (an inline GraphQL `query`, a JMAP `*/get`/`*/query`, or a
+JSON-RPC method on the recognized-read allowlist such as `eth_call`/`getBalance`).
+It is default-deny: a submitting method like `sendTransaction`, and any
+unrecognized method, are blocked. Anything else:
 
 ```json
 { "ok": false, "error": "access_denied", "credential": "mail-ro", "access": "ro", "reason": "write_blocked" }

--- a/plugins/agent-id-vault/bin/cli.mjs
+++ b/plugins/agent-id-vault/bin/cli.mjs
@@ -70,7 +70,8 @@ import {
   promptSecret,
   TrustedInputUnavailable,
 } from "../lib/trusted-input.mjs";
-import { CREDENTIAL_TYPES, SECRET_FIELDS } from "../lib/store.mjs";
+import { CREDENTIAL_TYPES, SECRET_FIELDS, validateRecord } from "../lib/store.mjs";
+import { ACCESS_LEVELS, effectiveAccess, isAccessRelaxation } from "../lib/access.mjs";
 import { collectSecret } from "@alien-id/agent-id-core/lib/secure-prompt.mjs";
 import { normalizeTotpInput } from "@alien-id/agent-id-core/lib/totp.mjs";
 import { generateSolanaKeypair } from "@alien-id/agent-id-core/lib/solana.mjs";
@@ -298,6 +299,10 @@ async function cmdAdd(flags) {
   if (!CREDENTIAL_TYPES.includes(type)) {
     return outputError(`Unknown type: ${type}. Allowed: ${CREDENTIAL_TYPES.join(", ")}`);
   }
+  const access = flags.access != null ? String(flags.access) : null;
+  if (access && !ACCESS_LEVELS.includes(access)) {
+    return outputError(`--access must be one of ${ACCESS_LEVELS.join(", ")}`);
+  }
   let domains = parseDomains(flags);
   if (domains.length === 0) {
     // `secret` is not host-scoped (it's used via exec/file, not the HTTP proxy),
@@ -339,7 +344,9 @@ async function cmdAdd(flags) {
       // /dev/tty → hosted harness), so this works where no GUI browser is present.
       const out = await collectSecret({
         title: `Add credential: ${name}`,
-        description: `${type} · ${domains.join(", ")}`,
+        // Show the access level so the human sees the grant they are making
+        // while typing the secret ("ro" = the agent can read, never write).
+        description: `${type} · ${domains.join(", ")}${access === "ro" ? " · access: READ-ONLY" : ""}`,
         fields: specs,
         label: `enter the "${name}" secret`,
         security:
@@ -363,6 +370,22 @@ async function cmdAdd(flags) {
     const record = { name, type, domains, description: flags.description || null };
     if (flags["upstream-scheme"] != null) {
       record.upstreamScheme = String(flags["upstream-scheme"]);
+    }
+    if (access) record.access = access;
+
+    // Upserting must never silently widen access: preserve the stored policy
+    // when no --access flag is given, and refuse a widening flag — only
+    // `set-access` (owner-confirmed) may relax.
+    const existing = vault.get(name);
+    if (existing) {
+      if (!access && existing.access != null) record.access = existing.access;
+      if (existing.accessRules != null) record.accessRules = existing.accessRules;
+      if (isAccessRelaxation(existing, record)) {
+        return outputError(
+          `Credential '${name}' has access level '${effectiveAccess(existing)}' — re-adding it ` +
+            `with '${access}' would widen what the agent may do. Use \`set-access\` (owner-confirmed).`,
+        );
+      }
     }
 
     switch (type) {
@@ -491,12 +514,16 @@ async function cmdAdd(flags) {
 
     const stored = vault.add(record);
     await vault.save();
-    stderr(`Added credential '${name}' (${type}) for ${domains.join(", ")}.`);
+    stderr(
+      `Added credential '${name}' (${type}) for ${domains.join(", ")}` +
+        `${stored.access ? ` — access: ${stored.access}` : ""}.`,
+    );
     outputJson({
       ok: true,
       name: stored.name,
       type: stored.type,
       domains: stored.domains,
+      access: effectiveAccess(stored),
       createdAt: stored.createdAt,
       updatedAt: stored.updatedAt,
     });
@@ -572,14 +599,23 @@ async function cmdShow(flags) {
   try {
     const rec = vault.get(name);
     if (!rec) return outputError(`No credential named '${name}'`);
-    if (rec.exportable === false) {
+    // Two sealing reasons: in-vault-generated secrets never export, and an
+    // access-restricted ("ro") credential's plaintext must not reach the agent
+    // — otherwise the proxy/browser read-only enforcement would be theater.
+    const sealedWhy =
+      rec.exportable === false
+        ? "generated in-vault, not exportable"
+        : effectiveAccess(rec) === "ro"
+          ? "access level 'ro' — enforced via the proxy/browser only"
+          : null;
+    if (sealedWhy) {
       const redacted = { ...rec };
       for (const f of SECRET_FIELDS) {
-        if (redacted[f] != null) redacted[f] = "[sealed — generated in-vault, not exportable]";
+        if (redacted[f] != null) redacted[f] = `[sealed — ${sealedWhy}]`;
       }
       stderr(
-        `Credential '${name}' was generated inside the vault; its secret is sealed ` +
-          "and cannot be exported. Use the proxy to exercise it.",
+        `Credential '${name}' is sealed (${sealedWhy}). ` +
+          "Use the proxy or the sealed browser to exercise it.",
       );
       outputJson({ ok: true, credential: redacted, sealed: true });
       return;
@@ -608,6 +644,11 @@ async function cmdGenerate(flags) {
     );
   }
 
+  const access = flags.access != null ? String(flags.access) : null;
+  if (access && !ACCESS_LEVELS.includes(access)) {
+    return outputError(`--access must be one of ${ACCESS_LEVELS.join(", ")}`);
+  }
+
   const vault = await openWithFlags(flags);
   try {
     if (vault.has(name) && !flags.overwrite) {
@@ -620,6 +661,19 @@ async function cmdGenerate(flags) {
       description: flags.description || null,
       exportable: false,
     };
+    if (access) record.access = access;
+    // Overwriting must not silently widen access (same rule as `add`).
+    const existing = vault.get(name);
+    if (existing) {
+      if (!access && existing.access != null) record.access = existing.access;
+      if (existing.accessRules != null) record.accessRules = existing.accessRules;
+      if (isAccessRelaxation(existing, record)) {
+        return outputError(
+          `Credential '${name}' has access level '${effectiveAccess(existing)}' — ` +
+            "overwriting cannot widen it. Use `set-access` (owner-confirmed).",
+        );
+      }
+    }
     let address;
     if (type === "solana-keypair") {
       const { publicKey, secretSeedHex } = generateSolanaKeypair();
@@ -654,6 +708,104 @@ async function cmdGenerate(flags) {
       domains: stored.domains,
       exportable: false,
       createdAt: stored.createdAt,
+    });
+  } finally {
+    vault.lock();
+  }
+}
+
+// ─── set-access: change a credential's access level / rules ────────────────────
+//
+// TIGHTENING (rw→ro, adding deny rules, dropping allow rules) applies
+// immediately — an agent may always give capabilities up. RELAXING (ro→rw,
+// adding allow rules, dropping deny rules) asks the OWNER to confirm
+// out-of-band via the secure prompt (they type the credential name), so an
+// agent cannot self-upgrade what its credentials permit.
+
+function describeAccess(rec) {
+  const rules = Array.isArray(rec.accessRules) ? ` + ${rec.accessRules.length} rule(s)` : "";
+  return `${effectiveAccess(rec)}${rules}`;
+}
+
+async function cmdSetAccess(flags) {
+  const name = flags.name;
+  if (!name) return outputError("--name <NAME> is required");
+  const wantLevel = flags.access != null ? String(flags.access) : null;
+  if (wantLevel && !ACCESS_LEVELS.includes(wantLevel)) {
+    return outputError(`--access must be one of ${ACCESS_LEVELS.join(", ")}`);
+  }
+  let wantRules; // undefined = leave untouched; null = clear; array = replace
+  if (flags["clear-rules"] === true) {
+    wantRules = null;
+  } else if (flags.rules != null) {
+    try {
+      wantRules = JSON.parse(String(flags.rules));
+    } catch (err) {
+      return outputError(`--rules must be a JSON array: ${err.message}`);
+    }
+  }
+  if (wantLevel == null && wantRules === undefined) {
+    return outputError(
+      "Nothing to change — pass --access ro|rw and/or --rules '<JSON array>' / --clear-rules",
+    );
+  }
+
+  const vault = await openWithFlags(flags);
+  try {
+    const rec = vault.get(name);
+    if (!rec) return outputError(`No credential named '${name}'`);
+
+    const after = { ...rec };
+    if (wantLevel != null) after.access = wantLevel;
+    if (wantRules !== undefined) {
+      if (wantRules == null) delete after.accessRules;
+      else after.accessRules = wantRules;
+    }
+    try {
+      validateRecord(after); // fail fast, before any owner ceremony
+    } catch (err) {
+      return outputError(err.message);
+    }
+
+    if (isAccessRelaxation(rec, after)) {
+      stderr(
+        `Widening access on '${name}' (${describeAccess(rec)} → ${describeAccess(after)}) ` +
+          "needs the owner's out-of-band confirmation…",
+      );
+      let values;
+      try {
+        ({ values } = await collectSecret({
+          title: `Allow MORE access: ${name}`,
+          description:
+            `The agent asks to widen what '${name}' may do: ` +
+            `${describeAccess(rec)} → ${describeAccess(after)}. ` +
+            "Approve only if YOU intend this.",
+          fields: [
+            {
+              name: "confirm",
+              label: `Type the credential name (${name}) to approve`,
+              secret: false,
+            },
+          ],
+          label: `approve wider access for "${name}"`,
+          security: "Typed by you, out of the agent's sight. Mismatch = no change.",
+        }));
+      } catch (err) {
+        return outputError(`owner confirmation: ${err.message}`);
+      }
+      if (String(values.confirm || "").trim() !== name) {
+        return outputError("owner confirmation did not match the credential name — access unchanged");
+      }
+    }
+
+    vault.add(after);
+    await vault.save();
+    stderr(`Access on '${name}' is now: ${describeAccess(after)}.`);
+    outputJson({
+      ok: true,
+      name,
+      access: effectiveAccess(after),
+      accessRules: after.accessRules ?? null,
     });
   } finally {
     vault.lock();
@@ -981,6 +1133,15 @@ async function cmdExec() {
             `'${s.field}' cannot leave the vault. Use the proxy to exercise it.`,
         );
       }
+      // An access-restricted credential handed raw to a child process would
+      // bypass the proxy/browser read-only gate — refuse, same as sealed.
+      if (effectiveAccess(rec) === "ro" && SECRET_FIELDS.includes(s.field)) {
+        return outputError(
+          `Credential '${s.credName}' has access level 'ro'; field '${s.field}' cannot be ` +
+            "exported to a child process (that would bypass read-only enforcement). " +
+            "Use the proxy/browser, or ask the owner to run `set-access --access rw`.",
+        );
+      }
       const value = rec[s.field];
       if (typeof value !== "string" || value.length === 0) {
         return outputError(`Credential '${s.credName}' has no usable string field '${s.field}'`);
@@ -1062,9 +1223,13 @@ function printHelp() {
       "       --unlock passphrase  typed into the secure form (dev mode)",
       "       default (no --unlock) = USER mode, agent-key auto-unlock.",
       "       passkey/passphrase default to NO agent-key slot; add --agent-key to keep one.",
-      "  add --name N --type T --domains H[,H…] [type-specific value flags]",
+      "  add --name N --type T --domains H[,H…] [--access ro|rw] [type-specific value flags]",
       "      --form   enter the secret out-of-band via the secure prompt (browser",
       "               form → /dev/tty → hosted harness); else --<field>-file/-env/stdin",
+      "      --access ro   read-only: the proxy/browser allow only read-shaped",
+      "               requests (GET/HEAD/OPTIONS + POST-tunneled reads: GraphQL",
+      "               query, JMAP get/query, JSON-RPC non-submitting); show/exec",
+      "               refuse the plaintext. Default rw (unrestricted).",
       "      oauth2: --token-endpoint URL --client-id ID [--client-secret-env V]",
       "              --refresh-token-file F [--scope S]   (auto-refreshes access tokens)",
       "      login:  --login-url URL [--otp none|totp|interactive] [--profile NAME]",
@@ -1073,6 +1238,11 @@ function printHelp() {
       "  set-totp --name N [--form]   attach/update a 2FA seed on a login|totp cred",
       "              accepts a base32 secret or an otpauth:// URI (use when 2FA is",
       "              enabled after the login was stored); else --seed-file/-env/stdin",
+      "  set-access --name N [--access ro|rw] [--rules '<JSON>' | --clear-rules]",
+      "              change a credential's access level. Tightening applies at",
+      "              once; WIDENING requires the owner to confirm via the secure",
+      "              prompt (the agent cannot self-upgrade). Rules: JSON array of",
+      '              {"effect":"allow|deny","methods":[..],"hosts":[..],"path":"/glob*"}',
       "  generate --name N --type solana-keypair|evm-keypair --domains H[,H…] [--overwrite]",
       "      creates the keypair inside the vault; prints ONLY the public address",
       "      evm:    [--chain-id-allowlist 1,137] [--to-allowlist 0x..,0x..]",
@@ -1114,6 +1284,7 @@ const commands = {
   init: cmdInit,
   add: cmdAdd,
   "set-totp": cmdSetTotp,
+  "set-access": cmdSetAccess,
   generate: cmdGenerate,
   show: cmdShow,
   list: cmdList,

--- a/plugins/agent-id-vault/bin/cli.mjs
+++ b/plugins/agent-id-vault/bin/cli.mjs
@@ -71,7 +71,12 @@ import {
   TrustedInputUnavailable,
 } from "../lib/trusted-input.mjs";
 import { CREDENTIAL_TYPES, SECRET_FIELDS, validateRecord } from "../lib/store.mjs";
-import { ACCESS_LEVELS, effectiveAccess, isAccessRelaxation } from "../lib/access.mjs";
+import {
+  ACCESS_LEVELS,
+  effectiveAccess,
+  isAccessRelaxation,
+  isAccessRestricted,
+} from "../lib/access.mjs";
 import { collectSecret } from "@alien-id/agent-id-core/lib/secure-prompt.mjs";
 import { normalizeTotpInput } from "@alien-id/agent-id-core/lib/totp.mjs";
 import { generateSolanaKeypair } from "@alien-id/agent-id-core/lib/solana.mjs";
@@ -605,8 +610,8 @@ async function cmdShow(flags) {
     const sealedWhy =
       rec.exportable === false
         ? "generated in-vault, not exportable"
-        : effectiveAccess(rec) === "ro"
-          ? "access level 'ro' — enforced via the proxy/browser only"
+        : isAccessRestricted(rec)
+          ? `access-restricted (${describeAccess(rec)}) — enforced via the proxy/browser only`
           : null;
     if (sealedWhy) {
       const redacted = { ...rec };
@@ -1133,13 +1138,15 @@ async function cmdExec() {
             `'${s.field}' cannot leave the vault. Use the proxy to exercise it.`,
         );
       }
-      // An access-restricted credential handed raw to a child process would
-      // bypass the proxy/browser read-only gate — refuse, same as sealed.
-      if (effectiveAccess(rec) === "ro" && SECRET_FIELDS.includes(s.field)) {
+      // An access-restricted credential (ro, OR rw with deny rules) handed raw
+      // to a child process would bypass the proxy/browser gate — refuse, same
+      // as sealed. Rule-only restrictions count: the rules are enforced at the
+      // proxy, so leaking the plaintext would make them theater.
+      if (isAccessRestricted(rec) && SECRET_FIELDS.includes(s.field)) {
         return outputError(
-          `Credential '${s.credName}' has access level 'ro'; field '${s.field}' cannot be ` +
-            "exported to a child process (that would bypass read-only enforcement). " +
-            "Use the proxy/browser, or ask the owner to run `set-access --access rw`.",
+          `Credential '${s.credName}' is access-restricted (${describeAccess(rec)}); field ` +
+            `'${s.field}' cannot be exported to a child process (that would bypass enforcement). ` +
+            "Use the proxy/browser, or ask the owner to run `set-access --access rw` (and clear rules).",
         );
       }
       const value = rec[s.field];

--- a/plugins/agent-id-vault/lib/access.mjs
+++ b/plugins/agent-id-vault/lib/access.mjs
@@ -64,6 +64,14 @@ export function effectiveAccess(rec) {
   return rec && rec.access != null ? rec.access : "rw";
 }
 
+// Is this credential restricted in ANY way (level or rules)? A rule-only
+// restriction (access:"rw" + a deny rule) still means the proxy/browser gate
+// the credential, so its plaintext must be sealed and the browser's
+// route-bypass channels closed — otherwise the rule is theater.
+export function isAccessRestricted(rec) {
+  return effectiveAccess(rec) === "ro" || Array.isArray(rec && rec.accessRules);
+}
+
 // ─── Validation (called from store.mjs validateRecord) ────────────────────────
 
 export function validateAccessFields(rec) {
@@ -136,15 +144,45 @@ function ruleMatches(rule, { method, host, path }) {
 
 const JMAP_READ_METHOD_RE = /\/(get|query|queryChanges|changes|echo|parse)$/;
 
-// JSON-RPC calls that submit/sign state changes (EVM + Solana vocabularies).
+// JSON-RPC is default-DENY: a method is a read ONLY if it matches a known
+// read-shaped vocabulary; anything unrecognized is "unknown" → blocked under
+// ro (matching the GraphQL/JMAP classifiers). This inverts an earlier
+// denylist that treated every non-EVM/Solana-write method as a read, so a
+// generic `deleteUser` / Bitcoin `sendtoaddress` / `wallet_sendCalls` no
+// longer slips through as a read.
+const JSONRPC_READ_RE =
+  /^(eth_(get\w+|call|blockNumber|chainId|gasPrice|estimateGas|feeHistory|maxPriorityFeePerGas|accounts|syncing|protocolVersion)|net_\w+|web3_\w+|get[A-Z]\w*|simulate\w+|isBlockhashValid|getHealth)$/;
+// Explicit writes (kept for clarity / defense in depth; unknown is already denied).
 const JSONRPC_WRITE_RE =
-  /^(eth_send|eth_sign|personal_|sendTransaction$|signTransaction$|signAllTransactions$|requestAirdrop$)/;
+  /^(eth_send|eth_sign|personal_|wallet_send|sendTransaction$|sendRawTransaction$|signTransaction$|signAllTransactions$|requestAirdrop$)/;
+
+// GraphQL operation-definition keyword at the start of a line (after stripping
+// leading commas/whitespace). Used to detect ANY mutation/subscription in a
+// multi-operation document — a request can name a later operation via
+// `operationName`, so the leading keyword alone is not trustworthy.
+const GQL_OP_RE = /(^|[\s,{}])(query|mutation|subscription)\b/g;
 
 function classifyGraphql(doc) {
-  // { query: "query { … }" } or "{ … }" (shorthand query). Mutations and
-  // subscriptions are writes. Operation type is the first keyword.
-  const q = String(doc.query).trimStart();
-  return /^(query\b|\{)/.test(q) ? "read" : "write";
+  // { query: "query { … }" } or "{ … }" (shorthand query). A document is a read
+  // ONLY if it contains no mutation/subscription operation anywhere — otherwise
+  // `operationName` could select a write even when the text starts with `query`.
+  // Strip line comments first (a `#`-comment could otherwise hide a keyword or
+  // fake a leading one). Shorthand `{ … }` with no keyword is an anonymous query.
+  const raw = String(doc.query || "");
+  const stripped = raw.replace(/#[^\n\r]*/g, "");
+  let sawWrite = false;
+  let sawQuery = false;
+  let m;
+  GQL_OP_RE.lastIndex = 0;
+  while ((m = GQL_OP_RE.exec(stripped)) !== null) {
+    if (m[2] === "query") sawQuery = true;
+    else sawWrite = true;
+  }
+  if (sawWrite) return "write";
+  if (sawQuery) return "read";
+  // No operation keyword at all: a bare `{ … }` shorthand query is a read;
+  // anything else (empty / unparseable) is unknown → blocked under ro.
+  return /^\s*\{/.test(stripped) ? "read" : "unknown";
 }
 
 function classifyOne(obj) {
@@ -158,7 +196,9 @@ function classifyOne(obj) {
     return allRead ? "read" : "write";
   }
   if (typeof obj.method === "string" && (obj.jsonrpc != null || obj.id !== undefined)) {
-    return JSONRPC_WRITE_RE.test(obj.method) ? "write" : "read";
+    if (JSONRPC_WRITE_RE.test(obj.method)) return "write";
+    if (JSONRPC_READ_RE.test(obj.method)) return "read";
+    return "unknown"; // default-deny: unrecognized RPC method is not a proven read
   }
   return "unknown";
 }
@@ -195,9 +235,16 @@ export function classifyBodyRead(body) {
  *
  * `path` is the pathname only (no query string). `body` is the UTF-8 request
  * body, or undefined when the caller has not buffered it. When the decision
- * would require the body to classify (a non-read method under "ro" with no
- * matching rule), the result carries `needsBody: true` and `allowed: false`;
- * the caller may buffer the body and re-evaluate.
+ * would require the body to classify (a POST that might be a tunneled read
+ * under "ro" with no matching rule), the result carries `needsBody: true` and
+ * `allowed: false`; the caller may buffer the body and re-evaluate.
+ *
+ * NOTE on `ro`: GET/HEAD/OPTIONS are treated as reads per the HTTP safe-method
+ * contract (RFC 9110 §9.2.1) — `ro` does NOT defend against a server that
+ * mutates on GET (unsubscribe/`?action=delete` links); constrain those with an
+ * explicit deny accessRule if needed. Body classification runs ONLY for POST —
+ * the sole method the read-through-POST protocols (GraphQL/JMAP/JSON-RPC) use —
+ * so a read-shaped body can never promote a PUT/PATCH/DELETE to allowed.
  */
 export function evaluateAccess(rec, { method, host, path, body }) {
   const m = String(method || "GET").toUpperCase();
@@ -216,6 +263,10 @@ export function evaluateAccess(rec, { method, host, path, body }) {
   if (effectiveAccess(rec) === "rw") return { allowed: true, reason: "level_rw" };
 
   if (READ_METHODS.includes(m)) return { allowed: true, reason: "read_method" };
+
+  // Every non-read method other than POST is a write under "ro" — its body is
+  // never consulted, so a read-shaped payload can't unlock a DELETE/PUT/PATCH.
+  if (m !== "POST") return { allowed: false, reason: "write_blocked" };
 
   if (body === undefined) {
     return { allowed: false, reason: "write_blocked", needsBody: true };
@@ -243,10 +294,21 @@ function ruleSet(rec, effect) {
   );
 }
 
+// Ordered, effect-qualified key list — position matters because evaluateAccess
+// is first-match-wins.
+function orderedRuleKeys(rec) {
+  return (Array.isArray(rec.accessRules) ? rec.accessRules : []).map((r) =>
+    JSON.stringify({ effect: r.effect, methods: r.methods, hosts: r.hosts, path: r.path }),
+  );
+}
+
 /**
  * Does `after` grant anything `before` did not? True when the level widens
- * (ro→rw), an allow rule appears that wasn't there, or a deny rule disappears.
- * Tightening (rw→ro, adding deny rules, dropping allow rules) is false.
+ * (ro→rw), an allow rule appears that wasn't there, a deny rule disappears, OR
+ * the relative order of rules common to both changes — because evaluateAccess
+ * is first-match-wins, moving an allow ahead of an overlapping deny widens
+ * access even when the rule SET is unchanged. Pure tightening (rw→ro, adding
+ * deny rules, dropping allow rules, no reorder) is false.
  */
 export function isAccessRelaxation(before, after) {
   if (ACCESS_RANK[effectiveAccess(after)] > ACCESS_RANK[effectiveAccess(before)]) return true;
@@ -257,6 +319,17 @@ export function isAccessRelaxation(before, after) {
   const afterDeny = ruleSet(after, "deny");
   for (const r of ruleSet(before, "deny")) {
     if (!afterDeny.has(r)) return true;
+  }
+  // Order sensitivity: compare the relative order of rules present in both. A
+  // swap (allow moved before a deny it previously lost to) flips precedence.
+  const beforeKeys = orderedRuleKeys(before);
+  const afterKeys = orderedRuleKeys(after);
+  const beforeSet = new Set(beforeKeys);
+  const afterSet = new Set(afterKeys);
+  const bCommon = beforeKeys.filter((k) => afterSet.has(k));
+  const aCommon = afterKeys.filter((k) => beforeSet.has(k));
+  for (let i = 0; i < bCommon.length; i++) {
+    if (bCommon[i] !== aCommon[i]) return true;
   }
   return false;
 }

--- a/plugins/agent-id-vault/lib/access.mjs
+++ b/plugins/agent-id-vault/lib/access.mjs
@@ -189,7 +189,9 @@ function classifyOne(obj) {
   if (!obj || typeof obj !== "object") return "unknown";
   if (typeof obj.query === "string") return classifyGraphql(obj);
   if (Array.isArray(obj.methodCalls)) {
-    // JMAP request: every invocation must be a read method.
+    // JMAP request: every invocation must be a read method. An empty batch is a
+    // no-op — classify as unknown (blocked under ro) rather than vacuously read.
+    if (obj.methodCalls.length === 0) return "unknown";
     const allRead = obj.methodCalls.every(
       (c) => Array.isArray(c) && typeof c[0] === "string" && JMAP_READ_METHOD_RE.test(c[0]),
     );
@@ -294,21 +296,40 @@ function ruleSet(rec, effect) {
   );
 }
 
-// Ordered, effect-qualified key list — position matters because evaluateAccess
-// is first-match-wins.
-function orderedRuleKeys(rec) {
-  return (Array.isArray(rec.accessRules) ? rec.accessRules : []).map((r) =>
-    JSON.stringify({ effect: r.effect, methods: r.methods, hosts: r.hosts, path: r.path }),
+// Effect-qualified key for a rule (position handled separately). Two rules with
+// the same {effect, methods, hosts, path} are interchangeable.
+function ruleKey(r) {
+  return JSON.stringify({ effect: r.effect, methods: r.methods, hosts: r.hosts, path: r.path });
+}
+
+// Do two rules overlap — i.e. could some request match BOTH? If so, their
+// relative order decides the outcome (first-match-wins). Conservative: a null
+// dimension means "matches anything" on that axis, so it overlaps unless the
+// other side is a disjoint concrete set.
+function rulesOverlap(a, b) {
+  const dimOverlap = (x, y, eq) => {
+    if (x == null || y == null) return true; // one is unconstrained on this axis
+    return x.some((xi) => y.some((yi) => eq(xi, yi)));
+  };
+  const methodsOk = dimOverlap(
+    a.methods && a.methods.map((m) => m.toUpperCase()),
+    b.methods && b.methods.map((m) => m.toUpperCase()),
+    (x, y) => x === y,
   );
+  if (!methodsOk) return false;
+  // hosts / path can't be proven disjoint cheaply (wildcards/globs), so treat
+  // any host/path pairing as potentially overlapping — the safe direction.
+  return true;
 }
 
 /**
  * Does `after` grant anything `before` did not? True when the level widens
  * (ro→rw), an allow rule appears that wasn't there, a deny rule disappears, OR
- * the relative order of rules common to both changes — because evaluateAccess
- * is first-match-wins, moving an allow ahead of an overlapping deny widens
- * access even when the rule SET is unchanged. Pure tightening (rw→ro, adding
- * deny rules, dropping allow rules, no reorder) is false.
+ * a reorder moves an allow ahead of an overlapping deny it previously lost to
+ * (first-match-wins, so that widens). Pure tightening (rw→ro, adding deny
+ * rules, dropping allow rules) and order-neutral reorders (deny↔deny,
+ * allow↔allow, or a deny moved EARLIER) are false — tightening applies without
+ * the owner ceremony.
  */
 export function isAccessRelaxation(before, after) {
   if (ACCESS_RANK[effectiveAccess(after)] > ACCESS_RANK[effectiveAccess(before)]) return true;
@@ -320,16 +341,27 @@ export function isAccessRelaxation(before, after) {
   for (const r of ruleSet(before, "deny")) {
     if (!afterDeny.has(r)) return true;
   }
-  // Order sensitivity: compare the relative order of rules present in both. A
-  // swap (allow moved before a deny it previously lost to) flips precedence.
-  const beforeKeys = orderedRuleKeys(before);
-  const afterKeys = orderedRuleKeys(after);
-  const beforeSet = new Set(beforeKeys);
-  const afterSet = new Set(afterKeys);
-  const bCommon = beforeKeys.filter((k) => afterSet.has(k));
-  const aCommon = afterKeys.filter((k) => beforeSet.has(k));
-  for (let i = 0; i < bCommon.length; i++) {
-    if (bCommon[i] !== aCommon[i]) return true;
+  // Precedence reorder: among rules common to both, a widening happens only if
+  // some allow rule A was AFTER an overlapping deny rule D in `before` but is
+  // now BEFORE it in `after` (A can now win where D used to). Reordering rules
+  // of the same effect, or moving a deny earlier, never widens.
+  const beforeRules = Array.isArray(before.accessRules) ? before.accessRules : [];
+  const afterRules = Array.isArray(after.accessRules) ? after.accessRules : [];
+  const afterKeys = new Set(afterRules.map(ruleKey));
+  const beforeKeys = new Set(beforeRules.map(ruleKey));
+  const common = (rules, otherKeys) =>
+    rules.map((r, i) => ({ r, i, key: ruleKey(r) })).filter((x) => otherKeys.has(x.key));
+  const bCommon = common(beforeRules, afterKeys);
+  const aPos = new Map(common(afterRules, beforeKeys).map((x) => [x.key, x.i]));
+  for (const allow of bCommon) {
+    if (allow.r.effect !== "allow") continue;
+    for (const deny of bCommon) {
+      if (deny.r.effect !== "deny") continue;
+      if (!rulesOverlap(allow.r, deny.r)) continue;
+      const denyBeforeAllow_before = deny.i < allow.i;
+      const allowBeforeDeny_after = aPos.get(allow.key) < aPos.get(deny.key);
+      if (denyBeforeAllow_before && allowBeforeDeny_after) return true;
+    }
   }
   return false;
 }

--- a/plugins/agent-id-vault/lib/access.mjs
+++ b/plugins/agent-id-vault/lib/access.mjs
@@ -1,0 +1,262 @@
+// Alien Agent ID — Per-credential access levels ("read my email, not write it").
+//
+// A credential record may carry:
+//
+//   access: "ro" | "rw"        (absent = "rw", backward compatible)
+//   accessRules: [ { effect: "allow"|"deny",
+//                    methods?: ["POST", …],       // HTTP methods (upper-cased)
+//                    hosts?:   ["*.example.com"], // same syntax as `domains`
+//                    path?:    "/api/v1/*" },     // pathname glob (* = any chars)
+//                  … ]                            // first match wins
+//
+// Evaluation order (evaluateAccess):
+//   1. accessRules, in order — an explicit rule always decides.
+//   2. The level default: "rw" allows everything; "ro" allows read-shaped
+//      requests only: GET/HEAD/OPTIONS, plus POST bodies that classify as reads
+//      on protocols that tunnel reads through POST (GraphQL query / JMAP
+//      */get,*/query / JSON-RPC non-submitting calls).
+//
+// WHO ENFORCES: the vault stores the policy; the processes that hold live
+// credential material enforce it on every use — agent-id-proxy for HTTP
+// injection and agent-id-browser's session server for sealed web sessions.
+// The policy is only as strong as the vault's unlock boundary: with an
+// agent-key slot the agent can open the vault itself, so for hard enforcement
+// pair `access: "ro"` with a vault the agent cannot self-unlock (passkey /
+// owner-approval slots).
+//
+// This module is dependency-free within the vault so both the proxy and the
+// browser plugin can import it (store.mjs imports it for validation, so it
+// must not import store.mjs back). hostMatchesAllowlist lives here for that
+// reason and is re-exported by store.mjs for its existing consumers.
+
+export const ACCESS_LEVELS = Object.freeze(["ro", "rw"]);
+
+// Methods that are read-shaped on their own, regardless of body.
+export const READ_METHODS = Object.freeze(["GET", "HEAD", "OPTIONS"]);
+
+const RULE_EFFECTS = Object.freeze(["allow", "deny"]);
+const METHOD_RE = /^[A-Z]+$/;
+
+// ─── Domain allowlist matching ────────────────────────────────────────────────
+// Supports literal hostnames and a single leading "*." wildcard.
+// `*.github.com` matches `github.com`, `api.github.com`, `x.y.github.com`.
+// (Moved from store.mjs so access rules and `domains` share one matcher
+// without a circular import; store.mjs re-exports it.)
+export function hostMatchesAllowlist(host, allowlist) {
+  if (!host || !Array.isArray(allowlist)) return false;
+  const hostLower = host.toLowerCase();
+  for (const entry of allowlist) {
+    const e = entry.toLowerCase();
+    if (e.startsWith("*.")) {
+      const suffix = e.slice(1); // ".github.com"
+      const bare = e.slice(2); // "github.com"
+      if (hostLower === bare) return true;
+      if (hostLower.endsWith(suffix)) return true;
+    } else if (hostLower === e) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// The level in force for a record — absent means unrestricted ("rw").
+export function effectiveAccess(rec) {
+  return rec && rec.access != null ? rec.access : "rw";
+}
+
+// ─── Validation (called from store.mjs validateRecord) ────────────────────────
+
+export function validateAccessFields(rec) {
+  if (rec.access != null && !ACCESS_LEVELS.includes(rec.access)) {
+    throw new Error(
+      `Credential ${rec.name}: access must be one of ${ACCESS_LEVELS.join(", ")}`,
+    );
+  }
+  if (rec.accessRules == null) return;
+  if (!Array.isArray(rec.accessRules) || rec.accessRules.length === 0) {
+    throw new Error(`Credential ${rec.name}: accessRules must be a non-empty array`);
+  }
+  for (const rule of rec.accessRules) {
+    if (!rule || typeof rule !== "object" || Array.isArray(rule)) {
+      throw new Error(`Credential ${rec.name}: each access rule must be an object`);
+    }
+    if (!RULE_EFFECTS.includes(rule.effect)) {
+      throw new Error(
+        `Credential ${rec.name}: rule effect must be one of ${RULE_EFFECTS.join(", ")}`,
+      );
+    }
+    if (rule.methods != null) {
+      if (!Array.isArray(rule.methods) || rule.methods.length === 0) {
+        throw new Error(`Credential ${rec.name}: rule methods must be a non-empty array`);
+      }
+      for (const m of rule.methods) {
+        if (typeof m !== "string" || !METHOD_RE.test(m.toUpperCase())) {
+          throw new Error(`Credential ${rec.name}: invalid rule method '${m}'`);
+        }
+      }
+    }
+    if (rule.hosts != null) {
+      if (!Array.isArray(rule.hosts) || rule.hosts.length === 0) {
+        throw new Error(`Credential ${rec.name}: rule hosts must be a non-empty array`);
+      }
+      for (const h of rule.hosts) {
+        if (typeof h !== "string" || h.length === 0) {
+          throw new Error(`Credential ${rec.name}: invalid rule host entry`);
+        }
+      }
+    }
+    if (rule.path != null && (typeof rule.path !== "string" || !rule.path.startsWith("/"))) {
+      throw new Error(`Credential ${rec.name}: rule path must be a string starting with '/'`);
+    }
+  }
+}
+
+// ─── Rule matching ────────────────────────────────────────────────────────────
+
+// Pathname glob: `*` matches any run of characters (including `/`). Anchored.
+export function pathMatchesGlob(pathname, glob) {
+  const re = new RegExp(
+    "^" + glob.split("*").map((s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("[^]*") + "$",
+  );
+  return re.test(pathname);
+}
+
+function ruleMatches(rule, { method, host, path }) {
+  if (rule.methods && !rule.methods.map((m) => m.toUpperCase()).includes(method)) return false;
+  if (rule.hosts && !hostMatchesAllowlist(host, rule.hosts)) return false;
+  if (rule.path && !pathMatchesGlob(path || "/", rule.path)) return false;
+  return true;
+}
+
+// ─── Read classification of POST-tunneled protocols ───────────────────────────
+// Several protocols tunnel reads through POST; a method-only "ro" gate would
+// either block those reads or force per-service rules everywhere. These
+// classifiers recognize the common read shapes. Anything unrecognized stays
+// blocked (default-deny for non-read methods under "ro").
+
+const JMAP_READ_METHOD_RE = /\/(get|query|queryChanges|changes|echo|parse)$/;
+
+// JSON-RPC calls that submit/sign state changes (EVM + Solana vocabularies).
+const JSONRPC_WRITE_RE =
+  /^(eth_send|eth_sign|personal_|sendTransaction$|signTransaction$|signAllTransactions$|requestAirdrop$)/;
+
+function classifyGraphql(doc) {
+  // { query: "query { … }" } or "{ … }" (shorthand query). Mutations and
+  // subscriptions are writes. Operation type is the first keyword.
+  const q = String(doc.query).trimStart();
+  return /^(query\b|\{)/.test(q) ? "read" : "write";
+}
+
+function classifyOne(obj) {
+  if (!obj || typeof obj !== "object") return "unknown";
+  if (typeof obj.query === "string") return classifyGraphql(obj);
+  if (Array.isArray(obj.methodCalls)) {
+    // JMAP request: every invocation must be a read method.
+    const allRead = obj.methodCalls.every(
+      (c) => Array.isArray(c) && typeof c[0] === "string" && JMAP_READ_METHOD_RE.test(c[0]),
+    );
+    return allRead ? "read" : "write";
+  }
+  if (typeof obj.method === "string" && (obj.jsonrpc != null || obj.id !== undefined)) {
+    return JSONRPC_WRITE_RE.test(obj.method) ? "write" : "read";
+  }
+  return "unknown";
+}
+
+// Classify a request body as "read" | "write" | "unknown". Accepts a UTF-8
+// string; batched arrays (GraphQL/JSON-RPC) are reads only if every item is.
+export function classifyBodyRead(body) {
+  if (body == null || body === "") return "unknown";
+  let parsed;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return "unknown";
+  }
+  const items = Array.isArray(parsed) ? parsed : [parsed];
+  if (items.length === 0) return "unknown";
+  let sawRead = false;
+  for (const item of items) {
+    const c = classifyOne(item);
+    if (c === "write") return "write";
+    if (c === "unknown") return "unknown";
+    sawRead = true;
+  }
+  return sawRead ? "read" : "unknown";
+}
+
+// ─── The evaluator ────────────────────────────────────────────────────────────
+
+/**
+ * Decide whether a request may use this credential.
+ *
+ *   evaluateAccess(rec, { method, host, path, body })
+ *     → { allowed: boolean, reason: string, needsBody?: true }
+ *
+ * `path` is the pathname only (no query string). `body` is the UTF-8 request
+ * body, or undefined when the caller has not buffered it. When the decision
+ * would require the body to classify (a non-read method under "ro" with no
+ * matching rule), the result carries `needsBody: true` and `allowed: false`;
+ * the caller may buffer the body and re-evaluate.
+ */
+export function evaluateAccess(rec, { method, host, path, body }) {
+  const m = String(method || "GET").toUpperCase();
+  const h = String(host || "").toLowerCase();
+  const p = path || "/";
+
+  if (Array.isArray(rec.accessRules)) {
+    for (let i = 0; i < rec.accessRules.length; i++) {
+      const rule = rec.accessRules[i];
+      if (ruleMatches(rule, { method: m, host: h, path: p })) {
+        return { allowed: rule.effect === "allow", reason: `rule_${i}_${rule.effect}` };
+      }
+    }
+  }
+
+  if (effectiveAccess(rec) === "rw") return { allowed: true, reason: "level_rw" };
+
+  if (READ_METHODS.includes(m)) return { allowed: true, reason: "read_method" };
+
+  if (body === undefined) {
+    return { allowed: false, reason: "write_blocked", needsBody: true };
+  }
+  if (classifyBodyRead(body) === "read") {
+    return { allowed: true, reason: "read_classified" };
+  }
+  return { allowed: false, reason: "write_blocked" };
+}
+
+// ─── Relaxation detection (gates the human ceremony in `set-access`) ──────────
+
+const ACCESS_RANK = { ro: 0, rw: 1 };
+
+// Strictest of two levels ("ro" beats "rw").
+export function strictestAccess(a, b) {
+  return ACCESS_RANK[a] <= ACCESS_RANK[b] ? a : b;
+}
+
+function ruleSet(rec, effect) {
+  return new Set(
+    (Array.isArray(rec.accessRules) ? rec.accessRules : [])
+      .filter((r) => r && r.effect === effect)
+      .map((r) => JSON.stringify({ methods: r.methods, hosts: r.hosts, path: r.path })),
+  );
+}
+
+/**
+ * Does `after` grant anything `before` did not? True when the level widens
+ * (ro→rw), an allow rule appears that wasn't there, or a deny rule disappears.
+ * Tightening (rw→ro, adding deny rules, dropping allow rules) is false.
+ */
+export function isAccessRelaxation(before, after) {
+  if (ACCESS_RANK[effectiveAccess(after)] > ACCESS_RANK[effectiveAccess(before)]) return true;
+  const beforeAllow = ruleSet(before, "allow");
+  for (const r of ruleSet(after, "allow")) {
+    if (!beforeAllow.has(r)) return true;
+  }
+  const afterDeny = ruleSet(after, "deny");
+  for (const r of ruleSet(before, "deny")) {
+    if (!afterDeny.has(r)) return true;
+  }
+  return false;
+}

--- a/plugins/agent-id-vault/lib/store.mjs
+++ b/plugins/agent-id-vault/lib/store.mjs
@@ -20,6 +20,11 @@
 
 import { nowMs } from "@alien-id/agent-id-core/lib/crypto.mjs";
 import { isLoopbackHost } from "@alien-id/agent-id-core/lib/http.mjs";
+import { hostMatchesAllowlist, validateAccessFields } from "./access.mjs";
+
+// Domain matching lives in access.mjs (access rules share the syntax); kept
+// exported here for the proxy/browser consumers that import it from store.
+export { hostMatchesAllowlist };
 
 export const CREDENTIAL_TYPES = Object.freeze([
   "bearer",
@@ -120,6 +125,9 @@ export function validateRecord(rec) {
       `Credential ${rec.name}: upstreamScheme must be one of ${UPSTREAM_SCHEMES.join(", ")}`,
     );
   }
+  // Optional per-credential access level + rules (enforced by the proxy and
+  // the browser session server; see access.mjs).
+  validateAccessFields(rec);
   switch (rec.type) {
     case "bearer":
       requireNonEmpty(rec, ["value"]);
@@ -324,6 +332,10 @@ export function listMetadata(payload) {
     type: c.type,
     domains: c.domains,
     description: c.description || null,
+    // Access level is metadata, not a secret — agents need to see it to know
+    // which operations a credential permits (and how to ask for more).
+    ...(c.access ? { access: c.access } : {}),
+    ...(Array.isArray(c.accessRules) ? { accessRules: c.accessRules } : {}),
     // The wallet address is public by design — agents need it to build
     // transactions and check balances without opening the record.
     ...(c.publicKey ? { publicKey: c.publicKey } : {}),
@@ -389,23 +401,3 @@ export function wipePayload(payload) {
   payload.credentials.length = 0;
 }
 
-// ─── Domain allowlist matching ──────────────────────────────────────────────────
-
-// Supports literal hostnames and a single leading "*." wildcard.
-// `*.github.com` matches `github.com`, `api.github.com`, `x.y.github.com`.
-export function hostMatchesAllowlist(host, allowlist) {
-  if (!host || !Array.isArray(allowlist)) return false;
-  const hostLower = host.toLowerCase();
-  for (const entry of allowlist) {
-    const e = entry.toLowerCase();
-    if (e.startsWith("*.")) {
-      const suffix = e.slice(1); // ".github.com"
-      const bare = e.slice(2); // "github.com"
-      if (hostLower === bare) return true;
-      if (hostLower.endsWith(suffix)) return true;
-    } else if (hostLower === e) {
-      return true;
-    }
-  }
-  return false;
-}

--- a/plugins/agent-id-vault/skills/agent-id-vault/SKILL.md
+++ b/plugins/agent-id-vault/skills/agent-id-vault/SKILL.md
@@ -156,6 +156,13 @@ cannot approve it itself, and `add`/`generate` refuse to overwrite a record
 with a wider level. When a human types the secret via `--form`, the form shows
 the access level being granted.
 
+Any credential the proxy restricts (level `ro`, or `rw` with rules) is also
+sealed against `show`/`exec` — its plaintext can't be extracted to sidestep the
+gate. Two things `ro` deliberately does **not** cover: a server that mutates on
+a `GET` (per HTTP safe-method convention `GET`/`HEAD`/`OPTIONS` are treated as
+reads — constrain such an endpoint with an explicit `deny` rule), and raw
+IMAP/SMTP (no HTTP method to gate — use an API or a web session).
+
 > The policy is enforced by the proxy / browser-session processes. With an
 > agent-key vault the agent could in principle open the vault directly, so for
 > a hard guarantee init the vault with `--unlock passkey` (no agent-key slot)

--- a/plugins/agent-id-vault/skills/agent-id-vault/SKILL.md
+++ b/plugins/agent-id-vault/skills/agent-id-vault/SKILL.md
@@ -158,10 +158,32 @@ the access level being granted.
 
 Any credential the proxy restricts (level `ro`, or `rw` with rules) is also
 sealed against `show`/`exec` — its plaintext can't be extracted to sidestep the
-gate. Two things `ro` deliberately does **not** cover: a server that mutates on
-a `GET` (per HTTP safe-method convention `GET`/`HEAD`/`OPTIONS` are treated as
-reads — constrain such an endpoint with an explicit `deny` rule), and raw
-IMAP/SMTP (no HTTP method to gate — use an API or a web session).
+gate.
+
+### Where `ro` works — the operation must be legible in the request
+
+Read/write can only be told apart when the request reveals the operation. It
+**fails safe**: when it can't tell, it denies (never silently allows a write).
+
+| API shape | Under `ro` |
+| --- | --- |
+| REST with real verbs (Gmail API, Stripe, GitHub REST) | reads pass, writes blocked — **best case** |
+| GraphQL with the **query text inline** in the body | `query` passes, `mutation`/`subscription` blocked |
+| JMAP (Fastmail) | `*/get`,`*/query` pass; `*/set` blocked |
+| JSON-RPC with recognized read methods | reads pass; unknown methods blocked |
+| GraphQL **persisted queries** (hash only, no query text — Reddit/X web) | over-blocks: reads AND writes denied |
+| Opaque binary RPC (gRPC-web, Connect, Twirp) | over-blocks: denied |
+
+Two things `ro` deliberately does **not** cover: a server that mutates on a
+`GET` (per HTTP safe-method convention `GET`/`HEAD`/`OPTIONS` are reads —
+constrain such an endpoint with an explicit `deny` rule), and raw IMAP/SMTP
+(no HTTP method to gate — use an API or a web session).
+
+For an over-blocked endpoint you have two levers: a scoped `allow` rule for a
+read path (but if reads and writes share one URL, e.g. a single `/graphql`, that
+also reopens writes there); or, for a token API, prefer a **server-side
+read-only scope** at onboarding (e.g. Gmail `gmail.readonly`) — the only
+enforcement even a client-side bug can't defeat.
 
 > The policy is enforced by the proxy / browser-session processes. With an
 > agent-key vault the agent could in principle open the vault directly, so for

--- a/plugins/agent-id-vault/skills/agent-id-vault/SKILL.md
+++ b/plugins/agent-id-vault/skills/agent-id-vault/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-id-vault
-description: Portable encrypted credential vault with LUKS-style slots (passkey/Touch ID, passphrase, agent-key, phone) and typed/domain-scoped credential records. Pairs with agent-id-proxy so the agent never sees credential values — the proxy injects them at request time. Can also GENERATE blockchain wallet keys (Solana ed25519, EVM secp256k1) inside the vault — the private key is sealed, only the address is printed, and transactions are signed by the proxy. Use whenever the user asks to save, fetch, or remove a service credential, create a crypto wallet for the agent, or whenever a downstream tool needs an external-service secret that must not appear in shell history, source files, or process arguments.
+description: Portable encrypted credential vault with LUKS-style slots (passkey/Touch ID, passphrase, agent-key, phone) and typed/domain-scoped credential records. Credentials can carry an ACCESS LEVEL (--access ro) so the agent can read a service but never write to it — enforced by the proxy and the sealed browser, widened only with the owner's out-of-band confirmation (set-access). Pairs with agent-id-proxy so the agent never sees credential values — the proxy injects them at request time. Can also GENERATE blockchain wallet keys (Solana ed25519, EVM secp256k1) inside the vault — the private key is sealed, only the address is printed, and transactions are signed by the proxy. Use whenever the user asks to save, fetch, or remove a service credential, create a crypto wallet for the agent, or whenever a downstream tool needs an external-service secret that must not appear in shell history, source files, or process arguments.
 license: MIT
 metadata:
   author: Alien Wallet
@@ -117,6 +117,49 @@ node CLI add --name github-pat --type bearer --domains api.github.com --form
 ```
 
 Never paste a secret into chat. The agent transcript persists.
+
+## Access levels — grant "read", not "everything"
+
+Any credential can carry `--access ro` (default is `rw`, unrestricted). A
+read-only credential can be **used** but not used to **change** anything:
+
+- **The proxy** allows read-shaped requests only: `GET`/`HEAD`/`OPTIONS`, plus
+  POST-tunneled reads it can classify (GraphQL `query`, JMAP `*/get`/`*/query`,
+  JSON-RPC calls that don't submit transactions). Everything else → structured
+  `403 access_denied`.
+- **The sealed browser** (agent-id-browser) enforces the same classification on
+  every request a `--access ro` session makes, at the network layer.
+- **Plaintext egress is sealed**: `show` redacts and `exec` refuses a ro
+  credential's secret fields — otherwise the enforcement would be theater.
+
+```bash
+# "The agent may READ my mailbox, never send/delete":
+node CLI add --name fastmail --type bearer --access ro \
+  --domains api.fastmail.com --form
+
+# Fine-grained overrides (first match wins), e.g. allow one search POST:
+node CLI set-access --name fastmail \
+  --rules '[{"effect":"allow","methods":["POST"],"path":"/search"}]'
+```
+
+**Changing the level later** (`set-access`) is asymmetric by design:
+
+```bash
+node CLI set-access --name fastmail --access ro   # tighten: applies at once
+node CLI set-access --name fastmail --access rw   # WIDEN: the owner must
+                                                  # confirm via the secure form
+```
+
+Widening (ro→rw, adding an `allow` rule, dropping a `deny` rule) opens the
+secure prompt and asks the **owner** to type the credential name — the agent
+cannot approve it itself, and `add`/`generate` refuse to overwrite a record
+with a wider level. When a human types the secret via `--form`, the form shows
+the access level being granted.
+
+> The policy is enforced by the proxy / browser-session processes. With an
+> agent-key vault the agent could in principle open the vault directly, so for
+> a hard guarantee init the vault with `--unlock passkey` (no agent-key slot)
+> and let only the proxy hold it unlocked.
 
 ## Generate a wallet keypair (the key never leaves the vault)
 

--- a/tests/test-access-policy.mjs
+++ b/tests/test-access-policy.mjs
@@ -169,6 +169,8 @@ describe("body classification (POST-tunneled reads)", () => {
       classifyBodyRead('{"methodCalls":[["Email/get",{},"0"],["EmailSubmission/set",{},"1"]]}'),
       "write",
     );
+    // an empty batch is a no-op → unknown (blocked under ro), not vacuously read
+    assert.equal(classifyBodyRead('{"methodCalls":[]}'), "unknown");
   });
 
   it("JSON-RPC: recognized reads pass, sends write", () => {
@@ -255,7 +257,7 @@ describe("relaxation detection", () => {
     );
   });
 
-  it("REORDERING an allow ahead of a deny is a relaxation (first-match-wins)", () => {
+  it("REORDERING an allow ahead of an overlapping deny is a relaxation (first-match-wins)", () => {
     const allow = { effect: "allow", methods: ["POST"], path: "/x" };
     const deny = { effect: "deny", methods: ["POST"], path: "/x" };
     // Same set, different order: [deny, allow] denies /x; [allow, deny] allows it.
@@ -265,6 +267,45 @@ describe("relaxation detection", () => {
         { access: "ro", accessRules: [allow, deny] },
       ),
       true,
+    );
+  });
+
+  it("harmless reorders and tightenings do NOT require the ceremony", () => {
+    const allow = { effect: "allow", methods: ["POST"], path: "/x" };
+    const deny = { effect: "deny", methods: ["POST"], path: "/x" };
+    const denyGet = { effect: "deny", methods: ["GET"], path: "/y" };
+    const allowOpt = { effect: "allow", methods: ["OPTIONS"], path: "/z" };
+    // moving a deny AHEAD of an allow is a tightening → not a relaxation
+    assert.equal(
+      isAccessRelaxation(
+        { access: "ro", accessRules: [allow, deny] },
+        { access: "ro", accessRules: [deny, allow] },
+      ),
+      false,
+    );
+    // reordering two denies among themselves → neutral
+    assert.equal(
+      isAccessRelaxation(
+        { access: "ro", accessRules: [deny, denyGet] },
+        { access: "ro", accessRules: [denyGet, deny] },
+      ),
+      false,
+    );
+    // reordering two allows among themselves → neutral
+    assert.equal(
+      isAccessRelaxation(
+        { access: "ro", accessRules: [allow, allowOpt] },
+        { access: "ro", accessRules: [allowOpt, allow] },
+      ),
+      false,
+    );
+    // an allow moving ahead of a NON-overlapping deny (different method) → neutral
+    assert.equal(
+      isAccessRelaxation(
+        { access: "ro", accessRules: [denyGet, allow] },
+        { access: "ro", accessRules: [allow, denyGet] },
+      ),
+      false,
     );
   });
 });

--- a/tests/test-access-policy.mjs
+++ b/tests/test-access-policy.mjs
@@ -14,6 +14,7 @@ import {
   effectiveAccess,
   evaluateAccess,
   isAccessRelaxation,
+  isAccessRestricted,
   pathMatchesGlob,
   strictestAccess,
 } from "../plugins/agent-id-vault/lib/access.mjs";
@@ -75,6 +76,18 @@ describe("evaluateAccess", () => {
     }
   });
 
+  it("a read-shaped body does NOT promote PUT/PATCH/DELETE (only POST tunnels reads)", () => {
+    const ro = { ...base, access: "ro" };
+    const readBody = '{"query":"{ __typename }"}';
+    for (const m of ["DELETE", "PUT", "PATCH"]) {
+      const d = evaluateAccess(ro, req({ method: m, body: readBody }));
+      assert.equal(d.allowed, false, `${m} with read-shaped body must stay blocked`);
+      assert.equal(d.needsBody, undefined, `${m} must not even ask for the body`);
+    }
+    // POST with the same read body is the only one that passes.
+    assert.equal(evaluateAccess(ro, req({ method: "POST", body: readBody })).allowed, true);
+  });
+
   it("asks for the body once, when only the body can decide", () => {
     const ro = { ...base, access: "ro" };
     const first = evaluateAccess(ro, req({ method: "POST" }));
@@ -127,6 +140,24 @@ describe("body classification (POST-tunneled reads)", () => {
     assert.equal(classifyBodyRead('[{"query":"query{a}"},{"query":"{b}"}]'), "read");
   });
 
+  it("GraphQL: a multi-operation doc with a mutation is a write even if it leads with query", () => {
+    // operationName could select the mutation — leading keyword is not enough.
+    assert.equal(
+      classifyBodyRead(
+        JSON.stringify({
+          query: "query GetMe { me { id } }\nmutation DoBad { sendMail }",
+          operationName: "DoBad",
+        }),
+      ),
+      "write",
+    );
+    // a `#`-comment must not hide a real mutation, nor fake a leading query
+    assert.equal(classifyBodyRead('{"query":"# query\\nmutation { x }"}'), "write");
+    assert.equal(classifyBodyRead('{"query":"query Foo { a }"}'), "read");
+    // leading comment before a genuine query stays a read
+    assert.equal(classifyBodyRead('{"query":"# hi\\nquery { a }"}'), "read");
+  });
+
   it("JMAP: get/query read, set writes", () => {
     assert.equal(
       classifyBodyRead(
@@ -140,15 +171,30 @@ describe("body classification (POST-tunneled reads)", () => {
     );
   });
 
-  it("JSON-RPC: balance reads, sends write", () => {
+  it("JSON-RPC: recognized reads pass, sends write", () => {
     assert.equal(classifyBodyRead('{"jsonrpc":"2.0","id":1,"method":"eth_getBalance"}'), "read");
+    assert.equal(classifyBodyRead('{"jsonrpc":"2.0","id":1,"method":"eth_call"}'), "read");
     assert.equal(classifyBodyRead('{"jsonrpc":"2.0","id":1,"method":"getBalance"}'), "read");
+    assert.equal(classifyBodyRead('{"jsonrpc":"2.0","id":1,"method":"simulateTransaction"}'), "read");
     assert.equal(
       classifyBodyRead('{"jsonrpc":"2.0","id":1,"method":"eth_sendRawTransaction"}'),
       "write",
     );
     assert.equal(classifyBodyRead('{"jsonrpc":"2.0","id":1,"method":"sendTransaction"}'), "write");
     assert.equal(classifyBodyRead('{"jsonrpc":"2.0","id":1,"method":"requestAirdrop"}'), "write");
+  });
+
+  it("JSON-RPC is default-DENY: unrecognized methods are unknown (blocked), not read", () => {
+    // Writes on non-EVM/Solana RPC services that the old denylist let through as
+    // reads — now unknown (→ blocked). `wallet_sendCalls` is explicitly a write.
+    for (const method of ["deleteUser", "sendtoaddress", "starknet_addInvokeTransaction", "admin_addPeer"]) {
+      assert.equal(
+        classifyBodyRead(`{"jsonrpc":"2.0","id":1,"method":"${method}"}`),
+        "unknown",
+        `${method} must not classify as a read`,
+      );
+    }
+    assert.equal(classifyBodyRead('{"jsonrpc":"2.0","id":1,"method":"wallet_sendCalls"}'), "write");
   });
 
   it("unknown shapes stay unknown (blocked under ro)", () => {
@@ -207,6 +253,29 @@ describe("relaxation detection", () => {
       ),
       false,
     );
+  });
+
+  it("REORDERING an allow ahead of a deny is a relaxation (first-match-wins)", () => {
+    const allow = { effect: "allow", methods: ["POST"], path: "/x" };
+    const deny = { effect: "deny", methods: ["POST"], path: "/x" };
+    // Same set, different order: [deny, allow] denies /x; [allow, deny] allows it.
+    assert.equal(
+      isAccessRelaxation(
+        { access: "ro", accessRules: [deny, allow] },
+        { access: "ro", accessRules: [allow, deny] },
+      ),
+      true,
+    );
+  });
+});
+
+describe("isAccessRestricted", () => {
+  it("true for ro and for any accessRules, false for plain rw", () => {
+    assert.equal(isAccessRestricted({ access: "ro" }), true);
+    assert.equal(isAccessRestricted({ access: "rw", accessRules: [{ effect: "deny" }] }), true);
+    assert.equal(isAccessRestricted({ accessRules: [{ effect: "deny" }] }), true);
+    assert.equal(isAccessRestricted({ access: "rw" }), false);
+    assert.equal(isAccessRestricted({}), false);
   });
 });
 

--- a/tests/test-access-policy.mjs
+++ b/tests/test-access-policy.mjs
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+
+// Unit tests for per-credential access levels (vault access.mjs + store
+// validation + the browser guard's pure pieces).
+//
+// Run: node --test tests/test-access-policy.mjs
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  ACCESS_LEVELS,
+  classifyBodyRead,
+  effectiveAccess,
+  evaluateAccess,
+  isAccessRelaxation,
+  pathMatchesGlob,
+  strictestAccess,
+} from "../plugins/agent-id-vault/lib/access.mjs";
+import { validateRecord } from "../plugins/agent-id-vault/lib/store.mjs";
+import {
+  assertActionAllowed,
+  guardDecision,
+} from "../plugins/agent-id-browser/lib/access-guard.mjs";
+
+const base = { name: "t", type: "bearer", value: "x", domains: ["api.example.com"] };
+
+describe("schema validation", () => {
+  it("accepts access ro/rw and rejects junk", () => {
+    validateRecord({ ...base, access: "ro" });
+    validateRecord({ ...base, access: "rw" });
+    assert.throws(() => validateRecord({ ...base, access: "readonly" }), /access must be one of/);
+    assert.deepEqual(ACCESS_LEVELS, ["ro", "rw"]);
+  });
+
+  it("validates accessRules shape", () => {
+    validateRecord({
+      ...base,
+      access: "ro",
+      accessRules: [
+        { effect: "allow", methods: ["POST"], path: "/search/*" },
+        { effect: "deny", hosts: ["*.example.com"] },
+      ],
+    });
+    assert.throws(() => validateRecord({ ...base, accessRules: [] }), /non-empty array/);
+    assert.throws(() => validateRecord({ ...base, accessRules: [{ effect: "block" }] }), /effect/);
+    assert.throws(
+      () => validateRecord({ ...base, accessRules: [{ effect: "allow", methods: [] }] }),
+      /methods/,
+    );
+    assert.throws(
+      () => validateRecord({ ...base, accessRules: [{ effect: "allow", path: "no-slash" }] }),
+      /path/,
+    );
+  });
+});
+
+describe("evaluateAccess", () => {
+  const req = (over = {}) => ({ method: "GET", host: "api.example.com", path: "/v1/x", ...over });
+
+  it("rw (and absent) allows everything", () => {
+    assert.equal(evaluateAccess(base, req({ method: "DELETE" })).allowed, true);
+    assert.equal(evaluateAccess({ ...base, access: "rw" }, req({ method: "POST" })).allowed, true);
+  });
+
+  it("ro allows read methods, blocks writes", () => {
+    const ro = { ...base, access: "ro" };
+    for (const m of ["GET", "HEAD", "OPTIONS", "get"]) {
+      assert.equal(evaluateAccess(ro, req({ method: m })).allowed, true, m);
+    }
+    for (const m of ["POST", "PUT", "PATCH", "DELETE"]) {
+      const d = evaluateAccess(ro, req({ method: m, body: null }));
+      assert.equal(d.allowed, false, m);
+      assert.equal(d.reason, "write_blocked");
+    }
+  });
+
+  it("asks for the body once, when only the body can decide", () => {
+    const ro = { ...base, access: "ro" };
+    const first = evaluateAccess(ro, req({ method: "POST" }));
+    assert.equal(first.allowed, false);
+    assert.equal(first.needsBody, true);
+    const second = evaluateAccess(ro, req({ method: "POST", body: '{"query":"query { me }"}' }));
+    assert.equal(second.allowed, true);
+    assert.equal(second.reason, "read_classified");
+  });
+
+  it("rules run first, in order, and beat the level", () => {
+    const rec = {
+      ...base,
+      access: "ro",
+      accessRules: [
+        { effect: "deny", methods: ["GET"], path: "/admin/*" },
+        { effect: "allow", methods: ["POST"], path: "/search" },
+      ],
+    };
+    assert.equal(evaluateAccess(rec, req({ path: "/admin/users" })).allowed, false);
+    assert.equal(evaluateAccess(rec, req({ method: "POST", path: "/search" })).allowed, true);
+    // unmatched POST falls through to the ro default
+    assert.equal(evaluateAccess(rec, req({ method: "POST", path: "/other", body: null })).allowed, false);
+  });
+
+  it("rule hosts use the domains wildcard syntax", () => {
+    const rec = {
+      ...base,
+      accessRules: [{ effect: "deny", hosts: ["*.internal.example.com"] }],
+    };
+    assert.equal(
+      evaluateAccess(rec, req({ host: "db.internal.example.com" })).allowed,
+      false,
+    );
+    assert.equal(evaluateAccess(rec, req()).allowed, true);
+  });
+});
+
+describe("body classification (POST-tunneled reads)", () => {
+  it("GraphQL: query reads, mutation writes", () => {
+    assert.equal(classifyBodyRead('{"query":"query Q { me { id } }"}'), "read");
+    assert.equal(classifyBodyRead('{"query":"{ me { id } }"}'), "read");
+    assert.equal(classifyBodyRead('{"query":"mutation M { send }"}'), "write");
+    assert.equal(classifyBodyRead('{"query":"subscription S { x }"}'), "write");
+    // batched: one mutation poisons the batch
+    assert.equal(
+      classifyBodyRead('[{"query":"query{a}"},{"query":"mutation{b}"}]'),
+      "write",
+    );
+    assert.equal(classifyBodyRead('[{"query":"query{a}"},{"query":"{b}"}]'), "read");
+  });
+
+  it("JMAP: get/query read, set writes", () => {
+    assert.equal(
+      classifyBodyRead(
+        '{"methodCalls":[["Email/query",{},"0"],["Email/get",{},"1"]]}',
+      ),
+      "read",
+    );
+    assert.equal(
+      classifyBodyRead('{"methodCalls":[["Email/get",{},"0"],["EmailSubmission/set",{},"1"]]}'),
+      "write",
+    );
+  });
+
+  it("JSON-RPC: balance reads, sends write", () => {
+    assert.equal(classifyBodyRead('{"jsonrpc":"2.0","id":1,"method":"eth_getBalance"}'), "read");
+    assert.equal(classifyBodyRead('{"jsonrpc":"2.0","id":1,"method":"getBalance"}'), "read");
+    assert.equal(
+      classifyBodyRead('{"jsonrpc":"2.0","id":1,"method":"eth_sendRawTransaction"}'),
+      "write",
+    );
+    assert.equal(classifyBodyRead('{"jsonrpc":"2.0","id":1,"method":"sendTransaction"}'), "write");
+    assert.equal(classifyBodyRead('{"jsonrpc":"2.0","id":1,"method":"requestAirdrop"}'), "write");
+  });
+
+  it("unknown shapes stay unknown (blocked under ro)", () => {
+    assert.equal(classifyBodyRead("a=b&c=d"), "unknown");
+    assert.equal(classifyBodyRead('{"hello":"world"}'), "unknown");
+    assert.equal(classifyBodyRead(""), "unknown");
+    assert.equal(classifyBodyRead(null), "unknown");
+  });
+});
+
+describe("glob + level helpers", () => {
+  it("pathMatchesGlob", () => {
+    assert.equal(pathMatchesGlob("/v1/messages", "/v1/*"), true);
+    assert.equal(pathMatchesGlob("/v1/messages/send", "/v1/*"), true); // * crosses /
+    assert.equal(pathMatchesGlob("/v2/messages", "/v1/*"), false);
+    assert.equal(pathMatchesGlob("/exact", "/exact"), true);
+    assert.equal(pathMatchesGlob("/exact/no", "/exact"), false);
+  });
+
+  it("strictestAccess / effectiveAccess", () => {
+    assert.equal(strictestAccess("ro", "rw"), "ro");
+    assert.equal(strictestAccess("rw", "rw"), "rw");
+    assert.equal(effectiveAccess({}), "rw");
+    assert.equal(effectiveAccess({ access: "ro" }), "ro");
+  });
+});
+
+describe("relaxation detection", () => {
+  it("level changes", () => {
+    assert.equal(isAccessRelaxation({ access: "ro" }, { access: "rw" }), true);
+    assert.equal(isAccessRelaxation({ access: "ro" }, {}), true); // absent = rw
+    assert.equal(isAccessRelaxation({ access: "rw" }, { access: "ro" }), false);
+    assert.equal(isAccessRelaxation({}, { access: "ro" }), false);
+  });
+
+  it("rule changes", () => {
+    const allow = { effect: "allow", methods: ["POST"], path: "/x" };
+    const deny = { effect: "deny", hosts: ["a.com"] };
+    // adding an allow rule = relax; adding a deny = tighten
+    assert.equal(isAccessRelaxation({ access: "ro" }, { access: "ro", accessRules: [allow] }), true);
+    assert.equal(isAccessRelaxation({ access: "ro" }, { access: "ro", accessRules: [deny] }), false);
+    // dropping a deny rule = relax; dropping an allow = tighten
+    assert.equal(
+      isAccessRelaxation({ access: "ro", accessRules: [deny] }, { access: "ro" }),
+      true,
+    );
+    assert.equal(
+      isAccessRelaxation({ access: "ro", accessRules: [allow] }, { access: "ro" }),
+      false,
+    );
+    // identical rules = no relax
+    assert.equal(
+      isAccessRelaxation(
+        { access: "ro", accessRules: [allow, deny] },
+        { access: "ro", accessRules: [allow, deny] },
+      ),
+      false,
+    );
+  });
+});
+
+describe("browser guard (pure pieces)", () => {
+  const ro = { access: "ro" };
+
+  it("assertActionAllowed refuses eval/fill-secret/fill-otp on ro only", () => {
+    for (const action of ["eval", "fill-secret", "fill-otp"]) {
+      assert.throws(() => assertActionAllowed(ro, action), /read-only session/);
+      assertActionAllowed({ access: "rw" }, action); // no throw
+      assertActionAllowed({}, action);
+    }
+    for (const action of ["navigate", "click", "type", "snapshot", "text", "screenshot"]) {
+      assertActionAllowed(ro, action);
+    }
+  });
+
+  it("guardDecision: reads pass, writes abort, non-http passes", () => {
+    assert.equal(
+      guardDecision(ro, { method: "GET", url: "https://x.com/home", postData: null }).allowed,
+      true,
+    );
+    assert.equal(
+      guardDecision(ro, {
+        method: "POST",
+        url: "https://x.com/i/api/graphql/abc/HomeTimeline",
+        postData: '{"query":"query{home}"}',
+      }).allowed,
+      true,
+    );
+    assert.equal(
+      guardDecision(ro, {
+        method: "POST",
+        url: "https://x.com/i/api/graphql/abc/CreateTweet",
+        postData: '{"variables":{},"queryId":"abc"}',
+      }).allowed,
+      false,
+    );
+    assert.equal(
+      guardDecision(ro, { method: "POST", url: "https://mail.google.com/sync", postData: "junk" })
+        .allowed,
+      false,
+    );
+    assert.equal(
+      guardDecision(ro, { method: "GET", url: "data:text/plain,hi", postData: null }).allowed,
+      true,
+    );
+  });
+});

--- a/tests/test-browser-ro-live.mjs
+++ b/tests/test-browser-ro-live.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+
+// LIVE real-browser proof of read-only enforcement (the "read my Reddit, don't
+// write it" story). Launches actual Chrome via the browser plugin's
+// launchContext + applyAccessGuard with access:"ro", points it at a local
+// server standing in for reddit.com, and asserts that a page-issued READ
+// reaches the server while a WRITE is aborted at the network layer.
+//
+// SKIPS automatically when patchright / Chrome are not installed (e.g. CI
+// without the on-demand browser install), so it never breaks the suite.
+//
+// Run: node --test tests/test-browser-ro-live.mjs
+
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { resolvePatchright, launchContext } from "../plugins/agent-id-browser/lib/launch.mjs";
+import {
+  applyAccessGuard,
+  contextOptionsForAccess,
+} from "../plugins/agent-id-browser/lib/access-guard.mjs";
+
+const patchrightAvailable = !!resolvePatchright();
+
+let server;
+let base;
+const seen = [];
+
+function startServer() {
+  return new Promise((resolve) => {
+    server = http.createServer((req, res) => {
+      let body = "";
+      req.on("data", (c) => (body += c));
+      req.on("end", () => {
+        seen.push({ method: req.method, url: req.url, body });
+        if (req.url === "/") {
+          res.writeHead(200, { "Content-Type": "text/html" });
+          res.end("<!doctype html><title>fake-reddit</title><h1>Inbox</h1>");
+        } else {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ ok: true }));
+        }
+      });
+    });
+    server.listen(0, "127.0.0.1", () => {
+      base = `http://127.0.0.1:${server.address().port}`;
+      resolve();
+    });
+  });
+}
+
+before(async () => {
+  if (patchrightAvailable) await startServer();
+});
+after(async () => {
+  if (server) await new Promise((r) => server.close(r));
+});
+
+test(
+  "an access:'ro' sealed browser session reads but cannot write (real Chrome)",
+  { skip: patchrightAvailable ? false : "patchright/Chrome not installed" },
+  async () => {
+    const roProfile = { type: "browser-profile", access: "ro", domains: ["*"] };
+    const workDir = await fs.mkdtemp(path.join(os.tmpdir(), "ro-live-"));
+    let ctx;
+    try {
+      ctx = await launchContext({
+        profileDir: workDir,
+        headless: true,
+        contextOptions: contextOptionsForAccess(roProfile),
+      });
+      const active = await applyAccessGuard(ctx, roProfile, { log: () => {} });
+      assert.equal(active, true, "the access guard should be active for a ro profile");
+
+      const page = ctx.pages()[0] || (await ctx.newPage());
+      await page.goto(`${base}/`, { waitUntil: "domcontentloaded" });
+
+      // Drive exactly what an agent on reddit.com would: a read, a write, a
+      // GraphQL query (read), and a GraphQL mutation (write).
+      const results = await page.evaluate(async (b) => {
+        const out = {};
+        const tryFetch = async (label, url, opts) => {
+          try {
+            const r = await fetch(url, opts);
+            out[label] = "reached:" + r.status;
+          } catch (e) {
+            out[label] = "BLOCKED:" + e.name;
+          }
+        };
+        await tryFetch("read", b + "/message/inbox", {});
+        await tryFetch("write", b + "/api/compose", { method: "POST", body: "to=x&text=hi" });
+        await tryFetch("gqlQuery", b + "/svc/gql", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ query: "query { inbox }" }),
+        });
+        await tryFetch("gqlMutation", b + "/svc/gql", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ query: "mutation { sendMessage }" }),
+        });
+        return out;
+      }, base);
+
+      const hit = (m, u) => seen.some((s) => s.method === m && s.url === u);
+
+      // Reads pass and actually reach the server.
+      assert.match(results.read, /^reached:200/, "read GET should succeed");
+      assert.ok(hit("GET", "/message/inbox"), "read GET should reach the server");
+      assert.match(results.gqlQuery, /^reached:200/, "GraphQL query POST should succeed");
+
+      // Writes are aborted at the wire and NEVER reach the server.
+      assert.match(results.write, /^BLOCKED/, "write POST should be blocked in the page");
+      assert.ok(!hit("POST", "/api/compose"), "write POST must never reach the server");
+      assert.match(results.gqlMutation, /^BLOCKED/, "GraphQL mutation should be blocked");
+      assert.ok(
+        !seen.some((s) => s.body && s.body.includes("mutation")),
+        "no mutation body may reach the server",
+      );
+    } finally {
+      if (ctx) await ctx.close().catch(() => {});
+      await fs.rm(workDir, { recursive: true, force: true }).catch(() => {});
+    }
+  },
+);

--- a/tests/test-proxy-access.mjs
+++ b/tests/test-proxy-access.mjs
@@ -1,0 +1,257 @@
+#!/usr/bin/env node
+
+// End-to-end access-level enforcement in the proxy: an `access: "ro"`
+// credential lets reads through and refuses writes with a structured 403, in
+// both URL-rewrite and legacy stub-injection modes.
+//
+// Run: node --test tests/test-proxy-access.mjs
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { initVault, openVault } from "../plugins/agent-id-vault/lib/vault.mjs";
+import { createProxy } from "../plugins/agent-id-proxy/lib/proxy.mjs";
+
+const upstreamSeen = { value: null };
+
+function startUpstream() {
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      const chunks = [];
+      req.on("data", (c) => chunks.push(c));
+      req.on("end", () => {
+        upstreamSeen.value = {
+          method: req.method,
+          url: req.url,
+          auth: req.headers.authorization || null,
+          body: Buffer.concat(chunks).toString("utf8"),
+        };
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: true }));
+      });
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const a = server.address();
+      resolve({ server, host: a.address, port: a.port });
+    });
+  });
+}
+
+// URL-rewrite mode request: /<credname>/<host:port>/<path>
+function rewriteRequest({ proxyPort, credname, upstream, pathq, method = "GET", body = null }) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        host: "127.0.0.1",
+        port: proxyPort,
+        method,
+        path: `/${credname}/${upstream.host}:${upstream.port}${pathq}`,
+        headers: body != null ? { "Content-Type": "application/json" } : {},
+      },
+      (res) => {
+        const chunks = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () =>
+          resolve({ status: res.statusCode, body: Buffer.concat(chunks).toString("utf8") }),
+        );
+      },
+    );
+    req.on("error", reject);
+    req.end(body != null ? body : undefined);
+  });
+}
+
+// Legacy stub mode request: absolute URI + AgentVault marker header.
+function stubRequest({ proxyPort, target, method = "GET", headers = {} }) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(target);
+    const req = http.request(
+      { host: "127.0.0.1", port: proxyPort, method, path: target, headers: { Host: url.host, ...headers } },
+      (res) => {
+        const chunks = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () =>
+          resolve({ status: res.statusCode, body: Buffer.concat(chunks).toString("utf8") }),
+        );
+      },
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+describe("proxy access-level enforcement", () => {
+  let stateDir;
+  let upstream;
+  let vault;
+  let proxy;
+  let proxyPort;
+  let logPath;
+
+  before(async () => {
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "agent-id-access-test-"));
+    await initVault({ stateDir, passphrase: "test-pass-1234" });
+    vault = await openVault({ stateDir, passphrase: "test-pass-1234" });
+
+    upstream = await startUpstream();
+
+    vault.add({
+      name: "mail-ro",
+      type: "bearer",
+      domains: [upstream.host],
+      upstreamScheme: "http",
+      access: "ro",
+      value: "tok_READONLY",
+    });
+    vault.add({
+      name: "mail-rw",
+      type: "bearer",
+      domains: [upstream.host],
+      upstreamScheme: "http",
+      value: "tok_READWRITE",
+    });
+    vault.add({
+      name: "ro-with-rules",
+      type: "bearer",
+      domains: [upstream.host],
+      upstreamScheme: "http",
+      access: "ro",
+      accessRules: [
+        { effect: "allow", methods: ["POST"], path: "/search" },
+        { effect: "deny", methods: ["GET"], path: "/admin/*" },
+      ],
+      value: "tok_RULES",
+    });
+    await vault.save();
+
+    logPath = path.join(stateDir, "proxy.log");
+    proxy = createProxy({ vault, logPath });
+    const addr = await proxy.listen();
+    proxyPort = addr.port;
+  });
+
+  after(async () => {
+    await proxy.close();
+    upstream.server.close();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  it("ro: GET passes and injects", async () => {
+    upstreamSeen.value = null;
+    const r = await rewriteRequest({ proxyPort, credname: "mail-ro", upstream, pathq: "/v1/messages" });
+    assert.equal(r.status, 200);
+    assert.equal(upstreamSeen.value.auth, "Bearer tok_READONLY");
+  });
+
+  it("ro: POST is refused with a structured 403 and the upstream is never hit", async () => {
+    upstreamSeen.value = null;
+    const r = await rewriteRequest({
+      proxyPort,
+      credname: "mail-ro",
+      upstream,
+      pathq: "/v1/messages/send",
+      method: "POST",
+      body: JSON.stringify({ to: "victim@example.com" }),
+    });
+    assert.equal(r.status, 403);
+    const err = JSON.parse(r.body);
+    assert.equal(err.error, "access_denied");
+    assert.equal(err.access, "ro");
+    assert.equal(upstreamSeen.value, null, "upstream must not see the blocked write");
+  });
+
+  it("ro: a GraphQL query POST is classified as a read and passes", async () => {
+    upstreamSeen.value = null;
+    const r = await rewriteRequest({
+      proxyPort,
+      credname: "mail-ro",
+      upstream,
+      pathq: "/graphql",
+      method: "POST",
+      body: JSON.stringify({ query: "query { inbox { subject } }" }),
+    });
+    assert.equal(r.status, 200);
+    assert.ok(upstreamSeen.value.body.includes("inbox"), "body forwarded intact");
+  });
+
+  it("ro: a GraphQL mutation POST is blocked", async () => {
+    upstreamSeen.value = null;
+    const r = await rewriteRequest({
+      proxyPort,
+      credname: "mail-ro",
+      upstream,
+      pathq: "/graphql",
+      method: "POST",
+      body: JSON.stringify({ query: "mutation { sendMail }" }),
+    });
+    assert.equal(r.status, 403);
+    assert.equal(upstreamSeen.value, null);
+  });
+
+  it("rules: an allow rule opens a specific POST; a deny rule closes a GET", async () => {
+    const ok = await rewriteRequest({
+      proxyPort,
+      credname: "ro-with-rules",
+      upstream,
+      pathq: "/search",
+      method: "POST",
+      body: '{"q":"hello"}',
+    });
+    assert.equal(ok.status, 200);
+
+    const denied = await rewriteRequest({
+      proxyPort,
+      credname: "ro-with-rules",
+      upstream,
+      pathq: "/admin/keys",
+    });
+    assert.equal(denied.status, 403);
+    assert.equal(JSON.parse(denied.body).error, "access_denied");
+  });
+
+  it("rw (default) is unaffected", async () => {
+    const r = await rewriteRequest({
+      proxyPort,
+      credname: "mail-rw",
+      upstream,
+      pathq: "/v1/messages/send",
+      method: "POST",
+      body: "{}",
+    });
+    assert.equal(r.status, 200);
+    assert.equal(upstreamSeen.value.auth, "Bearer tok_READWRITE");
+  });
+
+  it("stub mode: ro blocks non-read methods, allows GET", async () => {
+    const target = `http://${upstream.host}:${upstream.port}/v1/messages`;
+    const okGet = await stubRequest({
+      proxyPort,
+      target,
+      headers: { Authorization: "AgentVault mail-ro" },
+    });
+    assert.equal(okGet.status, 200);
+    assert.equal(upstreamSeen.value.auth, "Bearer tok_READONLY");
+
+    upstreamSeen.value = null;
+    const denied = await stubRequest({
+      proxyPort,
+      target,
+      method: "POST",
+      headers: { Authorization: "AgentVault mail-ro" },
+    });
+    assert.equal(denied.status, 403);
+    assert.equal(JSON.parse(denied.body).error, "access_denied");
+    assert.equal(upstreamSeen.value, null);
+  });
+
+  it("denials are audited, and the secret never reaches the log", async () => {
+    const log = await fs.readFile(logPath, "utf8");
+    assert.ok(log.includes('"event":"access_denied"'), "access_denied event logged");
+    assert.ok(log.includes('"credential":"mail-ro"'));
+    assert.ok(!log.includes("tok_READONLY"), "log leaked the secret");
+  });
+});

--- a/tests/test-proxy-access.mjs
+++ b/tests/test-proxy-access.mjs
@@ -41,7 +41,10 @@ function startUpstream() {
   });
 }
 
-// URL-rewrite mode request: /<credname>/<host:port>/<path>
+// URL-rewrite mode request: /<credname>/<host:port>/<path>. A body is sent with
+// an explicit Content-Length (as real JSON clients do) rather than chunked —
+// Node's own http client mis-reports the status when the server closes the
+// connection mid-chunked-upload, which is a client quirk, not proxy behavior.
 function rewriteRequest({ proxyPort, credname, upstream, pathq, method = "GET", body = null }) {
   return new Promise((resolve, reject) => {
     const req = http.request(
@@ -50,7 +53,13 @@ function rewriteRequest({ proxyPort, credname, upstream, pathq, method = "GET", 
         port: proxyPort,
         method,
         path: `/${credname}/${upstream.host}:${upstream.port}${pathq}`,
-        headers: body != null ? { "Content-Type": "application/json" } : {},
+        headers:
+          body != null
+            ? {
+                "Content-Type": "application/json",
+                "Content-Length": Buffer.byteLength(body),
+              }
+            : {},
       },
       (res) => {
         const chunks = [];
@@ -176,6 +185,21 @@ describe("proxy access-level enforcement", () => {
     });
     assert.equal(r.status, 200);
     assert.ok(upstreamSeen.value.body.includes("inbox"), "body forwarded intact");
+  });
+
+  it("ro: a DELETE with a read-shaped body is still blocked (only POST tunnels reads)", async () => {
+    upstreamSeen.value = null;
+    const r = await rewriteRequest({
+      proxyPort,
+      credname: "mail-ro",
+      upstream,
+      pathq: "/v1/messages/42",
+      method: "DELETE",
+      body: JSON.stringify({ query: "{ __typename }" }),
+    });
+    assert.equal(r.status, 403);
+    assert.equal(JSON.parse(r.body).error, "access_denied");
+    assert.equal(upstreamSeen.value, null, "the DELETE must never reach upstream");
   });
 
   it("ro: a GraphQL mutation POST is blocked", async () => {

--- a/tests/test-vault-set-access.mjs
+++ b/tests/test-vault-set-access.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+
+// CLI-level tests for the access-level lifecycle:
+//   - `set-access` tightens (rw→ro) with no ceremony
+//   - relaxing (ro→rw) requires the OWNER to confirm via the secure prompt;
+//     a wrong confirmation leaves the level unchanged
+//   - `add` refuses to widen an existing credential's level
+//   - `show` redacts and `exec` refuses secret fields of a ro credential
+//
+// Run: node --test tests/test-vault-set-access.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm, readFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { generateKeyPairSync } from "node:crypto";
+
+import { initVault, openVault } from "../plugins/agent-id-vault/lib/vault.mjs";
+import { writeJsonFile, statePaths } from "../plugins/agent-id-core/lib/state.mjs";
+import { fingerprintPublicKeyPem } from "../plugins/agent-id-core/lib/crypto.mjs";
+
+const CLI = new URL("../plugins/agent-id-vault/bin/cli.mjs", import.meta.url).pathname;
+
+async function makeVault(dir) {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const publicKeyPem = publicKey.export({ format: "pem", type: "spki" }).toString();
+  const privateKeyPem = privateKey.export({ format: "pem", type: "pkcs8" }).toString();
+  await writeJsonFile(statePaths(dir).mainKey, {
+    version: 1,
+    agentId: "main",
+    keyNonce: 0,
+    createdAt: 1,
+    publicKeyPem,
+    privateKeyPem,
+    fingerprint: fingerprintPublicKeyPem(publicKeyPem),
+  });
+  await initVault({ stateDir: dir, privateKeyPem, agentId: "main" });
+  return privateKeyPem;
+}
+
+function run(args, env = {}) {
+  return new Promise((resolve) => {
+    const child = spawn("node", [CLI, ...args], { env: { ...process.env, ...env } });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (d) => (stdout += d));
+    child.stderr.on("data", (d) => (stderr += d));
+    child.on("exit", (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+// Spawn the CLI and, when it prints the secure-form URL, submit `confirm` as
+// the human would.
+function runWithFormConfirm(args, confirm) {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [CLI, ...args], {
+      env: { ...process.env, AGENT_ID_NO_BROWSER: "1", AGENT_ID_SECURE_PROMPT: "browser" },
+    });
+    let stdout = "";
+    let stderr = "";
+    let submitted = false;
+    child.stdout.on("data", (d) => (stdout += d));
+    child.stderr.on("data", async (d) => {
+      stderr += d;
+      const m = stderr.match(/http:\/\/127\.0\.0\.1:\d+\/\?t=[a-f0-9]+/);
+      if (m && !submitted) {
+        submitted = true;
+        try {
+          const u = new URL(m[0]);
+          await fetch(`http://127.0.0.1:${u.port}/submit`, {
+            method: "POST",
+            body: new URLSearchParams({ _token: u.searchParams.get("t"), confirm }),
+          });
+        } catch (err) {
+          reject(err);
+        }
+      }
+    });
+    child.on("exit", (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+async function getRecord(dir, name) {
+  const { privateKeyPem } = JSON.parse(await readFile(statePaths(dir).mainKey, "utf8"));
+  const vault = await openVault({ stateDir: dir, privateKeyPem });
+  const rec = vault.get(name);
+  const copy = rec ? { ...rec } : null;
+  vault.lock();
+  return copy;
+}
+
+test("access-level lifecycle via the CLI", async (t) => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "setaccess-"));
+  try {
+    await makeVault(dir);
+
+    await t.test("add --access ro stores the level", async () => {
+      const r = await run(
+        ["add", "--name", "mail", "--type", "bearer", "--domains", "mail.example.com",
+         "--access", "ro", "--value-env", "TOK", "--state-dir", dir],
+        { TOK: "sekret_token_1" },
+      );
+      assert.equal(r.code, 0, r.stderr);
+      assert.equal(JSON.parse(r.stdout).access, "ro");
+    });
+
+    await t.test("show redacts a ro credential's secret", async () => {
+      const r = await run(["show", "--name", "mail", "--state-dir", dir]);
+      assert.equal(r.code, 0, r.stderr);
+      assert.ok(!r.stdout.includes("sekret_token_1"), "show leaked a ro secret");
+      assert.equal(JSON.parse(r.stdout).sealed, true);
+    });
+
+    await t.test("exec refuses a ro credential's secret field", async () => {
+      const r = await run([
+        "exec", "--env", "T=mail.value", "--state-dir", dir, "--", "node", "-e", "0",
+      ]);
+      assert.notEqual(r.code, 0);
+      assert.match(r.stderr + r.stdout, /access level 'ro'/);
+    });
+
+    await t.test("add cannot widen an existing ro credential", async () => {
+      const r = await run(
+        ["add", "--name", "mail", "--type", "bearer", "--domains", "mail.example.com",
+         "--access", "rw", "--value-env", "TOK", "--state-dir", dir],
+        { TOK: "attacker_supplied" },
+      );
+      assert.notEqual(r.code, 0);
+      assert.match(r.stderr + r.stdout, /widen|set-access/);
+      assert.equal((await getRecord(dir, "mail")).access, "ro");
+    });
+
+    await t.test("set-access relax with a WRONG confirmation is refused", async () => {
+      const r = await runWithFormConfirm(
+        ["set-access", "--name", "mail", "--access", "rw", "--state-dir", dir],
+        "not-the-name",
+      );
+      assert.notEqual(r.code, 0);
+      assert.match(r.stderr + r.stdout, /did not match/);
+      assert.equal((await getRecord(dir, "mail")).access, "ro");
+    });
+
+    await t.test("set-access relax with the owner's confirmation applies", async () => {
+      const r = await runWithFormConfirm(
+        ["set-access", "--name", "mail", "--access", "rw", "--state-dir", dir],
+        "mail",
+      );
+      assert.equal(r.code, 0, r.stderr);
+      assert.equal(JSON.parse(r.stdout).access, "rw");
+      assert.equal((await getRecord(dir, "mail")).access, "rw");
+    });
+
+    await t.test("set-access tighten needs no ceremony", async () => {
+      const r = await run(["set-access", "--name", "mail", "--access", "ro", "--state-dir", dir]);
+      assert.equal(r.code, 0, r.stderr);
+      assert.equal((await getRecord(dir, "mail")).access, "ro");
+    });
+
+    await t.test("set-access adding a deny rule needs no ceremony; an allow rule does", async () => {
+      const deny = await run([
+        "set-access", "--name", "mail",
+        "--rules", '[{"effect":"deny","methods":["GET"],"path":"/admin/*"}]',
+        "--state-dir", dir,
+      ]);
+      assert.equal(deny.code, 0, deny.stderr);
+
+      const allow = await runWithFormConfirm(
+        ["set-access", "--name", "mail",
+         "--rules", '[{"effect":"allow","methods":["POST"],"path":"/search"}]',
+         "--state-dir", dir],
+        "mail",
+      );
+      assert.equal(allow.code, 0, allow.stderr);
+      const rec = await getRecord(dir, "mail");
+      assert.equal(rec.accessRules.length, 1);
+      assert.equal(rec.accessRules[0].effect, "allow");
+    });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/test-vault-set-access.mjs
+++ b/tests/test-vault-set-access.mjs
@@ -118,7 +118,7 @@ test("access-level lifecycle via the CLI", async (t) => {
         "exec", "--env", "T=mail.value", "--state-dir", dir, "--", "node", "-e", "0",
       ]);
       assert.notEqual(r.code, 0);
-      assert.match(r.stderr + r.stdout, /access level 'ro'/);
+      assert.match(r.stderr + r.stdout, /access-restricted/);
     });
 
     await t.test("add cannot widen an existing ro credential", async () => {
@@ -177,6 +177,40 @@ test("access-level lifecycle via the CLI", async (t) => {
       assert.equal(rec.accessRules.length, 1);
       assert.equal(rec.accessRules[0].effect, "allow");
     });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("a rw credential with deny accessRules is sealed too (show redacts, exec refuses)", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "rwrules-"));
+  try {
+    await makeVault(dir);
+    // rw level, but a deny rule — the proxy enforces the rule, so the plaintext
+    // must not leak or the rule is theater.
+    const add = await run(
+      ["add", "--name", "svc", "--type", "bearer", "--domains", "api.svc.com",
+       "--value-env", "TOK", "--state-dir", dir],
+      { TOK: "rw_rules_secret" },
+    );
+    assert.equal(add.code, 0, add.stderr);
+    // Attach a deny rule (tightening → no ceremony).
+    const setr = await run([
+      "set-access", "--name", "svc",
+      "--rules", '[{"effect":"deny","methods":["POST","PUT","PATCH","DELETE"]}]',
+      "--state-dir", dir,
+    ]);
+    assert.equal(setr.code, 0, setr.stderr);
+
+    const show = await run(["show", "--name", "svc", "--state-dir", dir]);
+    assert.ok(!show.stdout.includes("rw_rules_secret"), "show leaked a rule-restricted secret");
+    assert.equal(JSON.parse(show.stdout).sealed, true);
+
+    const exec = await run([
+      "exec", "--env", "T=svc.value", "--state-dir", dir, "--", "node", "-e", "0",
+    ]);
+    assert.notEqual(exec.code, 0);
+    assert.match(exec.stderr + exec.stdout, /access-restricted/);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Per-credential access levels — "read my email, not write it"

Gives an agent a credential it can **read** with but not **write** with, for both
API credentials (proxy) and sealed web sessions (browser). Onboarding stays fully
automated — the user just adds `--access ro`; no OAuth app, no cloud project, no
settings toggles.

### What ships
- **Policy engine** (`@alien-id/agent-id-vault/lib/access.mjs`, new): records carry
  `access: "ro" | "rw"` (default `rw`) + optional ordered `accessRules`
  (`{effect, methods, hosts, path}`). `ro` allows `GET`/`HEAD`/`OPTIONS` and
  POST-tunneled reads it can classify (inline GraphQL `query`, JMAP `*/get`,
  known-read JSON-RPC). Default-deny: anything it can't prove is a read is blocked.
- **Proxy enforcement**: structured `403 access_denied` in both request modes,
  body-aware classification, audited denials.
- **Browser enforcement**: network-layer route gate on sealed `ro` sessions —
  writes abort at the wire; WebSockets/service-workers blocked (via
  `routeWebSocket`, evasion-proof); `eval`/`fill-secret`/`fill-otp` refused.
- **Lifecycle**: `set-access` changes the level — tightening is immediate,
  **widening requires the owner's out-of-band confirmation** on the secure form.
  `add`/`generate` refuse to widen; `show`/`exec` seal any restricted credential's
  plaintext so it can't be extracted to bypass the gate.

### Security hardening (two adversarial review rounds)
Multi-agent red-team review found and closed: a read-shaped body promoting
`DELETE`/`PUT`/`PATCH` (now POST-only classification); JSON-RPC default-allow (now
default-deny); order-blind relaxation; plaintext leak for `rw`+rules creds;
WebSocket block evadable from a Worker (now network-layer); and a GraphQL
multi-operation / `operationName` write bypass.

### Where it works (empirically tested)
Clean read/write split on REST-with-verbs, inline GraphQL, JMAP, and known
JSON-RPC. Fails **safe** (over-blocks, never silently allows a write) on
persisted-query GraphQL (Reddit/X web) and opaque binary RPC. Documented in the
skills, including the `--headed` note for bot-hostile sites.

### Tests
**511 passing**, ~45 new — policy units, proxy e2e (both modes), CLI lifecycle
with the owner-confirmation ceremony, and a **live real-Chrome** test
(`test-browser-ro-live.mjs`) proving a page's write is aborted while its read
passes. Also verified live on a real Reddit account (reads through, 29 real POST
writes blocked at the wire).

### Release
Changeset: `@alien-id/agent-id-vault` **minor** → 7.3.0. Core untouched; the
private proxy/browser plugins cascade their dep range automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
