### PR TITLE
fix(browser): 🐛 detect challenge widgets by vendor markers, not language

### DIFF
--- a/plugins/agent-id-browser/lib/auto-login.mjs
+++ b/plugins/agent-id-browser/lib/auto-login.mjs
@@ -213,9 +213,32 @@ export async function resolveOtp(cred, { env = process.env, log = () => {}, now 
   return String(values.otp || "").trim();
 }
 
+// A visible CAPTCHA / anti-automation challenge WIDGET, matched by well-known
+// vendor markers rather than page copy — so it flags a challenge wall no matter
+// what language the page is in (the text classifier is inherently localized; a
+// datacenter host gets pages in the region's language). LinkedIn's post-login
+// checkpoint embeds an Arkose FunCaptcha; reCAPTCHA/hCaptcha/PerimeterX are the
+// other common ones. An automated login can't solve any of these, so a VISIBLE
+// one means "blocked" (the caller advises a one-time headed login). We match only
+// the interactive widgets — NOT reCAPTCHA v3's always-present `.grecaptcha-badge`
+// — and require visibility, so a routine invisible token doesn't trip it.
+// Exported for tests.
+export const CHALLENGE_WIDGET_SEL = [
+  'iframe[src*="captcha" i]',
+  'iframe[src*="arkoselabs" i]',
+  'iframe[src*="funcaptcha" i]',
+  'iframe[title*="captcha" i]',
+  'iframe[title*="challenge" i]',
+  ".g-recaptcha",
+  ".h-captcha",
+  "#px-captcha",
+  '[id*="arkose" i]',
+  '[class*="arkose" i]',
+].join(",");
+
 // Snapshot the page into the shape classifyLogin expects (browser-side).
 async function detectPageState(page) {
-  return page.evaluate(() => {
+  return page.evaluate((challengeSel) => {
     const all = (sel) => Array.from(document.querySelectorAll(sel));
     const visible = (e) => !!(e.offsetParent !== null || e.getClientRects().length);
     const hasPasswordField = all('input[type="password"]').some(visible);
@@ -226,8 +249,11 @@ async function detectPageState(page) {
       .map((e) => `${e.name || ""} ${e.id || ""} ${e.placeholder || ""} ${e.autocomplete || ""}`.trim())
       .filter(Boolean);
     const bodyText = (document.body && document.body.innerText ? document.body.innerText : "").slice(0, 4000);
-    return { hasPasswordField, hasOtpField, otpFieldNames, bodyText };
-  });
+    // Language-independent block signal: a visible challenge widget. Fed to
+    // classifyLogin via its `blocked` input so it wins over "logged-in".
+    const blocked = all(challengeSel).some(visible);
+    return { hasPasswordField, hasOtpField, otpFieldNames, bodyText, blocked };
+  }, CHALLENGE_WIDGET_SEL);
 }
 
 // Best-effort fill of the OTP field, then submit.

--- a/tests/test-login-challenge-widget.mjs
+++ b/tests/test-login-challenge-widget.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+// The login classifier's ONE language-independent block signal: a visible
+// anti-automation challenge WIDGET (Arkose / reCAPTCHA / hCaptcha / PerimeterX),
+// matched by vendor DOM markers rather than page copy. This is what flags
+// LinkedIn's post-login checkpoint (an Arkose FunCaptcha) as "blocked" regardless
+// of the page's language — we deliberately do NOT try to enumerate block phrases
+// in every language. LIVE (matches selectors in a real browser); auto-skips when
+// patchright / Chrome are unavailable.
+//
+// Run: node --test tests/test-login-challenge-widget.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs/promises";
+
+import { resolvePatchright, launchContext } from "../plugins/agent-id-browser/lib/launch.mjs";
+import { CHALLENGE_WIDGET_SEL } from "../plugins/agent-id-browser/lib/auto-login.mjs";
+
+const patchrightAvailable = !!resolvePatchright();
+const skip = patchrightAvailable ? false : "patchright/Chrome not installed";
+
+// Count only VISIBLE matches (the same test detectPageState applies) so an
+// invisible token widget doesn't count as a challenge.
+async function visibleChallengeCount(page) {
+  return page.evaluate((sel) => {
+    const visible = (e) => !!(e.offsetParent !== null || e.getClientRects().length);
+    return Array.from(document.querySelectorAll(sel)).filter(visible).length;
+  }, CHALLENGE_WIDGET_SEL);
+}
+
+async function withPage(fn) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "challenge-"));
+  let ctx;
+  try {
+    ctx = await launchContext({ profileDir: dir, headless: true });
+    const page = ctx.pages()[0] || (await ctx.newPage());
+    await fn(page);
+  } finally {
+    if (ctx) await ctx.close().catch(() => {});
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+test("challenge widgets (Arkose / reCAPTCHA / hCaptcha) are detected, in any language", { skip }, async () => {
+  await withPage(async (page) => {
+    // Vendor markers only — no English text anywhere on the page.
+    await page.setContent(
+      `<div class="g-recaptcha" data-sitekey="x" style="width:300px;height:78px"></div>` +
+        `<iframe title="Vérification de sécurité" src="https://client-api.arkoselabs.com/x"` +
+        ` style="width:300px;height:200px"></iframe>`,
+    );
+    assert.ok((await visibleChallengeCount(page)) >= 1, "a visible challenge widget is found regardless of page language");
+  });
+});
+
+test("an ordinary login form is NOT flagged as a challenge", { skip }, async () => {
+  await withPage(async (page) => {
+    await page.setContent(
+      `<form><input type="email"><input type="password"><button>Se connecter</button></form>`,
+    );
+    assert.equal(await visibleChallengeCount(page), 0, "a plain login form has no challenge widget");
+  });
+});


### PR DESCRIPTION
## Context
Follow-up to the LinkedIn auto-login work. An auto-login that hits an anti-automation wall was reported as a generic `"timeout"`, because the wall's copy is **localized** (a datacenter host is served pages in the region's language — ours in eu-west-3 gets French) and the login-outcome classifier's block/error phrases are English.

The wrong fix is to enumerate block phrases per language (brittle, never complete). Forcing `locale: en-US` doesn't help either — IP-geo sites like LinkedIn ignore Accept-Language.

## Fix
Detect the challenge **widget** structurally by well-known vendor DOM markers — Arkose/FunCaptcha (what LinkedIn's checkpoint embeds), reCAPTCHA, hCaptcha, PerimeterX — which is **language-independent**. A visible one feeds `classifyLogin`'s existing `blocked` input, so the outcome becomes the actionable `"blocked"` (→ "sign in once headed") instead of `"timeout"`.

Precision: only matches interactive widgets (not reCAPTCHA v3's always-present invisible `.grecaptcha-badge`) and requires visibility, so a routine invisible token doesn't trip it.

## Test
`tests/test-login-challenge-widget.mjs` (live, auto-skips): a page with only vendor markers (no English text) is detected; a plain login form is not.

No changeset: private marketplace plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)