### PR TITLE
chore(browser): :bookmark: release agent-id-browser 7.3.1 (zoom in batch + type-text cadence)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -69,7 +69,7 @@
     {
       "name": "agent-id-browser",
       "description": "Universal browser the agent drives fine-grained (click, type, fill forms, upload files, navigate, switch tabs, reach into iframes, handle dialogs, capture downloads, screenshot, run JS) via an accessibility snapshot with element refs, with the logged-in profile sealed in the agent vault. One-time headed login; headless thereafter. Drives the user's installed Chrome via patchright (installed at runtime into the plugin data dir on first session; no browser download). For authenticated sites that block API/OAuth/cookie approaches.",
-      "version": "7.3.0",
+      "version": "7.3.1",
       "source": "./plugins/agent-id-browser",
       "category": "identity",
       "keywords": [

--- a/plugins/agent-id-browser/.claude-plugin/plugin.json
+++ b/plugins/agent-id-browser/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-id-browser",
-  "version": "7.3.0",
+  "version": "7.3.1",
   "description": "Universal browser the agent drives, with the logged-in profile sealed in the agent vault. One-time headed login; headless automated reads/fetches thereafter.",
   "author": {
     "name": "Alien",

--- a/plugins/agent-id-browser/package.json
+++ b/plugins/agent-id-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alien-id/agent-id-browser",
-  "version": "7.3.0",
+  "version": "7.3.1",
   "type": "module",
   "private": true,
   "description": "Universal browser automation with the profile sealed in the agent vault.",


### PR DESCRIPTION
Marketplace release of `agent-id-browser` **7.3.0 → 7.3.1** (patch), shipping the #62 fixes:

- `zoom` works inside `batch` — dispatch alias for the region-required screenshot
- `type-text` uses the jittered human keystroke cadence (`humanTypeFocused`) instead of a fixed 25 ms inter-key delay

Version bumped in `plugins/agent-id-browser/package.json` (single source of truth) and propagated into `plugin.json` / `marketplace.json` with `bun run sync-plugin-versions` — same shape as the 7.3.0 release (#61).

No changeset / no npm publish: the browser plugin is `private` and `ignore`d by changesets; merging this PR is the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)