### PR TITLE
feat(browser): :zap: JPEG screenshots by default for vision actions

### DIFF
--- a/plugins/agent-id-browser/bin/cli.mjs
+++ b/plugins/agent-id-browser/bin/cli.mjs
@@ -908,7 +908,8 @@ runCli({
         "  cookies [--url U]       cookie metadata (names/domains — values stay sealed)\n" +
         "  batch   --actions '[{\"action\":\"click-xy\",\"params\":{\"x\":9,\"y\":9}},…]' [--delay MS]\n" +
         "          one round trip; any action incl. click-xy/drag-xy; stops on error\n" +
-        "  screenshot --name N [--path P] [--full]     PNG + {dpr,viewport,image} for click-xy\n" +
+        "  screenshot --name N [--path P] [--full]     JPEG (PNG if --path *.png) +\n" +
+        "          {format,dpr,viewport,image} for click-xy\n" +
         "  eval    --name N --js 'EXPR'\n" +
         "  sessions                list open sessions   close --name N\n\n" +
         "Unlock: agent-key (auto) | --passphrase-file F | --passphrase-env V |\n" +

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -173,6 +173,20 @@ export function regionToClip(region, dpr) {
   };
 }
 
+// Screenshot encoding. Default to JPEG: a JPEG is a fraction of the equivalent
+// retina PNG, so the model ingests the image far faster (the dominant cost of a
+// vision step). Emit lossless PNG only when the caller's --path asks for it by a
+// `.png` extension. `quality` (JPEG only — invalid for PNG) is tunable via
+// AGENT_ID_SCREENSHOT_QUALITY, clamped to 1..100, default 80 (kept high so `zoom`
+// crops of tiny text/icons stay legible). Pure — exported for tests.
+export function screenshotEncoding(outPath, quality) {
+  if (/\.png$/i.test(String(outPath || ""))) return {};
+  const raw = typeof quality === "string" ? quality.trim() : quality;
+  const n = Number(raw);
+  const set = raw != null && raw !== "" && Number.isFinite(n);
+  return { type: "jpeg", quality: set ? Math.min(100, Math.max(1, Math.round(n))) : 80 };
+}
+
 // Clamp a clip (CSS px) to the viewport: an oversized region degrades to its
 // visible part, and one fully outside collapses to zero/negative area for the
 // caller to reject with a readable error (instead of Playwright's raw "clipped
@@ -697,7 +711,9 @@ async function dispatch(state, msg, policy = null) {
       p.requireRegion = true;
     // fallthrough
     case "screenshot": {
-      const out = p.path ? String(p.path) : path.join(sessionsDir(msg._stateDir), `shot-${Date.now()}.png`);
+      const out = p.path ? String(p.path) : path.join(sessionsDir(msg._stateDir), `shot-${Date.now()}.jpg`);
+      const enc = screenshotEncoding(out, process.env.AGENT_ID_SCREENSHOT_QUALITY);
+      const format = enc.type || "png";
       // dims are BEST-EFFORT and must never block the capture: a JS-hostile page
       // (PDF viewer, chrome://, mid-navigation) can't run this evaluate, but the
       // pixel capture is exactly what you still want there. Default dpr=1, no
@@ -731,19 +747,20 @@ async function dispatch(state, msg, policy = null) {
         // Guard the capture too: when viewport was unknown (JS-hostile page) we
         // couldn't clamp, so a raw clip error becomes a readable one.
         try {
-          await page.screenshot({ path: out, clip });
+          await page.screenshot({ path: out, clip, ...enc });
         } catch (err) {
           throw new Error(`screenshot --region could not capture (region likely outside the page): ${err.message || err}`);
         }
         return {
           screenshot: out,
+          format,
           dpr: info.dpr,
           region,
           image: { width: Math.round(clip.width * info.dpr), height: Math.round(clip.height * info.dpr) },
         };
       }
-      await page.screenshot({ path: out, fullPage: !!p.fullPage });
-      const result = { screenshot: out, dpr: info.dpr };
+      await page.screenshot({ path: out, fullPage: !!p.fullPage, ...enc });
+      const result = { screenshot: out, format, dpr: info.dpr };
       if (info.viewport) result.viewport = info.viewport;
       if (p.fullPage) {
         result.fullPage = true; // spans the whole page — not a valid click reference

--- a/plugins/agent-id-browser/skills/agent-id-browser/SKILL.md
+++ b/plugins/agent-id-browser/skills/agent-id-browser/SKILL.md
@@ -204,7 +204,7 @@ CLI back
 CLI page-text --max-chars 4000     # visible text of the page
 CLI get    --ref e5 --what text|html|value|attr --attr href   # or --what url|title
 CLI is     --ref e5 --what visible|enabled|checked|editable
-CLI screenshot --path /tmp/shot.png [--full]
+CLI screenshot --path /tmp/shot.jpg [--full]   # JPEG by default; pass a *.png path for lossless PNG
 CLI eval   --js "document.title"
 CLI wait   --text "Inbox"          # or --url SUBSTR | --load networkidle | --ms 1500
 ```
@@ -216,8 +216,8 @@ express the target — a `<canvas>`, a map, a custom-rendered widget, a drag on 
 visual slider. The loop is: `screenshot` → read the PNG → point at a pixel.
 
 ```bash
-CLI screenshot --path /tmp/shot.png
-# → { screenshot:"/tmp/shot.png", dpr:2, viewport:{width:1280,height:800},
+CLI screenshot --path /tmp/shot.jpg
+# → { screenshot:"/tmp/shot.jpg", format:"jpeg", dpr:2, viewport:{width:1280,height:800},
 #     image:{width:2560,height:1600} }   # coords you give are in IMAGE pixels
 CLI click-xy --x 1840 --y 220          # [--double] [--button right|middle]
 CLI type-text --text "wireless mouse" --submit   # into whatever click-xy focused
@@ -245,6 +245,9 @@ inserts the whole text at once like a paste (fast for long text, immune to
 per-key handlers mangling input).
 `probe-xy` is read-only (works on ro sessions) — use it to confirm a click landed
 on the intended element, or to recover a `ref` for a ref-based follow-up.
+Screenshots are **JPEG by default** (a fraction of a retina PNG's size, so the
+model reads them far faster); pass a `--path` ending in `.png` for lossless PNG,
+and tune JPEG quality with `AGENT_ID_SCREENSHOT_QUALITY` (1–100, default 80).
 
 **Batch coordinate sequences** — `batch` runs any of these (incl. `click-xy` /
 `drag-xy` / `scroll-xy`) in ONE round trip; add `--delay MS` to pace steps for

--- a/tests/test-browser-coords.mjs
+++ b/tests/test-browser-coords.mjs
@@ -16,6 +16,7 @@ import {
   clampClipToViewport,
   imageToViewport,
   regionToClip,
+  screenshotEncoding,
 } from "../plugins/agent-id-browser/lib/session-server.mjs";
 
 test("imageToViewport: dpr=1 is identity", () => {
@@ -101,4 +102,27 @@ test("clampClipToViewport: clip fully outside collapses to non-positive area", (
 test("clampClipToViewport: unknown viewport (JS-hostile page) passes the clip through", () => {
   const clip = { x: 5000, y: 5000, width: 100, height: 100 };
   assert.deepEqual(clampClipToViewport(clip, null), clip);
+});
+
+// screenshotEncoding — JPEG by default, PNG only for an explicit .png path
+test("screenshotEncoding: default (jpg path) is jpeg at quality 80", () => {
+  assert.deepEqual(screenshotEncoding("/tmp/shot.jpg"), { type: "jpeg", quality: 80 });
+});
+
+test("screenshotEncoding: an explicit .png path stays lossless PNG (no type/quality)", () => {
+  assert.deepEqual(screenshotEncoding("/tmp/shot.png"), {});
+  assert.deepEqual(screenshotEncoding("/tmp/SHOT.PNG"), {}); // case-insensitive
+});
+
+test("screenshotEncoding: quality is honored and clamped to 1..100", () => {
+  assert.equal(screenshotEncoding("/tmp/a.jpg", 50).quality, 50);
+  assert.equal(screenshotEncoding("/tmp/a.jpg", 0).quality, 1);
+  assert.equal(screenshotEncoding("/tmp/a.jpg", 999).quality, 100);
+  assert.equal(screenshotEncoding("/tmp/a.jpg", 61.7).quality, 62); // rounded
+});
+
+test("screenshotEncoding: non-numeric quality falls back to 80", () => {
+  assert.equal(screenshotEncoding("/tmp/a.jpg", undefined).quality, 80);
+  assert.equal(screenshotEncoding("/tmp/a.jpg", "").quality, 80);
+  assert.equal(screenshotEncoding("/tmp/a.jpg", "abc").quality, 80);
 });


### PR DESCRIPTION
Default `screenshot`/`zoom` to JPEG (quality 80, tunable via `AGENT_ID_SCREENSHOT_QUALITY`); an explicit `--path *.png` still captures lossless PNG. Response payloads gain a `format` field.

A retina PNG viewport screenshot is ~3-5x bigger than the equivalent JPEG, so the smaller file is quicker to read off disk, base64, and send. **This buys transfer latency, not tokens.** Images are billed by pixel dimensions (`⌈w/28⌉ × ⌈h/28⌉` visual tokens), so a JPEG and a PNG of the same screenshot cost exactly the same. The lever for spending fewer tokens is shrinking the image (`zoom --region` a crop, or a smaller viewport) — not the encoding.

The tradeoff: JPEG puts ringing artifacts around sharp text, which is what `zoom` exists to read. Quality is kept at 80 to stay legible, and `--path *.png` remains available where fidelity matters more than speed.

> Earlier revisions of this description claimed JPEG cut "the dominant per-step cost of coordinate (vision) actions." That was wrong on the mechanism — corrected here and in the code comments/skill docs.