### PR TITLE
feat(browser): human-like input (behavioural anti-detection layer)

### DIFF
--- a/plugins/agent-id-browser/lib/auto-login.mjs
+++ b/plugins/agent-id-browser/lib/auto-login.mjs
@@ -26,6 +26,19 @@
 import { generateTotp } from "@alien-id/agent-id-core/lib/totp.mjs";
 import { collectSecret } from "@alien-id/agent-id-core/lib/secure-prompt.mjs";
 import { classifyLogin } from "./login-detect.mjs";
+import { humanClick, humanDriver, humanType } from "./human-input.mjs";
+
+// Type a secret (password / OTP) with human cadence, guarding against a
+// keyboard/fill error that could echo the value — auto-login errors propagate to
+// the agent, so the raw error must never carry the secret. Mirrors the
+// session-server fill-secret guard.
+async function typeSecret(page, selector, value, opts = {}) {
+  try {
+    await humanType(page, selector, value, opts);
+  } catch {
+    throw new Error(`could not type into "${selector}" — element not visible/editable`);
+  }
+}
 
 const PLACEHOLDER_FIELDS = ["url", "value", "text", "selector", "key"];
 
@@ -58,7 +71,14 @@ export function stepNeedsOtp(step) {
  * the first time a step needs it (so a recipe whose login fails before the OTP
  * step never prompts). Actions: navigate, fill, type, click, press, wait.
  */
-export async function runRecipe(page, steps, { username, password, getOtp }) {
+// `driver` maps the action vocabulary to page interactions; it defaults to the
+// human-input driver (curved motion, key-by-key typing) and is injectable so the
+// mapping/{otp}-lazy-resolution logic unit-tests without a browser.
+export async function runRecipe(
+  page,
+  steps,
+  { username, password, getOtp, driver = humanDriver },
+) {
   let otp;
   const sub = async (s) => {
     if (typeof s !== "string") return s;
@@ -68,22 +88,22 @@ export async function runRecipe(page, steps, { username, password, getOtp }) {
   for (const step of steps) {
     switch (step.action) {
       case "navigate":
-        await page.goto(await sub(step.url), { waitUntil: "domcontentloaded", timeout: 30000 });
+        await driver.navigate(page, await sub(step.url));
         break;
       case "fill":
-        await page.fill(await sub(step.selector), await sub(step.value));
+        await driver.fill(page, await sub(step.selector), await sub(step.value));
         break;
       case "type": // alias of fill (kept for parity with the session vocabulary)
-        await page.fill(await sub(step.selector), await sub(step.text));
+        await driver.type(page, await sub(step.selector), await sub(step.text));
         break;
       case "click":
-        await page.click(await sub(step.selector));
+        await driver.click(page, await sub(step.selector));
         break;
       case "press":
-        await page.press(await sub(step.selector), step.key || "Enter");
+        await driver.press(page, await sub(step.selector), step.key || "Enter");
         break;
       case "wait":
-        await page.waitForTimeout(Number(step.ms) || 1000);
+        await driver.wait(page, Number(step.ms) || 1000);
         break;
       default:
         throw new Error(`unknown recipe action: ${step.action}`);
@@ -142,15 +162,16 @@ async function typeOtp(page, code) {
     'input[autocomplete="one-time-code"], input[name*="otp" i], input[id*="otp" i], ' +
     'input[name*="code" i], input[id*="code" i], input[name*="verif" i], input[id*="verif" i], ' +
     'input[inputmode="numeric"]';
-  const loc = page.locator(sel).first();
-  await loc.fill(code);
+  // The OTP code is low-sensitivity (single-use, seconds-lived) but still typed
+  // with human cadence and the value-free error guard, for consistency.
+  await typeSecret(page, sel, code);
   // ADFS / Entra submit via a button; generic forms submit on Enter.
   if (await page.locator("#submitButton").count()) {
-    await page.locator("#submitButton").click().catch(() => {});
+    await humanClick(page, "#submitButton").catch(() => {});
   } else if (await page.locator("#idSubmit_SAOTCC_Continue").count()) {
-    await page.locator("#idSubmit_SAOTCC_Continue").click().catch(() => {});
+    await humanClick(page, "#idSubmit_SAOTCC_Continue").catch(() => {});
   } else {
-    await loc.press("Enter").catch(() => {});
+    await page.locator(sel).first().press("Enter").catch(() => {});
   }
 }
 
@@ -174,15 +195,18 @@ async function detectMicrosoftFlow(page) {
 async function clickIfPresent(page, selector) {
   const loc = page.locator(selector).first();
   if (await loc.count()) {
-    await loc.click({ timeout: 8000 }).catch(() => {});
+    await humanClick(page, selector, { timeout: 8000 }).catch(() => {});
     return true;
   }
   return false;
 }
 
-async function fillWhenVisible(page, selector, value, timeout = 15000) {
+// Fill a field with human cadence once it's visible. `secret:true` routes through
+// the value-free error guard (for passwords).
+async function fillWhenVisible(page, selector, value, { timeout = 15000, secret = false } = {}) {
   await page.waitForSelector(selector, { state: "visible", timeout }).catch(() => {});
-  await page.fill(selector, value);
+  if (secret) await typeSecret(page, selector, value, { timeout });
+  else await humanType(page, selector, value, { timeout });
 }
 
 // Drive a Microsoft ADFS or Entra forms login: username → (Next) → password →
@@ -195,7 +219,7 @@ export async function microsoftLogin(page, cred, log = () => {}) {
     log("Detected Microsoft Entra (Azure AD) login");
     await fillWhenVisible(page, 'input[name="loginfmt"]', cred.username);
     await clickIfPresent(page, "#idSIButton9"); // Next
-    await fillWhenVisible(page, 'input[name="passwd"]', cred.password);
+    await fillWhenVisible(page, 'input[name="passwd"]', cred.password, { secret: true });
     await clickIfPresent(page, "#idSIButton9"); // Sign in
     return;
   }
@@ -203,7 +227,7 @@ export async function microsoftLogin(page, cred, log = () => {}) {
   await fillWhenVisible(page, "#userNameInput", cred.username);
   // Paginated ADFS: a "Next" button reveals the password page.
   if (await page.locator("#nextButton").count()) await clickIfPresent(page, "#nextButton");
-  await fillWhenVisible(page, "#passwordInput", cred.password);
+  await fillWhenVisible(page, "#passwordInput", cred.password, { secret: true });
   const kmsi = page.locator("#kmsiInput"); // "keep me signed in", if offered
   if (await kmsi.count()) await kmsi.check().catch(() => {});
   await clickIfPresent(page, "#submitButton");
@@ -219,11 +243,12 @@ async function heuristicLogin(page, { username, password }) {
     'input[id*="user" i], input[id*="email" i], input[autocomplete="username"], input[type="text"]';
   const pwSel = 'input[type="password"]';
 
-  const fillFirst = async (sel, value) => {
+  const fillFirst = async (sel, value, secret = false) => {
     const loc = page.locator(sel).first();
     if ((await loc.count()) === 0) return false;
     if (!(await loc.isVisible().catch(() => false))) return false;
-    await loc.fill(value);
+    if (secret) await typeSecret(page, sel, value);
+    else await humanType(page, sel, value);
     return true;
   };
 
@@ -233,7 +258,7 @@ async function heuristicLogin(page, { username, password }) {
     await page.keyboard.press("Enter").catch(() => {});
     await page.waitForTimeout(1500);
   }
-  const filledPw = await fillFirst(pwSel, password);
+  const filledPw = await fillFirst(pwSel, password, true);
   if (filledPw) await page.locator(pwSel).first().press("Enter").catch(() => {});
 }
 

--- a/plugins/agent-id-browser/lib/auto-login.mjs
+++ b/plugins/agent-id-browser/lib/auto-login.mjs
@@ -85,16 +85,33 @@ export async function runRecipe(
     if (s.includes("{otp}") && otp === undefined) otp = await getOtp();
     return applyVars(s, { username, password, otp });
   };
+  // A step whose template injects the password/otp must never surface the raw
+  // value in an error (the recipe path is otherwise unguarded, unlike the
+  // heuristic/Microsoft fills). Run it under a value-free catch.
+  const carriesSecret = (tpl) =>
+    typeof tpl === "string" && (tpl.includes("{password}") || tpl.includes("{otp}"));
+  const guarded = async (tpl, run) => {
+    if (!carriesSecret(tpl)) return run();
+    try {
+      return await run();
+    } catch {
+      throw new Error(`recipe step '${tpl}' failed while entering a secret value`);
+    }
+  };
   for (const step of steps) {
     switch (step.action) {
       case "navigate":
         await driver.navigate(page, await sub(step.url));
         break;
       case "fill":
-        await driver.fill(page, await sub(step.selector), await sub(step.value));
+        await guarded(step.value, async () =>
+          driver.fill(page, await sub(step.selector), await sub(step.value)),
+        );
         break;
       case "type": // alias of fill (kept for parity with the session vocabulary)
-        await driver.type(page, await sub(step.selector), await sub(step.text));
+        await guarded(step.text, async () =>
+          driver.type(page, await sub(step.selector), await sub(step.text)),
+        );
         break;
       case "click":
         await driver.click(page, await sub(step.selector));

--- a/plugins/agent-id-browser/lib/human-input.mjs
+++ b/plugins/agent-id-browser/lib/human-input.mjs
@@ -107,19 +107,23 @@ async function locate(page, selector, timeout) {
   return el;
 }
 
-// Move to an element and click it with a natural press dwell. Falls back to a
-// plain click if the element has no box (e.g. zero-size wrapper).
+// Click an element with a human cursor approach. The curved humanMove supplies
+// the behavioural signal (real mousemove trail + arrival dwell); the actual
+// click goes through the actionability-checked locator.click(), which auto-waits
+// for the element to be visible/stable and to actually receive the event (it
+// retries under overlays / sticky headers). Doing the click by raw page.mouse at
+// a coordinate would skip those checks and silently miss when anything covers
+// the point — so we keep the human motion but not the fragile raw click.
 export async function humanClick(page, selector, { rng = Math.random, timeout = 15000 } = {}) {
   if (!humanInputEnabled()) return void (await page.click(selector, { timeout }));
   const el = await locate(page, selector, timeout);
-  const box = await el.boundingBox();
-  if (!box) return void (await el.click({ timeout }));
-  const { x, y } = pointInBox(box, rng);
-  await humanMove(page, x, y, { rng });
-  await wait(page, 30 + rng() * 90);
-  await page.mouse.down();
-  await wait(page, 20 + rng() * 60);
-  await page.mouse.up();
+  const box = await el.boundingBox().catch(() => null);
+  if (box) {
+    const { x, y } = pointInBox(box, rng);
+    await humanMove(page, x, y, { rng });
+    await wait(page, 30 + rng() * 90); // arrival dwell before the press
+  }
+  await el.click({ timeout });
 }
 
 // Focus an element (by clicking it) and type text key-by-key with human cadence.
@@ -139,10 +143,13 @@ export async function humanType(
     return;
   }
   await humanClick(page, selector, { rng, timeout });
-  // Replace existing content (parity with fill()): select it so the first
-  // keystroke overwrites rather than appends. Best-effort — an empty or
-  // non-selectable field just types normally.
-  await page.locator(selector).first().selectText({ timeout }).catch(() => {});
+  // Deterministic replace (parity with fill): clear the field first — fill("")
+  // is actionability-checked and always empties, so the subsequent keystrokes
+  // never append to stale content, and an empty `value` clears correctly. NOT
+  // swallowed: if the field can't be cleared we must fail rather than type into
+  // (and corrupt) leftover content — the secret paths wrap this in a value-free
+  // catch, so a throw never leaks the value.
+  await page.locator(selector).first().fill("", { timeout });
   const delays = keystrokeDelays(value.length, { rng });
   for (let i = 0; i < value.length; i++) {
     await page.keyboard.type(value[i]);

--- a/plugins/agent-id-browser/lib/human-input.mjs
+++ b/plugins/agent-id-browser/lib/human-input.mjs
@@ -1,0 +1,206 @@
+// Alien Agent ID — Human-like input.
+//
+// Why this exists: the network + fingerprint layers of bot detection are already
+// solved for us — we drive the user's REAL Chrome, on their real profile, from
+// their real residential IP, so TLS/HTTP2/fingerprint/IP all authenticate as the
+// human (see lib/launch.mjs). Per the 2026 detection literature that leaves ONE
+// residual signal: behaviour. Driving a page with instantaneous synthetic events
+// (page.fill / page.click with no cursor trajectory and fixed pacing) is the
+// textbook bot signature — and it fires HARDER precisely because the rest of the
+// environment is pristine (pristine fingerprint + robotic motion is itself the
+// anomaly). This module replaces those with human-shaped motion and typing:
+//   - the cursor travels a curved (Bézier) path and dwells before a click,
+//   - text is typed key-by-key with jittered, occasionally-paused cadence,
+//   - scrolls are broken into eased wheel steps.
+//
+// The geometry/timing helpers are pure (injectable rng) so they unit-test with no
+// browser; the driving functions take a patchright Page.
+//
+// Escape hatch: set AGENT_ID_HUMAN_INPUT=0 to fall back to fast direct calls
+// (for speed-sensitive automation or debugging).
+
+export function humanInputEnabled() {
+  return process.env.AGENT_ID_HUMAN_INPUT !== "0";
+}
+
+// ─── Pure geometry / timing (unit-tested) ─────────────────────────────────────
+
+export function randBetween(min, max, rng = Math.random) {
+  return min + (max - min) * rng();
+}
+
+// A quadratic Bézier path from `from` to `to`, with the control point pushed
+// off the straight line (perpendicular, magnitude scaled to distance + jitter)
+// so the cursor arcs like a hand rather than sliding on a rail. Returns the
+// ordered waypoints AFTER `from` (the cursor is assumed already at `from`); the
+// final point is exactly `to`. Step count scales with distance.
+export function bezierPath(from, to, { rng = Math.random, maxSteps = 26 } = {}) {
+  const dx = to.x - from.x;
+  const dy = to.y - from.y;
+  const dist = Math.hypot(dx, dy) || 1;
+  const mx = (from.x + to.x) / 2;
+  const my = (from.y + to.y) / 2;
+  // Perpendicular unit vector × a signed, distance-bounded arc magnitude.
+  const px = -dy / dist;
+  const py = dx / dist;
+  const arc = (rng() - 0.5) * Math.min(dist * 0.3, 120);
+  const cx = mx + px * arc;
+  const cy = my + py * arc;
+  const steps = Math.max(3, Math.min(maxSteps, Math.round(dist / 12) + 4));
+  const pts = [];
+  for (let i = 1; i <= steps; i++) {
+    const t = i / steps;
+    const u = 1 - t;
+    pts.push({
+      x: u * u * from.x + 2 * u * t * cx + t * t * to.x,
+      y: u * u * from.y + 2 * u * t * cy + t * t * to.y,
+    });
+  }
+  return pts;
+}
+
+// Per-keystroke delays (ms): a human-ish base (≈45–120ms) with an occasional
+// longer "think" pause. One entry per character.
+export function keystrokeDelays(length, { rng = Math.random } = {}) {
+  const out = [];
+  for (let i = 0; i < length; i++) {
+    let d = 45 + rng() * 75;
+    if (rng() < 0.08) d += 120 + rng() * 220; // ~8% get a think-pause
+    out.push(Math.round(d));
+  }
+  return out;
+}
+
+// A slightly off-centre point inside a bounding box (real clicks rarely hit the
+// exact centre). Box is {x, y, width, height}.
+export function pointInBox(box, rng = Math.random) {
+  return {
+    x: box.x + box.width * (0.3 + rng() * 0.4),
+    y: box.y + box.height * (0.3 + rng() * 0.4),
+  };
+}
+
+// ─── Page-driving functions (need a real patchright Page) ─────────────────────
+
+// Track the virtual cursor position per page so successive moves start where the
+// last one ended (the cursor doesn't teleport between actions).
+const lastPos = new WeakMap();
+
+const wait = (page, ms) => page.waitForTimeout(Math.max(0, Math.round(ms)));
+
+// Move the cursor along a curved path to (x, y), emitting real mousemove events.
+export async function humanMove(page, x, y, { rng = Math.random } = {}) {
+  const from = lastPos.get(page) || { x: 6 + rng() * 40, y: 6 + rng() * 40 };
+  const pts = bezierPath(from, { x, y }, { rng });
+  for (const pt of pts) {
+    await page.mouse.move(pt.x, pt.y);
+    if (rng() < 0.5) await wait(page, 4 + rng() * 12); // human motion isn't uniform
+  }
+  lastPos.set(page, { x, y });
+}
+
+// Resolve a selector to a first visible element, scrolled into view.
+async function locate(page, selector, timeout) {
+  const el = page.locator(selector).first();
+  await el.waitFor({ state: "visible", timeout });
+  await el.scrollIntoViewIfNeeded({ timeout }).catch(() => {});
+  return el;
+}
+
+// Move to an element and click it with a natural press dwell. Falls back to a
+// plain click if the element has no box (e.g. zero-size wrapper).
+export async function humanClick(page, selector, { rng = Math.random, timeout = 15000 } = {}) {
+  if (!humanInputEnabled()) return void (await page.click(selector, { timeout }));
+  const el = await locate(page, selector, timeout);
+  const box = await el.boundingBox();
+  if (!box) return void (await el.click({ timeout }));
+  const { x, y } = pointInBox(box, rng);
+  await humanMove(page, x, y, { rng });
+  await wait(page, 30 + rng() * 90);
+  await page.mouse.down();
+  await wait(page, 20 + rng() * 60);
+  await page.mouse.up();
+}
+
+// Focus an element (by clicking it) and type text key-by-key with human cadence.
+// `submit` presses Enter afterwards. NOTE: callers injecting a secret must wrap
+// this in their own try/catch that emits a value-free error — an underlying
+// keyboard error can echo the character being typed.
+export async function humanType(
+  page,
+  selector,
+  text,
+  { rng = Math.random, timeout = 15000, submit = false } = {},
+) {
+  const value = String(text ?? "");
+  if (!humanInputEnabled()) {
+    await page.fill(selector, value, { timeout });
+    if (submit) await page.press(selector, "Enter");
+    return;
+  }
+  await humanClick(page, selector, { rng, timeout });
+  // Replace existing content (parity with fill()): select it so the first
+  // keystroke overwrites rather than appends. Best-effort — an empty or
+  // non-selectable field just types normally.
+  await page.locator(selector).first().selectText({ timeout }).catch(() => {});
+  const delays = keystrokeDelays(value.length, { rng });
+  for (let i = 0; i < value.length; i++) {
+    await page.keyboard.type(value[i]);
+    await wait(page, delays[i]);
+  }
+  if (submit) {
+    await wait(page, 80 + rng() * 160);
+    await page.keyboard.press("Enter");
+  }
+}
+
+export async function humanHover(page, selector, { rng = Math.random, timeout = 15000 } = {}) {
+  if (!humanInputEnabled()) return void (await page.hover(selector, { timeout }));
+  const el = await locate(page, selector, timeout);
+  const box = await el.boundingBox();
+  if (!box) return void (await el.hover({ timeout }));
+  const { x, y } = pointInBox(box, rng);
+  await humanMove(page, x, y, { rng });
+}
+
+// Break a scroll into a few eased wheel steps with short pauses.
+export async function humanScroll(page, dx, dy, { rng = Math.random } = {}) {
+  const totalY = Number(dy) || 0;
+  const totalX = Number(dx) || 0;
+  if (!humanInputEnabled() || (totalY === 0 && totalX === 0)) {
+    return void (await page.mouse.wheel(totalX, totalY));
+  }
+  const steps = Math.max(2, Math.min(6, Math.round(Math.abs(totalY || totalX) / 220) + 2));
+  let sentX = 0;
+  let sentY = 0;
+  for (let i = 1; i <= steps; i++) {
+    const t = i / steps;
+    const targetY = Math.round(totalY * t);
+    const targetX = Math.round(totalX * t);
+    await page.mouse.wheel(targetX - sentX, targetY - sentY);
+    sentX = targetX;
+    sentY = targetY;
+    await wait(page, 40 + rng() * 90);
+  }
+}
+
+// A small pre-press dwell, then the key. For submitting a field, etc.
+export async function humanPress(page, selector, key, { rng = Math.random, timeout = 15000 } = {}) {
+  await wait(page, 40 + rng() * 120);
+  if (selector) await page.press(selector, key, { timeout });
+  else await page.keyboard.press(key);
+}
+
+// ─── Driver: the surface auto-login's recipe engine uses (injectable for tests) ─
+//
+// Maps the recipe action vocabulary to human-input calls behind one object, so
+// runRecipe stays testable (tests pass a recording driver) while production uses
+// real human motion.
+export const humanDriver = {
+  navigate: (page, url) => page.goto(url, { waitUntil: "domcontentloaded", timeout: 30000 }),
+  fill: (page, selector, value) => humanType(page, selector, value),
+  type: (page, selector, value) => humanType(page, selector, value),
+  click: (page, selector) => humanClick(page, selector),
+  press: (page, selector, key) => humanPress(page, selector, key),
+  wait: (page, ms) => page.waitForTimeout(ms),
+};

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -31,6 +31,12 @@ import {
   assertActionAllowed,
   contextOptionsForAccess,
 } from "./access-guard.mjs";
+import {
+  humanClick,
+  humanHover,
+  humanScroll,
+  humanType,
+} from "./human-input.mjs";
 
 function sessionsDir(stateDir) {
   return path.join(stateDir, "browser-sessions");
@@ -151,15 +157,19 @@ async function dispatch(page, msg, policy = null) {
     case "text":
       return { text: String(await page.evaluate(() => (document.body ? document.body.innerText : ""))).slice(0, Number(p.maxChars || 6000)) };
     case "click":
-      await page.click(sel(p.ref), { timeout: ACTION_TIMEOUT });
+      await humanClick(page, sel(p.ref), { timeout: ACTION_TIMEOUT });
       return { clicked: p.ref };
     case "type":
-      await page.fill(sel(p.ref), String(p.text ?? ""), { timeout: ACTION_TIMEOUT });
-      if (p.submit) await page.press(sel(p.ref), "Enter");
+      await humanType(page, sel(p.ref), String(p.text ?? ""), {
+        timeout: ACTION_TIMEOUT,
+        submit: !!p.submit,
+      });
       return { typed: p.ref, submit: !!p.submit };
     case "fill": {
       const fields = Array.isArray(p.fields) ? p.fields : [];
-      for (const f of fields) await page.fill(sel(f.ref), String(f.value ?? ""), { timeout: ACTION_TIMEOUT });
+      for (const f of fields) {
+        await humanType(page, sel(f.ref), String(f.value ?? ""), { timeout: ACTION_TIMEOUT });
+      }
       return { filled: fields.map((f) => f.ref) };
     }
     case "fill-secret": {
@@ -181,11 +191,10 @@ async function dispatch(page, msg, policy = null) {
         if (typeof value !== "string" || !value) {
           throw new Error(`"${credName}.${field}" is not a usable string field`);
         }
-        // CRITICAL: patchright's fill/press errors echo the value being typed, so
+        // CRITICAL: a fill/keyboard error can echo the value being typed, so
         // never let the raw error escape — it would leak the secret to the agent.
         try {
-          await page.fill(sel(p.ref), value, { timeout: ACTION_TIMEOUT });
-          if (p.submit) await page.press(sel(p.ref), "Enter");
+          await humanType(page, sel(p.ref), value, { timeout: ACTION_TIMEOUT, submit: !!p.submit });
         } catch {
           throw new Error(`fill-secret: could not fill "${p.ref}" — element not visible/editable (re-snapshot and retry)`);
         }
@@ -215,8 +224,10 @@ async function dispatch(page, msg, policy = null) {
       }
       // Same leak guard as fill-secret: never surface the value-bearing error.
       try {
-        await page.fill(sel(p.ref), code, { timeout: ACTION_TIMEOUT });
-        if (p.submit !== false) await page.press(sel(p.ref), "Enter");
+        await humanType(page, sel(p.ref), code, {
+          timeout: ACTION_TIMEOUT,
+          submit: p.submit !== false,
+        });
       } catch {
         throw new Error(`fill-otp: could not fill "${p.ref}" — element not visible/editable (re-snapshot and retry)`);
       }
@@ -226,14 +237,14 @@ async function dispatch(page, msg, policy = null) {
       await page.selectOption(sel(p.ref), p.values, { timeout: ACTION_TIMEOUT });
       return { selected: p.ref };
     case "hover":
-      await page.hover(sel(p.ref), { timeout: ACTION_TIMEOUT });
+      await humanHover(page, sel(p.ref), { timeout: ACTION_TIMEOUT });
       return { hovered: p.ref };
     case "press":
       if (p.ref) await page.press(sel(p.ref), String(p.key));
       else await page.keyboard.press(String(p.key));
       return { pressed: p.key };
     case "scroll":
-      await page.mouse.wheel(Number(p.dx || 0), Number(p.dy || 600));
+      await humanScroll(page, Number(p.dx || 0), Number(p.dy || 600));
       return { scrolled: true };
     case "screenshot": {
       const out = p.path ? String(p.path) : path.join(sessionsDir(msg._stateDir), `shot-${Date.now()}.png`);

--- a/plugins/agent-id-browser/skills/agent-id-browser/SKILL.md
+++ b/plugins/agent-id-browser/skills/agent-id-browser/SKILL.md
@@ -256,4 +256,11 @@ return `"sessionExpired": true` with `"action": "re_login"`. On that signal,
   `AGENT_ID_SECURE_PROMPT=browser|tty|hosted` pins a backend.
 - The session is unsealed to a temp working dir only while a session/read runs,
   re-sealed (capturing new logins + rotated cookies) when it ends, and wiped.
+- **Human-like input.** `click`/`type`/`fill`/`hover`/`scroll` (and auto-login's
+  form filling) drive the page with real cursor travel and key-by-key typing
+  rather than instantaneous synthetic events — because you're a real Chrome on
+  the user's real IP, behaviour is the only residual bot signal, and robotic
+  motion against a pristine fingerprint is itself the tell. It costs a little
+  time per action; set `AGENT_ID_HUMAN_INPUT=0` to fall back to fast direct
+  input when a site isn't bot-hostile and speed matters.
 - Universal — point it at any site; not Gmail-specific.

--- a/tests/test-auto-login.mjs
+++ b/tests/test-auto-login.mjs
@@ -23,15 +23,21 @@ test("stepNeedsOtp detects {otp} in a placeholder field", () => {
   assert.equal(stepNeedsOtp({ action: "fill", selector: "#pw", value: "{password}" }), false);
 });
 
-test("runRecipe maps steps to page calls, substitutes vars, resolves {otp} once and lazily", async () => {
-  const calls = [];
-  const page = {
-    goto: async (url) => calls.push(["goto", url]),
-    fill: async (sel, val) => calls.push(["fill", sel, val]),
-    click: async (sel) => calls.push(["click", sel]),
-    press: async (sel, key) => calls.push(["press", sel, key]),
-    waitForTimeout: async (ms) => calls.push(["wait", ms]),
+// A recording driver stands in for the human-input driver so the recipe
+// mapping / var-substitution / lazy-OTP logic is tested without a browser.
+function recordingDriver(calls) {
+  return {
+    navigate: async (_p, url) => calls.push(["goto", url]),
+    fill: async (_p, sel, val) => calls.push(["fill", sel, val]),
+    type: async (_p, sel, val) => calls.push(["type", sel, val]),
+    click: async (_p, sel) => calls.push(["click", sel]),
+    press: async (_p, sel, key) => calls.push(["press", sel, key]),
+    wait: async (_p, ms) => calls.push(["wait", ms]),
   };
+}
+
+test("runRecipe maps steps to driver calls, substitutes vars, resolves {otp} once and lazily", async () => {
+  const calls = [];
   let otpCalls = 0;
   const getOtp = async () => {
     otpCalls++;
@@ -45,7 +51,12 @@ test("runRecipe maps steps to page calls, substitutes vars, resolves {otp} once 
     { action: "fill", selector: "#otp", value: "{otp}" },
     { action: "press", selector: "#otp", key: "Enter" },
   ];
-  await runRecipe(page, steps, { username: "alice", password: "s3cret", getOtp });
+  await runRecipe({}, steps, {
+    username: "alice",
+    password: "s3cret",
+    getOtp,
+    driver: recordingDriver(calls),
+  });
   assert.deepEqual(calls, [
     ["goto", "https://x/login"],
     ["fill", "#user", "alice"],
@@ -58,26 +69,26 @@ test("runRecipe maps steps to page calls, substitutes vars, resolves {otp} once 
 });
 
 test("runRecipe does not resolve OTP when no step needs it", async () => {
-  const noop = async () => {};
-  const page = { goto: noop, fill: noop, click: noop, press: noop, waitForTimeout: noop };
   let otpCalls = 0;
-  await runRecipe(page, [{ action: "fill", selector: "#u", value: "{username}" }], {
+  await runRecipe({}, [{ action: "fill", selector: "#u", value: "{username}" }], {
     username: "u",
     password: "p",
     getOtp: async () => {
       otpCalls++;
       return "x";
     },
+    driver: recordingDriver([]),
   });
   assert.equal(otpCalls, 0);
 });
 
 test("runRecipe rejects an unknown action", async () => {
   await assert.rejects(
-    runRecipe({ goto: async () => {} }, [{ action: "frobnicate" }], {
+    runRecipe({}, [{ action: "frobnicate" }], {
       username: "u",
       password: "p",
       getOtp: async () => "",
+      driver: recordingDriver([]),
     }),
     /unknown recipe action/,
   );

--- a/tests/test-human-input-live.mjs
+++ b/tests/test-human-input-live.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+
+// LIVE test that human-input produces real human-shaped events in a real browser:
+//   - a click is preceded by mousemove events (the cursor travels), not a
+//     teleport-and-click (the classic bot signature),
+//   - text is entered key-by-key (per-character keydown events), not pasted.
+// Skips automatically when patchright / Chrome are not installed.
+//
+// Run: node --test tests/test-human-input-live.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs/promises";
+
+import { resolvePatchright, launchContext } from "../plugins/agent-id-browser/lib/launch.mjs";
+import { humanClick, humanType } from "../plugins/agent-id-browser/lib/human-input.mjs";
+
+const patchrightAvailable = !!resolvePatchright();
+
+const PAGE = `<!doctype html><meta charset=utf-8><title>t</title>
+<input id="inp" type="text"><button id="btn">Go</button>`;
+
+// Install the event recorder in the live document (an inline <script> in
+// setContent doesn't reliably execute under the stealth context).
+async function installRecorder(page) {
+  await page.evaluate(() => {
+    window.__ev = { mousemoves: 0, clicks: 0, keys: [] };
+    document.addEventListener("mousemove", () => window.__ev.mousemoves++);
+    document.getElementById("btn").addEventListener("click", () => window.__ev.clicks++);
+    document.getElementById("inp").addEventListener("keydown", (e) => window.__ev.keys.push(e.key));
+  });
+}
+
+test(
+  "human input emits mousemoves before a click and types key-by-key (real Chrome)",
+  { skip: patchrightAvailable ? false : "patchright/Chrome not installed" },
+  async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "human-live-"));
+    let ctx;
+    try {
+      ctx = await launchContext({ profileDir: dir, headless: true });
+      const page = ctx.pages()[0] || (await ctx.newPage());
+      await page.setContent(PAGE);
+      await installRecorder(page);
+
+      // Pre-fill the field so we also verify humanType REPLACES (like fill did),
+      // not appends.
+      await page.evaluate(() => {
+        document.getElementById("inp").value = "STALE";
+      });
+
+      // Type into the field: focuses via a human click (→ mousemoves) then types.
+      await humanType(page, "#inp", "hello");
+      const afterType = await page.evaluate(() => ({
+        value: document.getElementById("inp").value,
+        mousemoves: window.__ev.mousemoves,
+        keys: window.__ev.keys.slice(),
+      }));
+      assert.equal(afterType.value, "hello", "the field received the typed text");
+      assert.ok(afterType.mousemoves > 0, "the cursor moved before focusing (no teleport)");
+      assert.deepEqual(afterType.keys, ["h", "e", "l", "l", "o"], "each character produced a keydown");
+
+      // Click the button: cursor should travel further before the click lands.
+      await humanClick(page, "#btn");
+      const afterClick = await page.evaluate(() => window.__ev);
+      assert.equal(afterClick.clicks, 1, "the button was clicked exactly once");
+      assert.ok(
+        afterClick.mousemoves > afterType.mousemoves,
+        "more mousemove events fired on the way to the button",
+      );
+    } finally {
+      if (ctx) await ctx.close().catch(() => {});
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    }
+  },
+);
+
+test(
+  "AGENT_ID_HUMAN_INPUT=0 falls back to a direct fill (still works, no motion required)",
+  { skip: patchrightAvailable ? false : "patchright/Chrome not installed" },
+  async () => {
+    const prev = process.env.AGENT_ID_HUMAN_INPUT;
+    process.env.AGENT_ID_HUMAN_INPUT = "0";
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "human-off-"));
+    let ctx;
+    try {
+      ctx = await launchContext({ profileDir: dir, headless: true });
+      const page = ctx.pages()[0] || (await ctx.newPage());
+      await page.setContent(PAGE);
+      await installRecorder(page);
+      await humanType(page, "#inp", "abc");
+      assert.equal(await page.evaluate(() => document.getElementById("inp").value), "abc");
+    } finally {
+      if (prev === undefined) delete process.env.AGENT_ID_HUMAN_INPUT;
+      else process.env.AGENT_ID_HUMAN_INPUT = prev;
+      if (ctx) await ctx.close().catch(() => {});
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    }
+  },
+);

--- a/tests/test-human-input-live.mjs
+++ b/tests/test-human-input-live.mjs
@@ -58,9 +58,23 @@ test(
         mousemoves: window.__ev.mousemoves,
         keys: window.__ev.keys.slice(),
       }));
-      assert.equal(afterType.value, "hello", "the field received the typed text");
+      assert.equal(afterType.value, "hello", "the field received the typed text (replaced, not appended)");
       assert.ok(afterType.mousemoves > 0, "the cursor moved before focusing (no teleport)");
-      assert.deepEqual(afterType.keys, ["h", "e", "l", "l", "o"], "each character produced a keydown");
+      // Each character produced its own keydown (the leading Delete is the
+      // clear-before-type step; filter to the single-character keys).
+      assert.deepEqual(
+        afterType.keys.filter((k) => k.length === 1),
+        ["h", "e", "l", "l", "o"],
+        "each character produced a keydown",
+      );
+
+      // Empty value must CLEAR the field (parity with fill), not leave it.
+      await humanType(page, "#inp", "");
+      assert.equal(
+        await page.evaluate(() => document.getElementById("inp").value),
+        "",
+        "typing an empty string clears the field",
+      );
 
       // Click the button: cursor should travel further before the click lands.
       await humanClick(page, "#btn");

--- a/tests/test-human-input.mjs
+++ b/tests/test-human-input.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+
+// Unit tests for the pure geometry/timing helpers behind human-like input
+// (lib/human-input.mjs). No browser — deterministic via an injected rng.
+//
+// Run: node --test tests/test-human-input.mjs
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  bezierPath,
+  keystrokeDelays,
+  pointInBox,
+  randBetween,
+} from "../plugins/agent-id-browser/lib/human-input.mjs";
+
+// Deterministic rng: a fixed repeating sequence so assertions are stable.
+function seq(values) {
+  let i = 0;
+  return () => values[i++ % values.length];
+}
+
+describe("bezierPath", () => {
+  it("ends exactly at the target and starts moving away from the origin", () => {
+    const from = { x: 0, y: 0 };
+    const to = { x: 300, y: 120 };
+    const pts = bezierPath(from, to, { rng: seq([0.5]) });
+    assert.ok(pts.length >= 3, "should have several waypoints");
+    const last = pts[pts.length - 1];
+    assert.ok(Math.abs(last.x - to.x) < 1e-6 && Math.abs(last.y - to.y) < 1e-6, "last point is the target");
+    // first waypoint is past the origin, not the origin itself
+    assert.ok(pts[0].x !== from.x || pts[0].y !== from.y);
+  });
+
+  it("arcs off the straight line (control point offset), not a rail", () => {
+    const from = { x: 0, y: 0 };
+    const to = { x: 200, y: 0 }; // horizontal line → any y-deviation is the arc
+    // rng=0.9 pushes the control point strongly off-axis
+    const pts = bezierPath(from, to, { rng: seq([0.9]) });
+    const maxY = Math.max(...pts.map((p) => Math.abs(p.y)));
+    assert.ok(maxY > 1, `path should bow off the straight line (maxY=${maxY})`);
+  });
+
+  it("scales waypoint count with distance and is finite", () => {
+    const short = bezierPath({ x: 0, y: 0 }, { x: 20, y: 0 }, { rng: seq([0.5]) });
+    const long = bezierPath({ x: 0, y: 0 }, { x: 600, y: 0 }, { rng: seq([0.5]) });
+    assert.ok(long.length > short.length, "longer move → more waypoints");
+    for (const p of [...short, ...long]) {
+      assert.ok(Number.isFinite(p.x) && Number.isFinite(p.y));
+    }
+  });
+
+  it("handles a zero-length move without NaN", () => {
+    const pts = bezierPath({ x: 10, y: 10 }, { x: 10, y: 10 }, { rng: seq([0.5]) });
+    for (const p of pts) assert.ok(Number.isFinite(p.x) && Number.isFinite(p.y));
+    const last = pts[pts.length - 1];
+    assert.deepEqual({ x: last.x, y: last.y }, { x: 10, y: 10 });
+  });
+});
+
+describe("keystrokeDelays", () => {
+  it("returns one delay per character, all within human bounds", () => {
+    const d = keystrokeDelays(12, { rng: seq([0.5]) }); // 0.5 → never a think-pause
+    assert.equal(d.length, 12);
+    for (const ms of d) {
+      assert.ok(ms >= 45 && ms <= 120, `base delay in range: ${ms}`);
+    }
+  });
+
+  it("injects longer think-pauses when the rng crosses the threshold", () => {
+    // A small constant rng forces the <0.08 pause branch on every key, so the
+    // resulting delays exceed the 45–120ms base band.
+    const d = keystrokeDelays(20, { rng: () => 0.01 });
+    assert.ok(
+      d.every((ms) => ms > 120),
+      "think-pause branch should push delays past the base range",
+    );
+  });
+
+  it("empty text → no delays", () => {
+    assert.deepEqual(keystrokeDelays(0, { rng: seq([0.5]) }), []);
+  });
+});
+
+describe("pointInBox / randBetween", () => {
+  it("pointInBox stays inside the box and off dead-centre", () => {
+    const box = { x: 100, y: 200, width: 40, height: 20 };
+    const p = pointInBox(box, seq([0.5]));
+    assert.ok(p.x > box.x && p.x < box.x + box.width);
+    assert.ok(p.y > box.y && p.y < box.y + box.height);
+  });
+
+  it("randBetween respects bounds", () => {
+    assert.equal(randBetween(10, 20, () => 0), 10);
+    assert.equal(randBetween(10, 20, () => 1), 20);
+    assert.equal(randBetween(10, 20, () => 0.5), 15);
+  });
+});


### PR DESCRIPTION
## Human-like input — the behavioural layer

Research (prior turn) concluded that with the browser already presenting as a real
Chrome on the user's real IP, the **only** residual bot signal is behaviour — and
a 2026 study (FP-Agent) caught AI agents on typing/mouse dynamics where
fingerprint checks caught almost none. Our session driver used `page.fill` /
`page.click`: instantaneous synthetic events with no cursor trajectory or pacing —
the textbook bot signature, made *worse* by the pristine fingerprint.

### What changed
New `lib/human-input.mjs`:
- curved (Bézier) cursor travel with an arrival dwell before clicks,
- key-by-key typing with jittered, occasionally-paused cadence,
- eased multi-step scroll.

Wired into the session actions (`click`/`type`/`fill`/`fill-secret`/`fill-otp`/
`hover`/`scroll`) and `auto-login` (recipe via an injectable driver; heuristic /
Microsoft form fills; OTP). Escape hatch: `AGENT_ID_HUMAN_INPUT=0` → fast direct
input.

### Safety / robustness (adversarial review applied)
- **Secret guards intact**: the vaulted password/OTP/secret is typed key-by-key
  and never reaches the agent; all secret-typing paths (incl. the recipe engine
  now) wrap in a value-free catch.
- **Overlay-safe**: the human motion supplies the behavioural trail, but the
  actual click/focus goes through Playwright's actionability-checked
  `locator.click()` / `fill("")` — so a field under a consent banner still
  focuses (a raw-coordinate click would silently miss). Deterministic replace
  (no append-to-stale), empty value clears the field.

### Tests
Pure geometry/timing units + a live real-Chrome test proving mousemove events
fire before a click, text is typed key-by-key, replace-not-append, empty-clears,
and the fallback works. Browser-plugin only (marketplace, not npm) — no
changeset. Full suite **523** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
