### PR TITLE
fix(browser): 🐛 type into the first VISIBLE field, not a hidden duplicate

### DIFF
--- a/plugins/agent-id-browser/lib/human-input.mjs
+++ b/plugins/agent-id-browser/lib/human-input.mjs
@@ -99,12 +99,34 @@ export async function humanMove(page, x, y, { rng = Math.random } = {}) {
   lastPos.set(page, { x, y });
 }
 
+// Resolve `selector` to its first VISIBLE match, waiting up to `timeout` for one
+// to appear. A plain `.first()` grabs the first element in DOM order — but a site
+// can render a HIDDEN duplicate of a field first and the real (visible) one after
+// (LinkedIn's login page renders the whole form twice: a hidden copy, then the
+// visible one). Targeting the hidden copy makes every action against it time out,
+// which is exactly how an auto-login silently fails to fill anything. Poll for a
+// visible match; fall back to `.first()` if none turns up so `locate`'s own
+// waitFor still yields a normal "not visible" timeout. `root` is a Page OR Frame.
+async function firstVisible(root, selector, timeout) {
+  const loc = root.locator(selector);
+  const deadline = Date.now() + Math.max(0, timeout);
+  for (;;) {
+    const n = await loc.count().catch(() => 0);
+    for (let i = 0; i < n; i++) {
+      const el = loc.nth(i);
+      if (await el.isVisible().catch(() => false)) return el;
+    }
+    if (Date.now() >= deadline) return loc.first();
+    await new Promise((r) => setTimeout(r, 100));
+  }
+}
+
 // Resolve a selector to a first visible element, scrolled into view. `root` is
 // a Page OR a Frame — an element inside an iframe is located via its frame,
 // while the mouse/keyboard (below) stay page-global (they address viewport
 // coordinates and the focused element, which frames share).
 async function locate(root, selector, timeout) {
-  const el = root.locator(selector).first();
+  const el = await firstVisible(root, selector, timeout);
   await el.waitFor({ state: "visible", timeout });
   await el.scrollIntoViewIfNeeded({ timeout }).catch(() => {});
   return el;
@@ -154,7 +176,7 @@ export async function humanType(
   // swallowed: if the field can't be cleared we must fail rather than type into
   // (and corrupt) leftover content — the secret paths wrap this in a value-free
   // catch, so a throw never leaks the value.
-  await root.locator(selector).first().fill("", { timeout });
+  await (await firstVisible(root, selector, timeout)).fill("", { timeout });
   const delays = keystrokeDelays(value.length, { rng });
   for (let i = 0; i < value.length; i++) {
     await page.keyboard.type(value[i]);

--- a/tests/test-human-input-live.mjs
+++ b/tests/test-human-input-live.mjs
@@ -138,3 +138,39 @@ test(
     }
   },
 );
+
+test(
+  "types into the first VISIBLE match when a hidden duplicate comes first (LinkedIn-style)",
+  { skip: patchrightAvailable ? false : "patchright/Chrome not installed" },
+  async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "human-dup-"));
+    let ctx;
+    try {
+      ctx = await launchContext({ profileDir: dir, headless: true });
+      const page = ctx.pages()[0] || (await ctx.newPage());
+      // A hidden copy of the field FIRST in DOM order, then the visible one — the
+      // shape LinkedIn's login page renders. A plain `.first()` targets the hidden
+      // copy and fills nothing; the fix is to target the first VISIBLE match.
+      await page.setContent(
+        `<input id="hidden" type="email" style="display:none">` +
+          `<input id="shown" type="email">`,
+      );
+      // Fill via the same kind of broad, multi-match selector the auto-login
+      // heuristic uses (matches BOTH inputs).
+      await humanType(page, 'input[type="email"]', "visible@example.com");
+      assert.equal(
+        await page.locator("#shown").inputValue(),
+        "visible@example.com",
+        "the visible field is the one that gets filled",
+      );
+      assert.equal(
+        await page.locator("#hidden").inputValue(),
+        "",
+        "the hidden duplicate is left untouched",
+      );
+    } finally {
+      if (ctx) await ctx.close().catch(() => {});
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    }
+  },
+);


### PR DESCRIPTION
## Symptom
`alien_browser_auto_login` against LinkedIn "attempted the login but timed out" — which read as anti-automation detection.

## Root cause (not detection)
Diagnosed live from the hosted container: LinkedIn's login page loads fine (HTTP 200, `navigator.webdriver === false`, clean UA — stealth is working). But its React login page renders the **whole form twice**: a hidden copy first in DOM order, then the visible one. `humanType`/`humanClick` resolved selectors with `.locator(sel).first()` = first in DOM order = the **hidden** field. So every fill/click targeted an invisible element and **nothing got entered**. The empty submit left the login classifier in `unknown` for all 6 rounds → the unhelpful `"timeout"` outcome.

This isn't LinkedIn-specific — any site with a hidden duplicate field breaks the same way.

## Fix
Add `firstVisible(root, selector, timeout)` — polls for the first *visible* match (falling back to `.first()` so `locate`'s own `waitFor` still yields a normal timeout) — and use it in `locate()` and `humanType`'s clear step. Ref-based interactive actions are unaffected (a `data-aibref` selector matches exactly one, already-visible element).

## Verification
Live against real LinkedIn from the container with the patched module: the visible email field received the probe value and the visible password field received 14 chars — both filled, no error. Added a deterministic regression test (`setContent` with a hidden-then-visible input; auto-skips without patchright).

No changeset: private marketplace plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)