### PR TITLE
fix(proxy): minimal DER INTEGER encoding fixes flaky control-tls test

### DIFF
--- a/plugins/agent-id-proxy/lib/control-tls.mjs
+++ b/plugins/agent-id-proxy/lib/control-tls.mjs
@@ -33,9 +33,19 @@ function tlv(tag, content) {
 }
 const SEQ = (...parts) => tlv(0x30, Buffer.concat(parts));
 const SET = (...parts) => tlv(0x31, Buffer.concat(parts));
+// DER INTEGER for a non-negative value, in MINIMAL form. Two rules that both
+// bite a 16-byte random serial:
+//   - strip redundant leading 0x00 bytes (a leading zero whose successor has the
+//     high bit clear is illegal padding — strict parsers throw
+//     "asn1 …::illegal padding"); happens ~1/512 random serials, which was the
+//     source of the flaky control-plane TLS test.
+//   - keep exactly one leading 0x00 when the top byte's high bit is set, so the
+//     value stays positive (X.509 serials must be positive).
 function INTEGER(buf) {
-  let b = buf;
-  if (b.length === 0) b = Buffer.from([0]);
+  let start = 0;
+  while (start < buf.length && buf[start] === 0x00) start++;
+  let b = buf.subarray(start);
+  if (b.length === 0) b = Buffer.from([0]); // the value is zero
   else if (b[0] & 0x80) b = Buffer.concat([Buffer.from([0]), b]); // keep positive
   return tlv(0x02, b);
 }
@@ -83,7 +93,14 @@ export function fingerprintOfCertPem(certPem) {
 // Generate a fresh self-signed P-256 cert. Returns { certPem, keyPem, fingerprint }
 // where fingerprint is the lowercase hex SHA-256 of the cert DER (what the phone
 // pins, and what tls.getPeerCertificate().fingerprint256 yields once normalized).
-export function generateControlCert({ cn = "alien-agent-id-control", days = 3650, now = new Date() } = {}) {
+export function generateControlCert({
+  cn = "alien-agent-id-control",
+  days = 3650,
+  now = new Date(),
+  // Serial bytes — injectable so tests can pin the leading-zero / high-bit edge
+  // cases the random default only hits ~1/512 of the time.
+  serial: serialBytes = randomBytes(16),
+} = {}) {
   const { privateKey, publicKey } = generateKeyPairSync("ec", { namedCurve: "P-256" });
   const spki = publicKey.export({ type: "spki", format: "der" }); // complete SubjectPublicKeyInfo
 
@@ -94,7 +111,7 @@ export function generateControlCert({ cn = "alien-agent-id-control", days = 3650
     UTCTIME(utcTime(new Date(now.getTime() + days * 86_400_000))),
   );
   const version = ctx(0, INTEGER(Buffer.from([2]))); // [0] EXPLICIT v3
-  const serial = INTEGER(randomBytes(16));
+  const serial = INTEGER(serialBytes);
   const basicConstraints = SEQ(OID(OID_BASIC_CONSTRAINTS), BOOL(true), OCTETSTRING(SEQ())); // cA=FALSE (default)
   const extensions = ctx(3, SEQ(basicConstraints)); // [3] EXPLICIT Extensions
 

--- a/tests/test-control-tls.mjs
+++ b/tests/test-control-tls.mjs
@@ -13,7 +13,7 @@ import https from "node:https";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { createECDH } from "node:crypto";
+import { createECDH, X509Certificate } from "node:crypto";
 
 import {
   generateControlCert,
@@ -39,6 +39,28 @@ describe("self-signed cert generation", () => {
 
   it("two certs have different fingerprints", () => {
     assert.notEqual(generateControlCert().fingerprint, generateControlCert().fingerprint);
+  });
+
+  // Regression: a serial that DER-encodes with a redundant leading zero byte
+  // (leading 0x00 followed by a high-bit-clear byte) is illegal padding and made
+  // strict parsers throw "asn1 …::illegal padding" — the ~1/512 flake in the TLS
+  // tests below. The INTEGER encoder now emits minimal DER, so every serial edge
+  // case must parse via the strict X509Certificate constructor.
+  it("encodes every serial edge case as valid DER (no illegal padding)", () => {
+    const serials = {
+      "leading zero + high-bit-clear (the flake)": Buffer.from([0x00, 0x45, 0x9a, 0xbc]),
+      "leading zero + high-bit-set (0x00 required)": Buffer.from([0x00, 0x80, 0x11, 0x22]),
+      "two leading zeros": Buffer.from([0x00, 0x00, 0x33, 0x44]),
+      "top bit set, no leading zero": Buffer.from([0xff, 0x11, 0x22]),
+      "ordinary": Buffer.from([0x45, 0x11, 0x22]),
+      "all zero": Buffer.from([0x00, 0x00]),
+    };
+    for (const [label, serial] of Object.entries(serials)) {
+      const { certPem, fingerprint } = generateControlCert({ serial });
+      // Throws on illegal padding — the exact failure we're regressing against.
+      assert.doesNotThrow(() => new X509Certificate(certPem), `strict parse: ${label}`);
+      assert.equal(fingerprintOfCertPem(certPem), fingerprint, `fingerprint stable: ${label}`);
+    }
   });
 });
 


### PR DESCRIPTION
## Fix the flaky `test-control-tls.mjs` (`asn1 …::illegal padding`)

### Root cause
`control-tls.mjs` hand-encodes the self-signed control-plane cert's DER. Its
`INTEGER` helper prepended a `0x00` when the top bit was set (to keep the value
positive) but **never stripped redundant leading zeros**. The 16-byte random
serial (`INTEGER(randomBytes(16))`) therefore produced illegal DER whenever it
started with `0x00` followed by a high-bit-clear byte — e.g. `02 10 00 45 …`.
A leading `0x00` whose successor's top bit is clear is *illegal padding* in DER,
so strict parsers (`X509Certificate`, the TLS stack) throw
`asn1 encoding routines::illegal padding`. Probability ≈ **1/512 per cert** —
hence "passes locally, flakes occasionally in CI."

### Fix
Encode non-negative `INTEGER`s in **minimal DER**: strip leading zero bytes,
then keep exactly one `0x00` only when the top bit is set. `generateControlCert`
gains an injectable `serial` so the edge cases are exercised deterministically.

### Verification
- New regression test walks every serial edge case (leading-zero-clear /
  leading-zero-set / two-zeros / top-bit / ordinary / all-zero) through the
  strict `X509Certificate` constructor — it **fails against the old encoder** and
  passes with the fix.
- Stress: 4000 random-serial certs all parse (25 had a leading byte stripped);
  0 failures.
- Full suite **530** green.

Proxy plugin only (marketplace, not npm) — no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
