### PR TITLE
chore(browser): :bookmark: release agent-id-browser 7.3.0 (vision actions + fill-text)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -69,7 +69,7 @@
     {
       "name": "agent-id-browser",
       "description": "Universal browser the agent drives fine-grained (click, type, fill forms, upload files, navigate, switch tabs, reach into iframes, handle dialogs, capture downloads, screenshot, run JS) via an accessibility snapshot with element refs, with the logged-in profile sealed in the agent vault. One-time headed login; headless thereafter. Drives the user's installed Chrome via patchright (installed at runtime into the plugin data dir on first session; no browser download). For authenticated sites that block API/OAuth/cookie approaches.",
-      "version": "7.2.0",
+      "version": "7.3.0",
       "source": "./plugins/agent-id-browser",
       "category": "identity",
       "keywords": [

--- a/plugins/agent-id-browser/.claude-plugin/plugin.json
+++ b/plugins/agent-id-browser/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-id-browser",
-  "version": "7.2.0",
+  "version": "7.3.0",
   "description": "Universal browser the agent drives, with the logged-in profile sealed in the agent vault. One-time headed login; headless automated reads/fetches thereafter.",
   "author": {
     "name": "Alien",

--- a/plugins/agent-id-browser/package.json
+++ b/plugins/agent-id-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alien-id/agent-id-browser",
-  "version": "7.2.0",
+  "version": "7.3.0",
   "type": "module",
   "private": true,
   "description": "Universal browser automation with the profile sealed in the agent vault.",


### PR DESCRIPTION
Marketplace release for the private browser plugin — bumps `plugins/agent-id-browser/package.json` to **7.3.0** and propagates it via `bun run sync-plugin-versions` (plugin.json + marketplace.json).

Ships #59 (coordinate/vision actions: click-xy, drag-xy, scroll-xy, type-text, probe-xy, zoom, resize, batch --delay, 1440×900 window) and #60 (fill-text paste-style insert).

npm is untouched: the browser plugin is `private` and changesets-`ignore`d; no pending changesets on main, so no Version PR / publish is involved. Same shape as #47's in-PR bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)