### PR TITLE
Preserve session cookies in sealed browser profiles

### DIFF
--- a/plugins/agent-id-browser/bin/cli.mjs
+++ b/plugins/agent-id-browser/bin/cli.mjs
@@ -42,6 +42,7 @@ import {
 import { openVault, loadAgentPrivateKey } from "@alien-id/agent-id-vault/lib/vault.mjs";
 
 import {
+  captureSessionCookies,
   newDek,
   sealProfile,
   unsealProfile,
@@ -236,6 +237,7 @@ async function withProfile({ flags, name, headless, action }) {
       try {
         result = await action(ctx, cred);
       } finally {
+        await captureSessionCookies({ context: ctx, profileDir: work }).catch(() => {});
         await ctx.close();
       }
       // Re-seal to capture the refreshed session (rotated cookies), then persist.
@@ -300,6 +302,11 @@ async function cmdLogin(flags) {
         flags["headed-default"] === true ? false : reuse ? reuse.headless !== false : true;
 
       const ctx = await launchContext({ profileDir: work, headless: false });
+      const cookieCheckpoint = setInterval(
+        () => captureSessionCookies({ context: ctx, profileDir: work }).catch(() => {}),
+        1000,
+      );
+      cookieCheckpoint.unref();
       stderr(
         resuming
           ? `A browser opened with your '${name}' session loaded${flags.url ? " at " + startUrl : ""}. ` +
@@ -314,7 +321,9 @@ async function cmdLogin(flags) {
         /* about:blank or slow page — fine, the user drives from here */
       }
       await waitForUserClose(ctx, Number(flags["timeout-sec"] || 600) * 1000);
+      clearInterval(cookieCheckpoint);
       try {
+        await captureSessionCookies({ context: ctx, profileDir: work });
         await ctx.close();
       } catch {
         /* already closed by the user */
@@ -449,6 +458,7 @@ async function cmdAutoLogin(flags) {
         result = await autoLogin({ page, cred, env: process.env, log: (m) => stderr(m) });
       } finally {
         // Close so the context flushes cookies/storage to the work dir before sealing.
+        await captureSessionCookies({ context: ctx, profileDir: work }).catch(() => {});
         await ctx.close().catch(() => {});
       }
 

--- a/plugins/agent-id-browser/lib/launch.mjs
+++ b/plugins/agent-id-browser/lib/launch.mjs
@@ -29,6 +29,8 @@ import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
+import { restoreSessionCookies } from "./profile-store.mjs";
+
 const require = createRequire(import.meta.url);
 const PLUGIN_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -180,5 +182,7 @@ export async function launchContext({ profileDir, headless = true, contextOption
     const ua = await resolveHeadlessUserAgent();
     if (ua) opts.userAgent = ua;
   }
-  return chromium.launchPersistentContext(profileDir, opts);
+  const context = await chromium.launchPersistentContext(profileDir, opts);
+  await restoreSessionCookies({ context, profileDir });
+  return context;
 }

--- a/plugins/agent-id-browser/lib/profile-store.mjs
+++ b/plugins/agent-id-browser/lib/profile-store.mjs
@@ -21,6 +21,7 @@ import { promisify } from "node:util";
 const pExecFile = promisify(execFile);
 
 const PROFILES_SUBDIR = "browser-profiles";
+const SESSION_COOKIES_FILE = ".agent-id-session-cookies.json";
 
 // Chrome writes large, regenerable caches into the profile; excluding them keeps
 // a sealed profile to ~2 MB instead of tens of MB.
@@ -42,6 +43,41 @@ export function sealedProfilePath(stateDir, file) {
 
 export function newDek() {
   return crypto.randomBytes(32).toString("hex");
+}
+
+// Chrome removes session-only cookies from its cookie database on a clean
+// shutdown. Keep those cookies inside the plaintext working profile while the
+// browser is live so they are included in the encrypted profile sidecar and can
+// be restored on the next launch. Persistent cookies remain Chrome-managed.
+export async function captureSessionCookies({ context, profileDir }) {
+  const cookies = await context.cookies();
+  const sessionCookies = cookies.filter((cookie) => cookie.expires === -1);
+  const file = path.join(profileDir, SESSION_COOKIES_FILE);
+  const tmp = `${file}.tmp`;
+  await fs.writeFile(tmp, JSON.stringify(sessionCookies), { mode: 0o600 });
+  await fs.rename(tmp, file);
+  return sessionCookies.length;
+}
+
+export async function restoreSessionCookies({ context, profileDir }) {
+  let cookies;
+  try {
+    cookies = JSON.parse(await fs.readFile(path.join(profileDir, SESSION_COOKIES_FILE), "utf8"));
+  } catch (err) {
+    if (err?.code === "ENOENT" || err instanceof SyntaxError) return 0;
+    throw err;
+  }
+  if (!Array.isArray(cookies) || cookies.length === 0) return 0;
+  const valid = cookies.filter(
+    (cookie) =>
+      cookie &&
+      typeof cookie.name === "string" &&
+      typeof cookie.value === "string" &&
+      typeof cookie.domain === "string" &&
+      typeof cookie.path === "string",
+  );
+  if (valid.length) await context.addCookies(valid);
+  return valid.length;
 }
 
 // Layout: iv(12) | gcm-tag(16) | ciphertext

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -28,7 +28,7 @@ import path from "node:path";
 import crypto from "node:crypto";
 
 import { launchContext } from "./launch.mjs";
-import { sealProfile } from "./profile-store.mjs";
+import { captureSessionCookies, sealProfile } from "./profile-store.mjs";
 import { openVault, loadAgentPrivateKey } from "@alien-id/agent-id-vault/lib/vault.mjs";
 import { SECRET_FIELDS, hostMatchesAllowlist } from "@alien-id/agent-id-vault/lib/store.mjs";
 import { resolveOtp } from "./auto-login.mjs";
@@ -982,6 +982,7 @@ export async function runSession({
   async function finalize() {
     if (finalizing) return;
     finalizing = true;
+    try { await captureSessionCookies({ context: ctx, profileDir: workDir }); } catch { /* already gone */ }
     try { await ctx.close(); } catch { /* already gone */ }
     try { await sealProfile({ stateDir, file: profileFile, dekHex, sourceDir: workDir }); } catch { /* best effort */ }
     try { await fs.rm(workDir, { recursive: true, force: true }); } catch { /* best effort */ }

--- a/tests/test-browser-session-cookies.mjs
+++ b/tests/test-browser-session-cookies.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  captureSessionCookies,
+  restoreSessionCookies,
+} from "../plugins/agent-id-browser/lib/profile-store.mjs";
+
+test("session-only cookies survive an encrypted-profile close/reopen cycle", async () => {
+  const profileDir = await fs.mkdtemp(path.join(os.tmpdir(), "agent-id-cookie-test-"));
+  try {
+    const session = {
+      name: "session",
+      value: "secret-session-value",
+      domain: "example.com",
+      path: "/",
+      expires: -1,
+      httpOnly: true,
+      secure: true,
+      sameSite: "Lax",
+    };
+    const persistent = { ...session, name: "persistent", expires: 2_000_000_000 };
+    const source = { cookies: async () => [session, persistent] };
+    assert.equal(await captureSessionCookies({ context: source, profileDir }), 1);
+
+    let restored = null;
+    const target = { addCookies: async (cookies) => { restored = cookies; } };
+    assert.equal(await restoreSessionCookies({ context: target, profileDir }), 1);
+    assert.deepEqual(restored, [session]);
+  } finally {
+    await fs.rm(profileDir, { recursive: true, force: true });
+  }
+});
+
+test("capturing an empty cookie jar clears a stale session checkpoint", async () => {
+  const profileDir = await fs.mkdtemp(path.join(os.tmpdir(), "agent-id-cookie-test-"));
+  try {
+    await captureSessionCookies({
+      context: {
+        cookies: async () => [
+          { name: "old", value: "value", domain: "example.com", path: "/", expires: -1 },
+        ],
+      },
+      profileDir,
+    });
+    await captureSessionCookies({ context: { cookies: async () => [] }, profileDir });
+
+    let called = false;
+    const count = await restoreSessionCookies({
+      context: { addCookies: async () => { called = true; } },
+      profileDir,
+    });
+    assert.equal(count, 0);
+    assert.equal(called, false);
+  } finally {
+    await fs.rm(profileDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- preserve Chrome session-only cookies when sealing browser profiles
- restore those cookies into the persistent context on the next launch
- checkpoint headed sessions so closing the browser window does not lose the latest session state
- cover capture, restore, persistent-cookie exclusion, and logout clearing behavior

## Validation

- `npm test` (577 tests: 572 passed, 5 skipped)
- real Patchright/Chrome login against `the-internet.herokuapp.com`
- sealed profile reopened in a fresh browser process at `/secure` with `sessionExpired: false`

Session cookies are stored only in the temporary plaintext profile while active and inside the existing AES-256-GCM sealed profile at rest. They are not emitted to stdout or stored in vault metadata.
