### PR TITLE
fix(browser): 💬 NO_PROFILE hint names the headless auto-login path

### DIFF
--- a/plugins/agent-id-browser/bin/cli.mjs
+++ b/plugins/agent-id-browser/bin/cli.mjs
@@ -48,6 +48,7 @@ import {
   sealedProfileExists,
 } from "../lib/profile-store.mjs";
 import { launchContext } from "../lib/launch.mjs";
+import { DEFAULT_PROFILE, loginHint, noProfileHint } from "../lib/hints.mjs";
 import { autoLogin } from "../lib/auto-login.mjs";
 import { looksLoggedOut } from "../lib/session.mjs";
 import { runSession, callSession } from "../lib/session-server.mjs";
@@ -199,10 +200,8 @@ function waitForUserClose(ctx, timeoutMs) {
 // The default browser session is ONE shared cookie jar ("main") so logins — and
 // especially shared SSO like "Sign in with Google" — carry across sites. Pass
 // --name to opt into a separate, isolated session (a second account, a sandbox).
-const DEFAULT_PROFILE = "main";
 
 // Suggest the right login command: bare `login` for the shared default, `--name` otherwise.
-const loginHint = (name) => (name === DEFAULT_PROFILE ? "`login`" : "`login --name " + name + "`");
 
 // ─── Profile lifecycle: unseal → run → reseal → wipe ──────────────────────────────
 
@@ -212,7 +211,7 @@ async function withProfile({ flags, name, headless, action }) {
   try {
     const cred = vault.get(name);
     if (!cred || cred.type !== "browser-profile") {
-      const e = new Error(`no browser-profile named '${name}' — run ${loginHint(name)} first`);
+      const e = new Error(`no browser-profile named '${name}' — ${noProfileHint(name)}`);
       e.code = "NO_PROFILE";
       throw e;
     }
@@ -680,7 +679,7 @@ async function cmdOpen(flags) {
   try {
     const cred = vault.get(name);
     if (!cred || cred.type !== "browser-profile") {
-      const e = new Error(`no browser-profile named '${name}' — run ${loginHint(name)} first`);
+      const e = new Error(`no browser-profile named '${name}' — ${noProfileHint(name)}`);
       e.code = "NO_PROFILE";
       throw e;
     }

--- a/plugins/agent-id-browser/lib/hints.mjs
+++ b/plugins/agent-id-browser/lib/hints.mjs
@@ -1,0 +1,16 @@
+// User-facing hint strings for the browser CLI, kept in a pure module so they
+// can be unit-tested without importing bin/cli.mjs (which runs the CLI on load).
+
+export const DEFAULT_PROFILE = "main";
+
+// Re-authenticate an EXISTING profile (headed). Used when a sealed session has
+// gone stale (logged out) — headed `login` re-signs into the same session.
+export const loginHint = (name) =>
+  name === DEFAULT_PROFILE ? "`login`" : "`login --name " + name + "`";
+
+// No profile exists YET. Both ways to create one are valid, but headed `login`
+// needs a display, so name the headless `auto-login` path first — it's the only
+// one available on a server / in a container.
+export const noProfileHint = (name) =>
+  `create one first with \`auto-login --cred <LOGIN_CRED>\` (headless, from a stored ` +
+  `login credential) or ${loginHint(name)} (headed, needs a display)`;

--- a/tests/test-browser-hints.mjs
+++ b/tests/test-browser-hints.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+// Tests for the browser CLI hint strings (lib/hints.mjs). The NO_PROFILE hint
+// must name the headless `auto-login` path — it's the only way to create a
+// profile on a server / in a container (headed `login` needs a display), and
+// pointing the agent at `login` there is exactly what made a "no profile yet"
+// state read as "the browser is broken". Pure — no browser.
+//
+// Run: node --test tests/test-browser-hints.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { DEFAULT_PROFILE, loginHint, noProfileHint } from "../plugins/agent-id-browser/lib/hints.mjs";
+
+test("loginHint: bare for the default profile, named otherwise", () => {
+  assert.equal(loginHint(DEFAULT_PROFILE), "`login`");
+  assert.equal(loginHint("reddit"), "`login --name reddit`");
+});
+
+test("noProfileHint: names the headless auto-login path first", () => {
+  const hint = noProfileHint("reddit");
+  assert.match(hint, /auto-login --cred/);
+  // auto-login must come before the headed login fallback.
+  assert.ok(hint.indexOf("auto-login") < hint.indexOf("login --name reddit"));
+  // It must be clear the headed path needs a display (why it's the fallback).
+  assert.match(hint, /headless/);
+  assert.match(hint, /needs a display/);
+});
+
+test("noProfileHint: carries the profile name into the headed fallback", () => {
+  assert.match(noProfileHint("acct2"), /login --name acct2/);
+  assert.doesNotMatch(noProfileHint(DEFAULT_PROFILE), /--name/);
+});


### PR DESCRIPTION
When `alien_browser_open` (or read/fetch) runs before any profile exists, the daemon returns `no browser-profile named 'X' — run \`login --name X\` first`. But headed `login` needs a display and is unavailable on a server / in a container, so this normal "no profile yet" state misled the agent into thinking the browser was broken.

The hint now names the headless `auto-login --cred <LOGIN_CRED>` path first (the one that actually works in a container), with headed `login` as the display-only fallback.

Extracted `loginHint`/`noProfileHint`/`DEFAULT_PROFILE` into `lib/hints.mjs` so they're unit-testable — `bin/cli.mjs` runs the CLI on import, so it can't be imported from a test. New `tests/test-browser-hints.mjs`. No changeset: private marketplace plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)