### PR TITLE
fix(browser): 🐳 opt-in --no-sandbox for root-in-container deployments

### DIFF
--- a/plugins/agent-id-browser/lib/launch.mjs
+++ b/plugins/agent-id-browser/lib/launch.mjs
@@ -80,12 +80,26 @@ export async function loadChromium() {
   return chromium;
 }
 
-function launchOptions(headless) {
+// Chrome hard-refuses to start as root with the sandbox on ("Running as root
+// without --no-sandbox is not supported"), which is exactly the situation in a
+// containerized deployment (e.g. lethe-hosted per-user containers run as root;
+// the container itself is the isolation boundary there). This explicit opt-in
+// KEEPS patchright's injected --no-sandbox instead of stripping it. Default
+// (unset) preserves the stealth-validated sandbox-on launch. Not fingerprintable
+// from the page: --no-sandbox changes no JS surface and no request header.
+// Exported for tests.
+export function sandboxDisabled(env = process.env) {
+  return env.AGENT_ID_BROWSER_NO_SANDBOX === "1";
+}
+
+// Exported for tests (the env-driven sandbox toggle must be provable without a
+// browser launch).
+export function launchOptions(headless) {
   return {
     channel: "chrome",
     headless,
     viewport: null,
-    ignoreDefaultArgs: ["--no-sandbox"],
+    ignoreDefaultArgs: sandboxDisabled() ? [] : ["--no-sandbox"],
     args: ["--test-type"],
     // Explicit (it's the modern default) so the session server's download
     // listener always gets Download objects rather than canceled downloads.
@@ -123,7 +137,7 @@ async function resolveHeadlessUserAgent() {
       const browser = await chromium.launch({
         channel: "chrome",
         headless: true,
-        ignoreDefaultArgs: ["--no-sandbox"],
+        ignoreDefaultArgs: sandboxDisabled() ? [] : ["--no-sandbox"],
         args: ["--test-type"],
       });
       try {

--- a/tests/test-browser-sandbox-toggle.mjs
+++ b/tests/test-browser-sandbox-toggle.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+// The container sandbox opt-out (AGENT_ID_BROWSER_NO_SANDBOX=1): by default the
+// launcher strips patchright's injected --no-sandbox to keep the renderer
+// sandbox ON (the stealth-validated config). Chrome refuses to start as root
+// with the sandbox on, so containerized deployments that run as root (e.g.
+// lethe-hosted per-user containers) set the env var to keep the injected flag.
+// Pure — no browser.
+//
+// Run: node --test tests/test-browser-sandbox-toggle.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { sandboxDisabled, launchOptions } from "../plugins/agent-id-browser/lib/launch.mjs";
+
+test("sandboxDisabled: only the literal '1' opts out", () => {
+  assert.equal(sandboxDisabled({}), false);
+  assert.equal(sandboxDisabled({ AGENT_ID_BROWSER_NO_SANDBOX: "1" }), true);
+  assert.equal(sandboxDisabled({ AGENT_ID_BROWSER_NO_SANDBOX: "0" }), false);
+  assert.equal(sandboxDisabled({ AGENT_ID_BROWSER_NO_SANDBOX: "true" }), false);
+  assert.equal(sandboxDisabled({ AGENT_ID_BROWSER_NO_SANDBOX: "" }), false);
+});
+
+test("default launch strips --no-sandbox (sandbox stays on)", () => {
+  delete process.env.AGENT_ID_BROWSER_NO_SANDBOX;
+  const opts = launchOptions(true);
+  assert.deepEqual(opts.ignoreDefaultArgs, ["--no-sandbox"]);
+  assert.equal(opts.channel, "chrome");
+});
+
+test("opt-in keeps patchright's --no-sandbox (root-in-container launch works)", () => {
+  process.env.AGENT_ID_BROWSER_NO_SANDBOX = "1";
+  try {
+    const opts = launchOptions(true);
+    assert.deepEqual(opts.ignoreDefaultArgs, []);
+    // Everything else about the stealth config is unchanged.
+    assert.equal(opts.channel, "chrome");
+    assert.deepEqual(opts.args, ["--test-type"]);
+  } finally {
+    delete process.env.AGENT_ID_BROWSER_NO_SANDBOX;
+  }
+});


### PR DESCRIPTION
Chrome hard-refuses to start as root with the sandbox on — exactly the situation in containerized deployments (lethe-hosted per-user containers run as root; the container is the isolation boundary there). The launcher deliberately strips patchright's injected `--no-sandbox` to keep the stealth-validated sandbox-on config, which made every launch fail in those containers.

New explicit opt-in: `AGENT_ID_BROWSER_NO_SANDBOX=1` keeps patchright's injected `--no-sandbox` (both in `launchOptions` and the headless-UA probe launch). Default (unset) is unchanged. The flag alters no JS surface and no request header, so it is not fingerprintable from the page.

Test: `tests/test-browser-sandbox-toggle.mjs` (pure, no browser). No changeset: private marketplace plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)