### PR TITLE
feat(browser): :sparkles: fill-text — paste-style one-shot insert into the focused element

### DIFF
--- a/plugins/agent-id-browser/bin/cli.mjs
+++ b/plugins/agent-id-browser/bin/cli.mjs
@@ -816,6 +816,7 @@ runCli({
     "drag-xy": actionCmd("drag-xy", (f) => ({ x: f.x, y: f.y, tox: f.tox, toy: f.toy, css: f.css === true })),
     "scroll-xy": actionCmd("scroll-xy", (f) => ({ x: f.x, y: f.y, dx: f.dx, dy: f.dy, css: f.css === true })),
     "type-text": actionCmd("type-text", (f) => ({ text: f.text ?? "", submit: f.submit === true })),
+    "fill-text": actionCmd("fill-text", (f) => ({ text: f.text ?? "", submit: f.submit === true })),
     "probe-xy": actionCmd("probe-xy", (f) => ({ x: f.x, y: f.y, css: f.css === true })),
     resize: actionCmd("resize", (f) => ({ width: f.width, height: f.height })),
     screenshot: actionCmd("screenshot", (f) => ({ path: f.path, fullPage: f.full === true || f.fullPage === true, region: region(f.region) })),
@@ -886,6 +887,8 @@ runCli({
         "          (zoom-toward-point on maps; scroll an inner pane). dy>0 = down.\n" +
         "  type-text --name N --text T [--submit]       type into the focused element\n" +
         "          (plaintext only — secrets stay ref-based via fill-secret/fill-otp)\n" +
+        "  fill-text --name N --text T [--submit]       paste into the focused element\n" +
+        "          (one-shot insert, no per-key events — fast for long text)\n" +
         "  probe-xy --name N --x N --y N                what element is at a pixel\n" +
         "          (tag/role/name/ref — vision→DOM bridge; read-only, ro-safe)\n" +
         "  zoom    --name N --region x0,y0,x1,y1 [--path P]   cropped closer view of\n" +

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -588,6 +588,20 @@ async function dispatch(state, msg, policy = null) {
       if (p.submit) await page.keyboard.press("Enter");
       return { typed: text.length, submit: !!p.submit };
     }
+    case "fill-text": {
+      // Paste-style counterpart to `type-text`: insert the whole text at the
+      // caret in one shot (insertText — an `input` event, no per-key keydown/
+      // keyup), the way a clipboard paste lands. Use it for long text where
+      // per-keystroke typing is slow or where key handlers mangle input; use
+      // `type-text` when the page needs real keystrokes (search-as-you-type,
+      // autocomplete). Same contract otherwise: PLAINTEXT ONLY (secrets stay
+      // ref-based via fill-secret/fill-otp), APPENDS at the caret (no clear),
+      // and only the length leaves the session, never the text.
+      const text = String(p.text ?? "");
+      await page.keyboard.insertText(text);
+      if (p.submit) await page.keyboard.press("Enter");
+      return { filled: text.length, submit: !!p.submit };
+    }
     case "probe-xy": {
       // Read-only vision→DOM bridge: what element sits under a screenshot pixel?
       // Runs a fixed elementFromPoint (not agent JS like `eval`), reads no input

--- a/plugins/agent-id-browser/skills/agent-id-browser/SKILL.md
+++ b/plugins/agent-id-browser/skills/agent-id-browser/SKILL.md
@@ -221,6 +221,7 @@ CLI screenshot --path /tmp/shot.png
 #     image:{width:2560,height:1600} }   # coords you give are in IMAGE pixels
 CLI click-xy --x 1840 --y 220          # [--double] [--button right|middle]
 CLI type-text --text "wireless mouse" --submit   # into whatever click-xy focused
+CLI fill-text --text "long paste-style text"     # same target, one-shot insert
 CLI move-xy --x 400 --y 300            # hover by pixel
 CLI drag-xy --x 200 --y 500 --tox 900 --toy 500  # visual drag (sliders, canvas)
 CLI scroll-xy --x 900 --y 500 --dy -300          # wheel AT a point (dy<0 zoom in
@@ -235,9 +236,13 @@ for you (retina screenshots are 2× the viewport), so pass what you see in the
 PNG. Add `--css` only if your coords are already CSS pixels (e.g. from a
 `getBoundingClientRect` via `eval`). Coords address the **viewport**: scroll the
 target into view first, and use a viewport screenshot (not `--full`) as the
-reference — a full-page shot is taller than the clickable area. `type-text` types
-**plaintext only** (and appends — it doesn't clear the field); a secret still
-goes through ref-based `fill-secret`/`fill-otp`.
+reference — a full-page shot is taller than the clickable area. `type-text` and
+`fill-text` both write into the focused element, **plaintext only** (and append —
+they don't clear the field); a secret still goes through ref-based
+`fill-secret`/`fill-otp`. Choose by how the page listens: `type-text` sends real
+keystrokes (search-as-you-type, autocomplete, key-filtered inputs), `fill-text`
+inserts the whole text at once like a paste (fast for long text, immune to
+per-key handlers mangling input).
 `probe-xy` is read-only (works on ro sessions) — use it to confirm a click landed
 on the intended element, or to recover a `ref` for a ref-based follow-up.
 


### PR DESCRIPTION
Adds `fill-text` to the vision (coordinate) action family so the agent can choose between **typing** and **pasting** into the element a `click-xy` focused:

- `type-text` — real per-key keystrokes (search-as-you-type, autocomplete, key-filtered inputs)
- `fill-text` — one-shot `keyboard.insertText` (a single `input` event, like a clipboard paste): fast for long text, immune to per-key handlers mangling input

Same contract as `type-text` otherwise: plaintext only (secrets stay ref-based via `fill-secret`/`fill-otp`), appends at the caret (no clear), and only the text **length** leaves the session. Read-only sessions: allowed at the action layer like all DOM interaction — writes still die at the network gate.

Touchpoints: CLI registration + help, session-server dispatch, SKILL.md (with type-vs-paste guidance). Private plugin — no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)