### PR TITLE
fix(browser): :bug: detect login block walls and warm up before deep login links

### DIFF
--- a/plugins/agent-id-browser/bin/cli.mjs
+++ b/plugins/agent-id-browser/bin/cli.mjs
@@ -454,15 +454,26 @@ async function cmdAutoLogin(flags) {
       }
 
       if (!result || !result.ok) {
+        const outcome = result ? result.outcome : "unknown";
+        // A bot-block wall (e.g. Reddit's "blocked by network security") can't be
+        // cleared by an automated credential submission — the login handshake is
+        // exactly where anti-automation bites. A human driving a headed login
+        // clears it and the session seals with the SAME access level.
+        const message =
+          outcome === "blocked"
+            ? `Auto-login for '${credName}' was blocked by an anti-automation wall (bot ` +
+              "challenge / network-security block). This hits the login handshake specifically; " +
+              `sign in yourself once with headed \`login --name ${profileName}` +
+              `${requestedAccess ? ` --access ${requestedAccess}` : ""}\` — it seals the same session.`
+            : `Auto-login for '${credName}' did not complete (${outcome}). ` +
+              "Verify the credentials / loginUrl, add a `recipe` to the credential, or bootstrap " +
+              `once with headed \`login --name ${profileName}\`.`;
         outputJson({
           ok: false,
           error: "AUTO_LOGIN_FAILED",
-          outcome: result ? result.outcome : "unknown",
+          outcome,
           finalUrl: result ? result.finalUrl : null,
-          message:
-            `Auto-login for '${credName}' did not complete (${result ? result.outcome : "unknown"}). ` +
-            "Verify the credentials / loginUrl, add a `recipe` to the credential, or bootstrap " +
-            `once with headed \`login --name ${profileName}\`.`,
+          message,
         });
         process.exitCode = 1;
         return;

--- a/plugins/agent-id-browser/lib/auto-login.mjs
+++ b/plugins/agent-id-browser/lib/auto-login.mjs
@@ -50,6 +50,63 @@ function hostOf(url) {
   }
 }
 
+// Scheme+host origin of a URL (e.g. "https://www.reddit.com"), or null.
+export function originOf(url) {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return null;
+  }
+}
+
+// Is the login URL a DEEP link (a real path like /login) rather than the bare
+// origin root? A warmup navigation only helps for deep links — if the login URL
+// is already the root there is nothing to warm up first.
+export function isDeepLoginUrl(url) {
+  try {
+    const u = new URL(url);
+    return u.pathname !== "/" && u.pathname !== "";
+  } catch {
+    return false;
+  }
+}
+
+// A URL path segment that names a login / auth / challenge step. Matched against
+// whole segments (so "/authors/x" is NOT login-ish, but "/login/" and
+// "/oauth2/authorize" are) to keep the "still on the login page" check precise.
+const LOGIN_SEGMENT_RE = /^(log[-_]?in|sign[-_]?in|signin|auth|authorize|sso|oauth2?|challenge|checkpoint|verify)$/i;
+
+export function isLoginishPath(pathname) {
+  return String(pathname || "")
+    .split("/")
+    .some((seg) => LOGIN_SEGMENT_RE.test(seg));
+}
+
+// Are we still sitting on the login/auth host+path after the form cleared? A real
+// login LEAVES the login page (redirect to the app/feed). If the password field
+// merely vanished while we're still on a login-ish path — an SPA re-render, or a
+// redirect into a bot-challenge wall like Reddit's /login?...js_challenge — that
+// is NOT a completed login, and sealing it yields a session with no auth cookie.
+// This is the positive-confirmation backstop for "logged-in" (paired with the
+// "blocked" classifier, which catches walls that carry visible block copy).
+export function stillOnLoginPage(currentUrl, loginUrl) {
+  let cur, login;
+  try {
+    cur = new URL(currentUrl);
+  } catch {
+    return false;
+  }
+  try {
+    login = new URL(loginUrl);
+  } catch {
+    return false;
+  }
+  // Left the auth host entirely → definitely progressed.
+  if (cur.hostname !== login.hostname) return false;
+  // Same host: only "stuck" if we're on a login-ish path.
+  return isLoginishPath(cur.pathname);
+}
+
 // Substitute {username}/{password}/{otp} in a string. Pure.
 export function applyVars(str, vars = {}) {
   if (typeof str !== "string") return str;
@@ -295,6 +352,26 @@ export async function autoLogin({
   if (!cred.loginUrl) throw new Error(`login '${cred.name}': loginUrl is required for auto-login`);
   const getOtp = () => resolveOtp(cred, { env, log });
 
+  // Warm up before a deep login link. Some sites (e.g. Reddit) wall a COLD
+  // deep-link straight to /login with a "blocked by network security" bot block,
+  // but let it through once the ORIGIN has loaded and the anti-bot's clearance
+  // cookie is set — which is how a human arrives (homepage → click "Log in"), not
+  // by cold deep-link. General + best-effort: one harmless extra navigation for
+  // sites without such a wall, skipped when the login URL is already the origin
+  // root or when the credential opts out with `warmup: false`. The clearance
+  // applies on the NEXT navigation, so we deliberately don't inspect this page —
+  // the origin itself may still show the block while the cookie is being set.
+  const origin = originOf(cred.loginUrl);
+  if (origin && isDeepLoginUrl(cred.loginUrl) && cred.warmup !== false) {
+    log("auto-login: warming up via the site origin before the login page");
+    try {
+      await page.goto(origin, { waitUntil: "domcontentloaded", timeout: 30000 });
+      await page.waitForTimeout(Math.max(settleMs * 2, 4000));
+    } catch {
+      /* warmup is best-effort — proceed to the login URL regardless */
+    }
+  }
+
   await page.goto(cred.loginUrl, { waitUntil: "domcontentloaded", timeout: 30000 });
   await page.waitForTimeout(settleMs);
 
@@ -311,9 +388,20 @@ export async function autoLogin({
   for (let round = 0; round < maxRounds; round++) {
     const outcome = classifyLogin(await detectPageState(page));
     log(`auto-login: ${outcome}`);
-    if (outcome === "logged-in") return { ok: true, outcome, finalUrl: page.url() };
-    if (outcome === "failed") return { ok: false, outcome, finalUrl: page.url() };
-    if (outcome === "otp-required") {
+    // A bot-block / human-verification wall never clears by waiting — stop and
+    // report it (the caller advises a headed login, which a human can clear).
+    if (outcome === "blocked") return { ok: false, outcome: "blocked", finalUrl: page.url() };
+    if (outcome === "logged-in") {
+      // Positive confirmation: the form is gone AND we've left the login page.
+      // Without this, a vanished password field on a block/challenge or SPA
+      // re-render sealed an unauthenticated session while reporting success.
+      if (!stillOnLoginPage(page.url(), cred.loginUrl)) {
+        return { ok: true, outcome, finalUrl: page.url() };
+      }
+      log("auto-login: form cleared but still on the login page — awaiting redirect");
+    } else if (outcome === "failed") {
+      return { ok: false, outcome, finalUrl: page.url() };
+    } else if (outcome === "otp-required") {
       if (cred.otp === "none") {
         return { ok: false, outcome: "otp-unexpected", finalUrl: page.url() };
       }
@@ -321,7 +409,7 @@ export async function autoLogin({
       await page.waitForTimeout(settleMs);
       continue;
     }
-    await page.waitForTimeout(settleMs); // unknown — let the page settle, re-check
+    await page.waitForTimeout(settleMs); // unknown / unconfirmed — settle, re-check
   }
   return { ok: false, outcome: "timeout", finalUrl: page.url() };
 }

--- a/plugins/agent-id-browser/lib/login-detect.mjs
+++ b/plugins/agent-id-browser/lib/login-detect.mjs
@@ -4,13 +4,22 @@
 // states. `looksLoggedOut` (session.mjs) is too coarse here: right after the
 // password step you are usually STILL on the auth host — entering a 2FA code —
 // which it would read as "logged out" for both "OTP required" and "wrong
-// password". This is a focused 3-way classifier over a snapshot of the page:
+// password". This is a focused classifier over a snapshot of the page:
 //
+//   "blocked"      — a bot-block / human-verification interstitial (a network
+//                    -security wall, CAPTCHA, "unusual traffic"). The form is
+//                    gone but we are NOT in — must not be mistaken for success.
 //   "otp-required" — a second-factor affordance is present (a one-time-code input,
 //                    an OTP-ish field name, or body copy describing 2FA)
 //   "failed"       — a credential error is shown and there is no OTP affordance
 //   "logged-in"    — no password field remains and nothing looks gated
 //   "unknown"      — indeterminate (page may not have advanced yet; caller waits)
+//
+// The "blocked" state is checked FIRST and exists because of a real false
+// positive: a "blocked by network security" wall has no password field, no OTP
+// affordance, and no credential-error copy, so it was classified "logged-in" —
+// and the caller sealed an UNauthenticated session (no auth cookie) while
+// reporting success. A block wall never clears by waiting, so the caller stops.
 //
 // Pure + dependency-free so it unit-tests without a browser. The browser side
 // (auto-login.mjs) gathers the snapshot via page.evaluate and calls this.
@@ -29,6 +38,17 @@ const OTP_BODY_RE =
 // Body / inline text that signals the credentials were rejected.
 const ERROR_RE =
   /(incorrect|invalid|wrong password|that password|couldn.?t (?:sign|log) ?you in|try again|doesn.?t match|not recognized|too many attempts|account.*lock)/i;
+
+// Bot-block / human-verification interstitial copy. DISTINCT from ERROR_RE: these
+// describe an anti-automation wall (network-security block, CAPTCHA, rate limit),
+// not a bad password, and no retyping or waiting clears them. Every phrase is
+// high-precision — near-exclusive to a block/challenge page — because a false
+// match aborts an otherwise-successful login. Deliberately NOT here: a bare
+// "cloudflare" (legit footers say "secured by Cloudflare") — the CF challenge is
+// caught by "checking your browser" / "verify you are human" instead. Matching
+// login path SEGMENTS is done separately in auto-login.mjs.
+const BLOCK_RE =
+  /(blocked by network security|you.?ve been blocked|access to this page (?:has been |is )?denied|verify (?:you are|you.?re) (?:a )?human|are you a (?:human|robot)|checking your browser before|unusual (?:traffic|activity) (?:from|detected|on)|automated (?:queries|traffic|requests)|too many requests|suspicious (?:traffic|network) activity)/i;
 
 /**
  * Classify a login attempt's current page state.
@@ -49,15 +69,22 @@ export function classifyLogin({
   otpFieldNames = [],
   bodyText = "",
   errorText = null,
+  blocked = false,
 } = {}) {
+  const isBlocked =
+    blocked === true || BLOCK_RE.test(bodyText) || BLOCK_RE.test(String(errorText || ""));
   const otpAffordance =
     hasOtpField ||
     (Array.isArray(otpFieldNames) && otpFieldNames.some((n) => OTP_FIELD_RE.test(String(n || "")))) ||
     OTP_BODY_RE.test(bodyText);
   const hasError = ERROR_RE.test(String(errorText || "")) || ERROR_RE.test(bodyText);
 
+  // A bot-block / human-verification wall: the form is gone but we are NOT in.
+  // Checked FIRST — otherwise the missing password field reads as success and an
+  // unauthenticated session gets sealed (the bug this outcome was added for).
+  if (isBlocked) return "blocked";
   // An OTP affordance is the strongest signal the password step succeeded and a
-  // second factor is now being requested — check it first.
+  // second factor is now being requested — check it next.
   if (otpAffordance) return "otp-required";
   // No second factor, but a credential error → the password was rejected.
   if (hasError) return "failed";
@@ -67,4 +94,4 @@ export function classifyLogin({
   return "unknown";
 }
 
-export { OTP_FIELD_RE, OTP_BODY_RE, ERROR_RE };
+export { OTP_FIELD_RE, OTP_BODY_RE, ERROR_RE, BLOCK_RE };

--- a/tests/test-auto-login.mjs
+++ b/tests/test-auto-login.mjs
@@ -9,7 +9,16 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { applyVars, stepNeedsOtp, runRecipe, resolveOtp } from "../plugins/agent-id-browser/lib/auto-login.mjs";
+import {
+  applyVars,
+  stepNeedsOtp,
+  runRecipe,
+  resolveOtp,
+  isLoginishPath,
+  stillOnLoginPage,
+  originOf,
+  isDeepLoginUrl,
+} from "../plugins/agent-id-browser/lib/auto-login.mjs";
 import { generateTotp } from "../plugins/agent-id-core/lib/totp.mjs";
 
 test("applyVars substitutes username/password/otp; passes non-strings through", () => {
@@ -103,4 +112,55 @@ test("resolveOtp generates a code from a stored TOTP seed (RFC vector)", async (
 
 test("resolveOtp throws when otp=totp but no seed is stored", async () => {
   await assert.rejects(resolveOtp({ name: "x", otp: "totp" }, {}), /totpSecret/);
+});
+
+// ── Positive-confirmation helpers (the "logged-in" false-positive guard) ──────────
+
+test("isLoginishPath matches whole login/auth segments, not substrings", () => {
+  for (const p of ["/login", "/login/", "/account/signin", "/oauth2/authorize", "/auth/callback", "/challenge"]) {
+    assert.equal(isLoginishPath(p), true, `login-ish: ${p}`);
+  }
+  // "authors" must NOT match "auth"; app paths are not login-ish.
+  for (const p of ["/", "/feed", "/authors/jane", "/r/test", "/user/me", "/settings"]) {
+    assert.equal(isLoginishPath(p), false, `app path: ${p}`);
+  }
+});
+
+test("stillOnLoginPage: true only when stuck on the same-host login page", () => {
+  const loginUrl = "https://www.reddit.com/login";
+  // The exact Reddit failure: form gone but still on /login with a js_challenge.
+  assert.equal(
+    stillOnLoginPage("https://www.reddit.com/login/?solution=abc&js_challenge=1", loginUrl),
+    true,
+  );
+  // Real success leaves the login page (redirect to the feed) → confirmed.
+  assert.equal(stillOnLoginPage("https://www.reddit.com/", loginUrl), false);
+  assert.equal(stillOnLoginPage("https://www.reddit.com/r/programming/", loginUrl), false);
+  // Left the auth host entirely → progressed.
+  assert.equal(stillOnLoginPage("https://app.example.com/dashboard", loginUrl), false);
+  // Garbage URLs don't wedge the caller into a false "stuck".
+  assert.equal(stillOnLoginPage("not a url", loginUrl), false);
+});
+
+test("stillOnLoginPage: a modal login on the homepage isn't falsely flagged as stuck", () => {
+  // loginUrl is the app homepage (login via modal, URL unchanged). After login we
+  // are on "/" — NOT a login-ish path — so "logged-in" is confirmed, not rejected.
+  assert.equal(stillOnLoginPage("https://app.example.com/", "https://app.example.com/"), false);
+});
+
+// ── Warmup helpers (the cold-deep-link block fix) ─────────────────────────────────
+
+test("originOf returns scheme+host, null on garbage", () => {
+  assert.equal(originOf("https://www.reddit.com/login/?x=1"), "https://www.reddit.com");
+  assert.equal(originOf("http://host:8080/a/b"), "http://host:8080");
+  assert.equal(originOf("not a url"), null);
+});
+
+test("isDeepLoginUrl: true for a real path, false for the bare origin root", () => {
+  assert.equal(isDeepLoginUrl("https://www.reddit.com/login/"), true);
+  assert.equal(isDeepLoginUrl("https://accounts.example.com/auth/signin"), true);
+  // Bare root → nothing to warm up first.
+  assert.equal(isDeepLoginUrl("https://www.reddit.com/"), false);
+  assert.equal(isDeepLoginUrl("https://www.reddit.com"), false);
+  assert.equal(isDeepLoginUrl("garbage"), false);
 });

--- a/tests/test-login-detect.mjs
+++ b/tests/test-login-detect.mjs
@@ -60,3 +60,67 @@ test("a bare 'code' field name (postal_code / promo code) does NOT trigger OTP",
     "logged-in",
   );
 });
+
+// Regression: the exact false positive that sealed an UNauthenticated Reddit
+// session — verbatim text captured from Reddit's real wall. It has no password
+// field, no OTP affordance, and no credential-error copy (note: NO "try again"),
+// so the OLD classifier returned "logged-in". It MUST now be "blocked".
+test("blocked: Reddit's real network-security wall is NOT mistaken for logged-in", () => {
+  assert.equal(
+    classifyLogin({
+      hasPasswordField: false,
+      bodyText:
+        "You've been blocked by network security. If you think you've been blocked by mistake, file a ticket below and we'll look into it.",
+    }),
+    "blocked",
+  );
+});
+
+test("blocked: takes precedence over a vanished password field (logged-in) and over errors", () => {
+  // No password field (would be "logged-in") + block copy → "blocked".
+  assert.equal(classifyLogin({ hasPasswordField: false, bodyText: "unusual traffic detected" }), "blocked");
+  // Block copy alongside a stray error phrase → still "blocked" (a wall, not a bad password).
+  assert.equal(
+    classifyLogin({ hasPasswordField: true, bodyText: "Verify you are human. try again" }),
+    "blocked",
+  );
+});
+
+test("blocked: an explicit blocked flag forces the outcome", () => {
+  assert.equal(classifyLogin({ hasPasswordField: false, blocked: true, bodyText: "" }), "blocked");
+});
+
+test("blocked: a captcha / verification challenge is caught", () => {
+  assert.equal(
+    classifyLogin({ hasPasswordField: false, bodyText: "Are you a robot? Complete the challenge to continue." }),
+    "blocked",
+  );
+});
+
+test("NOT blocked: ordinary app copy that merely contains benign words stays logged-in", () => {
+  assert.equal(
+    classifyLogin({ hasPasswordField: false, bodyText: "Traffic report: your commute is clear today" }),
+    "logged-in",
+  );
+});
+
+test("NOT blocked: a legit page's Cloudflare footer does NOT trip the wall detector", () => {
+  // The precision reason bare "cloudflare" was excluded from BLOCK_RE.
+  assert.equal(
+    classifyLogin({
+      hasPasswordField: false,
+      bodyText: "Welcome back!  •  Performance & security by Cloudflare",
+    }),
+    "logged-in",
+  );
+});
+
+test("blocked: Google's real 'unusual traffic from your network' wall is caught", () => {
+  assert.equal(
+    classifyLogin({
+      hasPasswordField: false,
+      bodyText: "Our systems have detected unusual traffic from your computer network.",
+    }),
+    "blocked",
+  );
+});


### PR DESCRIPTION
## Problem

`agent-id-browser auto-login` had two failure modes on services with an
anti-automation wall (surfaced end-to-end against Reddit's "blocked by network
security" — Fastly Bot Management's JS proof-of-work challenge):

1. **False success.** When the login form vanished behind a bot-block / challenge
   wall, `classifyLogin` read "no password field" as `logged-in`, so the caller
   **sealed an UNauthenticated session and reported success** (zero auth cookies).
2. **Never reached the form.** It cold-navigated straight to the deep login URL,
   which such walls treat as the highest-suspicion path — so the automated login
   was walled before it could fill anything.

## Fix

- **`login-detect.mjs`** — add a `"blocked"` outcome (high-precision `BLOCK_RE`,
  checked *before* `"logged-in"`) so a wall / CAPTCHA / rate-limit page is never
  mistaken for a completed login.
- **`auto-login.mjs`** — (a) require positive confirmation (we actually left the
  login page) before accepting `"logged-in"`; (b) return
  `{ ok:false, outcome:"blocked" }` on a wall; (c) **warm up via the site origin
  before a deep login URL** so the anti-bot's clearance cookie is set first — a
  human reaches `/login` *from* the site, not by cold deep-link. General +
  best-effort, gated on `isDeepLoginUrl` and `cred.warmup !== false`.
- **`cli.mjs`** — tailored `blocked` message pointing at the headed-login fallback.

## Why this is the right fix (empirical)

- A headless auto-login with the warmup **actually logged in** (verified:
  `/user/me` → the real username). Restores headless **and** headed automated
  login (they go through the identical warmup path).
- An offline CDP-leak probe (main-world `Error.stack` getter +
  `Proxy.ownKeys`/`getOwnPropertyDescriptor` traps) confirmed our patchright
  stack does **not** leak the `Runtime.enable` signal — headless or headed — so
  the residual block is IP-level behavioural rate-limiting, not automation
  fingerprinting. On `blocked`, the tool now stops cleanly and advises a headed
  manual login (a human clears the wall; seals the same `ro` session).

## Testing

- `bun run test` → **542 pass, 0 fail**.
- New regression guards: `classifyLogin` block cases (incl. Reddit's verbatim
  wall text, which the old classifier scored `logged-in`), `stillOnLoginPage`,
  and `originOf` / `isDeepLoginUrl`.

Marketplace-only plugin (`agent-id-browser`) — **no changeset** (core/vault
untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
