### PR TITLE
fix(browser): 🔒 block read-back of secrets typed into non-password fields

### DIFF
--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -55,7 +55,7 @@ export function sessionFilePath(stateDir, name) {
 // returns a flat list. `prefix` namespaces refs per frame: "" for the main
 // frame ("e1", "e2", …), "f1" for the first iframe ("f1e1", …) — so a ref is
 // self-describing about which frame it lives in.
-function snapshotInPage(prefix) {
+export function snapshotInPage(prefix) {
   const pre = prefix || "";
   const SEL = [
     "a[href]", "button", "input:not([type=hidden])", "textarea", "select",
@@ -81,10 +81,24 @@ function snapshotInPage(prefix) {
     }
     const ref = pre + "e" + ++i;
     el.setAttribute("data-aibref", ref);
+    // el.value is a useful *label* only for button-like inputs (submit/button/
+    // reset), where the value IS the visible caption. For any text-entry field
+    // el.value is user-entered content that could be a secret — OTP/2FA fields
+    // are type=text/tel, and a show-password toggle flips a password field to
+    // type=text — so never surface it here (a subsequent snapshot would hand the
+    // agent a value the vault typed in). Also never surface a field the vault
+    // marked tainted ("data-aib-secret" — must match SECRET_TAINT_ATTR).
+    // Non-secret values stay readable on demand via `get --what value`.
+    const valueLabel =
+      el.tagName === "INPUT" &&
+      ["submit", "button", "reset"].includes(el.type) &&
+      !el.hasAttribute("data-aib-secret")
+        ? el.value
+        : "";
     const name = (
       el.getAttribute("aria-label") ||
       el.getAttribute("placeholder") ||
-      (el.tagName === "INPUT" || el.tagName === "TEXTAREA" ? el.value : "") ||
+      valueLabel ||
       el.innerText ||
       el.getAttribute("title") ||
       el.getAttribute("name") ||
@@ -131,15 +145,41 @@ function frameForRef(state, ref) {
   return frame;
 }
 
-// `get --what value|attr value` must not read back a password field: the vault
-// may have just typed a secret there via fill-secret, and returning it would
-// hand the agent the very value the vault exists to withhold.
-async function refusePasswordRead(target, selector) {
-  const isPassword = await target
-    .$eval(selector, (el) => el.tagName === "INPUT" && el.type === "password")
+// A field the vault typed a secret into is tagged with this attribute (see
+// markSecretField). It rides on the DOM element, not the ref — a re-snapshot
+// invalidates refs but only clears "data-aibref", so the taint survives across
+// snapshots as long as the site keeps the node. Kept in sync with the literal
+// hard-coded inside snapshotInPage (page functions can't close over module scope).
+export const SECRET_TAINT_ATTR = "data-aib-secret";
+
+// Tag the element a fill-secret/fill-otp just wrote to, so every later read-back
+// (get --what value, get --what attr value, and the snapshot el.value name
+// fallback) refuses it — REGARDLESS of the input's `type`. This is what closes
+// the leak for non-password fields: OTP/2FA inputs are type=text/tel, and a
+// show-password toggle flips a password field to type=text, so a type-only test
+// misses them. Best-effort: if the site has already swapped the node out there
+// is nothing (and no value) left to tag.
+export async function markSecretField(target, selector) {
+  await target
+    .$eval(selector, (el, attr) => el.setAttribute(attr, "1"), SECRET_TAINT_ATTR)
+    .catch(() => {});
+}
+
+// `get --what value|attr value` must not read back a field that holds an injected
+// secret: the vault may have just typed one there (fill-secret/fill-otp), and
+// returning it would hand the agent the very value the vault exists to withhold.
+// Refuse a password-type input AND any field the vault tagged tainted — the
+// latter catches secrets typed into a non-password field (see markSecretField).
+export async function refusePasswordRead(target, selector) {
+  const refuse = await target
+    .$eval(
+      selector,
+      (el, attr) => (el.tagName === "INPUT" && el.type === "password") || el.hasAttribute(attr),
+      SECRET_TAINT_ATTR,
+    )
     .catch(() => false);
-  if (isPassword) {
-    throw new Error("refusing to read a password field's value");
+  if (refuse) {
+    throw new Error("refusing to read a field that holds a password or an injected secret");
   }
 }
 
@@ -359,6 +399,8 @@ async function dispatch(state, msg, policy = null) {
         } catch {
           throw new Error(`fill-secret: could not fill "${p.ref}" — element not visible/editable (re-snapshot and retry)`);
         }
+        // Tag the field so a later read-back is refused whatever its input type.
+        await markSecretField(target, sel(p.ref));
       } finally {
         vault.lock();
       }
@@ -396,6 +438,10 @@ async function dispatch(state, msg, policy = null) {
       } catch {
         throw new Error(`fill-otp: could not fill "${p.ref}" — element not visible/editable (re-snapshot and retry)`);
       }
+      // A derived OTP isn't sealed at fill time (see assertFillAllowed), so the
+      // read-back guard is what protects it: tag the field so its value can't be
+      // read back regardless of the input's type (OTP inputs are text/tel).
+      await markSecretField(target, sel(p.ref));
       return { filled: p.ref, otp: true };
     }
     case "select":

--- a/tests/test-browser-secret-readback.mjs
+++ b/tests/test-browser-secret-readback.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+
+// Proof that a secret typed into a NON-password field can't be read back by the
+// controlling agent — the two leak paths fill-secret/fill-otp used to leave open:
+//
+//   1. `snapshot` used el.value as the element's name fallback for any input, so
+//      a value the vault typed (OTP into a type=text field, or a password field
+//      flipped to type=text by a show-password toggle) surfaced in a later
+//      snapshot.
+//   2. `get --what value` returned inputValue guarded only by a type==="password"
+//      check, so the same non-password field read straight back.
+//
+// The fix tags a filled field with SECRET_TAINT_ATTR (markSecretField); snapshot
+// suppresses the el.value name fallback for every text-entry field, and
+// refusePasswordRead refuses any tainted field regardless of type.
+//
+// LIVE real-browser test (snapshotInPage / the read-back guard run against actual
+// DOM), so it SKIPS automatically when patchright / Chrome are not installed.
+//
+// Run: node --test tests/test-browser-secret-readback.mjs
+
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { resolvePatchright, launchContext } from "../plugins/agent-id-browser/lib/launch.mjs";
+import {
+  snapshotInPage,
+  refusePasswordRead,
+  markSecretField,
+  SECRET_TAINT_ATTR,
+} from "../plugins/agent-id-browser/lib/session-server.mjs";
+
+const patchrightAvailable = !!resolvePatchright();
+
+// A login form standing in for the real thing: a password field, an OTP-style
+// text field, a benign text field, and a submit button (whose value IS its
+// visible label). The OTP/benign fields carry a value but NO aria-label /
+// placeholder / name, so el.value is the only fallback that could surface them.
+const FORM = `<!doctype html><meta charset=utf-8><title>login</title><form>
+  <input id="pw" type="password" value="hunter2">
+  <input id="otp" type="text" autocomplete="one-time-code" value="778899">
+  <input id="who" type="text" value="alice@example.com">
+  <input id="go" type="submit" value="Sign in">
+</form>`;
+
+let ctx;
+let workDir;
+let page;
+
+before(async () => {
+  if (!patchrightAvailable) return;
+  workDir = await fs.mkdtemp(path.join(os.tmpdir(), "secret-readback-"));
+  ctx = await launchContext({ profileDir: workDir, headless: true, contextOptions: {} });
+  page = ctx.pages()[0] || (await ctx.newPage());
+  await page.setContent(FORM, { waitUntil: "domcontentloaded" });
+});
+
+after(async () => {
+  if (ctx) await ctx.close().catch(() => {});
+  if (workDir) await fs.rm(workDir, { recursive: true, force: true }).catch(() => {});
+});
+
+const skip = patchrightAvailable ? false : "patchright/Chrome not installed";
+
+test("snapshot never surfaces a text field's value, but keeps a submit's label", { skip }, async () => {
+  const snap = await page.evaluate(snapshotInPage, "");
+  const names = snap.elements.map((e) => e.name);
+
+  // Leak path 1 is closed: neither the OTP value nor the benign text value
+  // appears as any element's accessible name.
+  assert.ok(!names.includes("778899"), "OTP value must not leak into snapshot names");
+  assert.ok(!names.includes("alice@example.com"), "text-field value must not leak into snapshot names");
+  assert.ok(
+    !snap.elements.some((e) => /778899|alice@example\.com|hunter2/.test(e.name)),
+    "no field value may appear anywhere in a snapshot name",
+  );
+
+  // A submit button's value is a visible caption, not user content — still shown.
+  assert.ok(names.includes("Sign in"), "a submit button's value is its label and stays visible");
+});
+
+test("read-back guard: password refused, benign text allowed, tainted field refused", { skip }, async () => {
+  // A password field is refused (the original guard).
+  await assert.rejects(() => refusePasswordRead(page, "#pw"), /password|secret/i);
+
+  // A benign, un-tainted text field is readable — the guard must not over-block.
+  await assert.doesNotReject(() => refusePasswordRead(page, "#who"));
+
+  // Before tainting, the OTP text field reads back (this is exactly the old leak).
+  await assert.doesNotReject(() => refusePasswordRead(page, "#otp"));
+
+  // markSecretField tags it; now leak path 2 is closed regardless of type=text.
+  await markSecretField(page, "#otp");
+  const tagged = await page.$eval("#otp", (el, attr) => el.hasAttribute(attr), SECRET_TAINT_ATTR);
+  assert.equal(tagged, true, "markSecretField must set the taint attribute");
+  await assert.rejects(() => refusePasswordRead(page, "#otp"), /secret/i);
+});
+
+test("taint survives a re-snapshot and keeps suppressing the value", { skip }, async () => {
+  // snapshot clears data-aibref but leaves the taint attribute, so a field the
+  // vault filled stays protected across the re-snapshots the agent does between
+  // steps of a login flow.
+  await markSecretField(page, "#otp");
+  const snap = await page.evaluate(snapshotInPage, "");
+  const stillTainted = await page.$eval("#otp", (el, attr) => el.hasAttribute(attr), SECRET_TAINT_ATTR);
+  assert.equal(stillTainted, true, "re-snapshot must not strip the taint attribute");
+  assert.ok(
+    !snap.elements.some((e) => e.name === "778899"),
+    "a tainted field's value stays out of snapshot names after re-snapshot",
+  );
+  await assert.rejects(() => refusePasswordRead(page, "#otp"), /secret/i);
+});


### PR DESCRIPTION
## Problem

`fill-secret`/`fill-otp` are meant to keep injected secrets from the controlling agent, but the read-back guard (`refusePasswordRead`) only refused inputs with `type === "password"`. Two leak paths remained for a secret typed into a **non-password** field — common for OTP/2FA inputs (`type=text`/`tel`) and for sites with a show-password toggle (flips the field to `type=text`):

1. `snapshot` used `el.value` as the element-name fallback for any input, so a subsequent snapshot surfaced the typed value to the agent.
2. `get --what value` returned `inputValue` guarded only by the password-type check (same for `get --what attr value`).

`assertFillAllowed` also explicitly doesn't treat a derived OTP as sealed, so the read-back guard is the only protection an OTP code gets.

## Fix

- **Taint marking**: new `SECRET_TAINT_ATTR` (`data-aib-secret`) + `markSecretField()`. After a successful `fill-secret`/`fill-otp`, the target element is tagged. The taint rides on the DOM node (not the ref), so it survives the re-snapshots an agent does between login steps — `snapshot` only clears `data-aibref`.
- **`refusePasswordRead`** now refuses a password-type input **or** any tainted field, regardless of input type.
- **`snapshot`** only uses `el.value` as a label for button-like inputs (`submit`/`button`/`reset`, where the value is the visible caption), never for text-entry fields, and never for a tainted field. Non-secret values stay readable on demand via `get --what value`.

## Test

`tests/test-browser-secret-readback.mjs` — live-browser test (auto-skips without patchright) proving both leak paths are closed while a submit button's label and benign field reads still work. Full suite: 545 pass.

No changeset: only the private marketplace plugin `agent-id-browser` changed (not npm-published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)