### PR TITLE
fix(browser): :bug: zoom in batch + human type-text cadence

### DIFF
--- a/plugins/agent-id-browser/lib/human-input.mjs
+++ b/plugins/agent-id-browser/lib/human-input.mjs
@@ -177,6 +177,21 @@ export async function humanType(
   // (and corrupt) leftover content — the secret paths wrap this in a value-free
   // catch, so a throw never leaks the value.
   await (await firstVisible(root, selector, timeout)).fill("", { timeout });
+  await humanTypeFocused(page, value, { rng, submit });
+}
+
+// Type into whatever currently holds focus, key-by-key with the same jittered
+// cadence as humanType — for coordinate-mode typing (`type-text`), where focus
+// came from a click-xy rather than a locator. No click, no clear: it appends at
+// the caret. `submit` presses Enter after a short dwell. With human input
+// disabled the keystrokes are sent back-to-back (still real key events).
+export async function humanTypeFocused(page, text, { rng = Math.random, submit = false } = {}) {
+  const value = String(text ?? "");
+  if (!humanInputEnabled()) {
+    await page.keyboard.type(value);
+    if (submit) await page.keyboard.press("Enter");
+    return;
+  }
   const delays = keystrokeDelays(value.length, { rng });
   for (let i = 0; i < value.length; i++) {
     await page.keyboard.type(value[i]);

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -43,6 +43,7 @@ import {
   humanMove,
   humanScroll,
   humanType,
+  humanTypeFocused,
 } from "./human-input.mjs";
 
 function sessionsDir(stateDir) {
@@ -169,6 +170,23 @@ export function regionToClip(region, dpr) {
     y: Math.min(y0, y1) / d,
     width: Math.abs(x1 - x0) / d,
     height: Math.abs(y1 - y0) / d,
+  };
+}
+
+// Clamp a clip (CSS px) to the viewport: an oversized region degrades to its
+// visible part, and one fully outside collapses to zero/negative area for the
+// caller to reject with a readable error (instead of Playwright's raw "clipped
+// area outside image"). Unknown viewport (JS-hostile page — the capture must
+// still be attempted) passes the clip through. Pure — exported for tests.
+export function clampClipToViewport(clip, viewport) {
+  if (!viewport) return { ...clip };
+  const x = Math.max(0, Math.min(clip.x, viewport.width));
+  const y = Math.max(0, Math.min(clip.y, viewport.height));
+  return {
+    x,
+    y,
+    width: Math.min(clip.width, viewport.width - x),
+    height: Math.min(clip.height, viewport.height - y),
   };
 }
 
@@ -583,9 +601,10 @@ async function dispatch(state, msg, policy = null) {
       // PLAINTEXT ONLY — secrets stay ref-based via fill-secret/fill-otp. Note it
       // APPENDS (no clear) unlike ref-based `type`; click a field's clear/select-all
       // first if replacing. Only the length leaves the session, never the text.
+      // Cadence comes from humanTypeFocused — the same jittered per-key delays as
+      // ref-based `type`; a fixed inter-key interval is itself a bot fingerprint.
       const text = String(p.text ?? "");
-      await page.keyboard.type(text, { delay: 25 });
-      if (p.submit) await page.keyboard.press("Enter");
+      await humanTypeFocused(page, text, { submit: !!p.submit });
       return { typed: text.length, submit: !!p.submit };
     }
     case "fill-text": {
@@ -670,6 +689,13 @@ async function dispatch(state, msg, policy = null) {
         .catch(() => null);
       return { resized: { width, height }, ...(viewport ? { viewport } : {}) };
     }
+    case "zoom":
+      // At the CLI `zoom` is sugar that the client maps onto `screenshot` with
+      // requireRegion set — but `batch` re-enters dispatch() by raw action name,
+      // so the alias must exist here too (SKILL.md promises batch runs any
+      // action). Force the region requirement and fall into the handler.
+      p.requireRegion = true;
+    // fallthrough
     case "screenshot": {
       const out = p.path ? String(p.path) : path.join(sessionsDir(msg._stateDir), `shot-${Date.now()}.png`);
       // dims are BEST-EFFORT and must never block the capture: a JS-hostile page
@@ -696,15 +722,9 @@ async function dispatch(state, msg, policy = null) {
       // `zoom` sets requireRegion — a region-less zoom is a mistake, not a full shot.
       if (p.requireRegion && !region) throw new Error("zoom needs --region x0,y0,x1,y1");
       if (region) {
-        const clip = regionToClip(region, p.css ? 1 : info.dpr);
         // Clamp to the viewport so an over-large region gives a helpful error
         // instead of a raw Playwright "clipped area outside image".
-        if (info.viewport) {
-          clip.x = Math.max(0, Math.min(clip.x, info.viewport.width));
-          clip.y = Math.max(0, Math.min(clip.y, info.viewport.height));
-          clip.width = Math.min(clip.width, info.viewport.width - clip.x);
-          clip.height = Math.min(clip.height, info.viewport.height - clip.y);
-        }
+        const clip = clampClipToViewport(regionToClip(region, p.css ? 1 : info.dpr), info.viewport);
         if (clip.width < 1 || clip.height < 1) {
           throw new Error("screenshot --region has zero area (or lies outside the viewport)");
         }

--- a/tests/test-browser-coords.mjs
+++ b/tests/test-browser-coords.mjs
@@ -12,7 +12,11 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { imageToViewport, regionToClip } from "../plugins/agent-id-browser/lib/session-server.mjs";
+import {
+  clampClipToViewport,
+  imageToViewport,
+  regionToClip,
+} from "../plugins/agent-id-browser/lib/session-server.mjs";
 
 test("imageToViewport: dpr=1 is identity", () => {
   assert.deepEqual(imageToViewport(300, 200, 1), { x: 300, y: 200 });
@@ -57,4 +61,44 @@ test("regionToClip: order-agnostic (x1<x0 / y1<y0 still yields positive size)", 
 
 test("regionToClip: string coords (from CLI) are coerced", () => {
   assert.deepEqual(regionToClip(["200", "100", "800", "500"], "2"), { x: 100, y: 50, width: 300, height: 200 });
+});
+
+// clampClipToViewport — keep a region crop inside the visible viewport
+
+const VIEWPORT = { width: 1280, height: 800 };
+
+test("clampClipToViewport: clip inside the viewport is unchanged", () => {
+  const clip = { x: 100, y: 50, width: 300, height: 200 };
+  assert.deepEqual(clampClipToViewport(clip, VIEWPORT), clip);
+});
+
+test("clampClipToViewport: oversized clip is trimmed to the viewport edges", () => {
+  assert.deepEqual(clampClipToViewport({ x: 1000, y: 700, width: 600, height: 300 }, VIEWPORT), {
+    x: 1000,
+    y: 700,
+    width: 280,
+    height: 100,
+  });
+});
+
+test("clampClipToViewport: negative origin is pulled back to 0", () => {
+  assert.deepEqual(clampClipToViewport({ x: -40, y: -20, width: 100, height: 100 }, VIEWPORT), {
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 100,
+  });
+});
+
+test("clampClipToViewport: clip fully outside collapses to non-positive area", () => {
+  const clamped = clampClipToViewport({ x: 2000, y: 1200, width: 300, height: 200 }, VIEWPORT);
+  assert.equal(clamped.x, VIEWPORT.width);
+  assert.equal(clamped.y, VIEWPORT.height);
+  assert.ok(clamped.width < 1);
+  assert.ok(clamped.height < 1);
+});
+
+test("clampClipToViewport: unknown viewport (JS-hostile page) passes the clip through", () => {
+  const clip = { x: 5000, y: 5000, width: 100, height: 100 };
+  assert.deepEqual(clampClipToViewport(clip, null), clip);
 });


### PR DESCRIPTION
Two small confirmed follow-ups from the #59 review of the coordinate (vision) actions.

## 1. `zoom` now works inside `batch`

`zoom` was CLI-level sugar only — `bin/cli.mjs` mapped it onto `screenshot` with `requireRegion: true`, but the dispatch switch in `lib/session-server.mjs` had no `"zoom"` case. So `batch --actions '[{"action":"zoom","params":{"region":[…]}}]'` threw `unknown action: zoom` while SKILL.md promises batch runs any action.

Fix: a dispatch alias — `case "zoom"` forces `p.requireRegion = true` and falls through into the `screenshot` handler. A region-less zoom in batch still errors (`zoom needs --region x0,y0,x1,y1`), same as at the CLI. `zoom` stays ro-safe (it is not in `RO_DENIED_ACTIONS`, like `screenshot`).

## 2. `type-text` gets human keystroke cadence

`type-text` typed with a fixed 25 ms inter-key delay — a robotic timing fingerprint inconsistent with the plugin's stealth posture, while ref-based `type` uses the jittered 45–120 ms (plus occasional think-pause) `keystrokeDelays` from `lib/human-input.mjs`.

Fix: the focused-element typing tail of `humanType` is extracted into a new exported `humanTypeFocused(page, text, { rng, submit })` (no click, no clear — appends at the caret), and `type-text` now calls it. It honors the `AGENT_ID_HUMAN_INPUT=0` escape hatch (back-to-back keystrokes, still real key events) and keeps the pre-Enter dwell on `--submit`. `humanType` now reuses the same tail, so ref- and coordinate-mode typing share one cadence path. **`fill-text` is untouched** — one-shot `insertText` is intentionally instant.

## Extra

The inline viewport-clamping in the screenshot `--region` path is extracted into a pure exported `clampClipToViewport(clip, viewport)` and unit-tested in `tests/test-browser-coords.mjs` (inside/oversized/negative-origin/fully-outside/unknown-viewport cases).

No changeset: `agent-id-browser` is a private marketplace plugin.

## Test plan

- [x] `bun run test` — 575 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)