### PR TITLE
feat(browser): publish agent-id-browser to npm

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -13,8 +13,7 @@
   "ignore": [
     "@alien-id/agent-id-auth",
     "@alien-id/agent-id-git",
-    "@alien-id/agent-id-proxy",
-    "@alien-id/agent-id-browser"
+    "@alien-id/agent-id-proxy"
   ],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "updateInternalDependents": "always"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,21 +7,27 @@ and approve two gates.
 
 ## What is published
 
-Only the two shared libraries go to npm:
+Three packages go to npm:
 
 | Package | npm | Why |
 | --- | --- | --- |
 | `@alien-id/agent-id-core` | public | shared crypto / bundle / verifier / OIDC / state |
 | `@alien-id/agent-id-vault` | public | encrypted credential vault (depends on core) |
+| `@alien-id/agent-id-browser` | public | vault-sealed browser automation; also consumed as a library (the Lethe desktop bundles it as an npm dependency) |
 
-The four consuming plugins — `agent-id-auth`, `agent-id-git`,
-`agent-id-proxy`, `agent-id-browser` — are **marketplace-only**. They are
-`"private": true` and listed under `ignore` in `.changeset/config.json`, so
-changesets never versions or publishes them. At runtime each one `npm install`s
-`@alien-id/agent-id-core` (+ `-vault`) into its persistent plugin-data dir via a
-`SessionStart` hook (`hooks/install-deps.sh`) and symlinks it into the plugin
-root so the bare `@alien-id/*` ESM imports resolve. **Core and vault must exist
-on npm before those plugins can install** — see Bootstrap below.
+`agent-id-browser` is dual-channel: it ships as a marketplace plugin **and** is
+published to npm, so external apps can depend on it instead of vendoring a
+tarball. Its published tarball carries `^`-ranged `@alien-id/agent-id-core` (+
+`-vault`) deps, so an `npm install` pulls them transitively.
+
+The three remaining consuming plugins — `agent-id-auth`, `agent-id-git`,
+`agent-id-proxy` — are **marketplace-only**. They are `"private": true` and
+listed under `ignore` in `.changeset/config.json`, so changesets never versions
+or publishes them. At runtime each one `npm install`s `@alien-id/agent-id-core`
+(+ `-vault`) into its persistent plugin-data dir via a `SessionStart` hook
+(`hooks/install-deps.sh`) and symlinks it into the plugin root so the bare
+`@alien-id/*` ESM imports resolve. **Core and vault must exist on npm before
+those plugins can install** — see Bootstrap below.
 
 ## Three manual gates
 
@@ -53,8 +59,8 @@ degrading to a decision, so a network blip can never skip a real publish.
 
 ## Adding a changeset
 
-On any branch that touches code shipped to npm (`plugins/agent-id-core/**` or
-`plugins/agent-id-vault/**`):
+On any branch that touches code shipped to npm (`plugins/agent-id-core/**`,
+`plugins/agent-id-vault/**`, or `plugins/agent-id-browser/**`):
 
 ```bash
 bun changeset
@@ -70,10 +76,10 @@ bump too (`updateInternalDependents: always`).
 
 | Bumping... | Auto-patches |
 | --- | --- |
-| `@alien-id/agent-id-core` | `@alien-id/agent-id-vault` |
-| `@alien-id/agent-id-vault` | (nothing published) |
+| `@alien-id/agent-id-core` | `@alien-id/agent-id-vault`, `@alien-id/agent-id-browser` |
+| `@alien-id/agent-id-vault` | `@alien-id/agent-id-browser` |
 
-The four `ignore`d plugins keep their own `version` (changesets never bumps
+The three `ignore`d plugins keep their own `version` (changesets never bumps
 it), but `changeset version` **does rewrite their dependency range** — e.g. a
 core minor turns `"@alien-id/agent-id-core": "^7.0.0"` into `"^7.1.0"` in each
 plugin's `package.json`. So a Version PR carries package.json diffs for the
@@ -138,9 +144,13 @@ After that, the changesets pipeline owns all subsequent releases.
 
 ## Manual operator tasks (one-time)
 
-1. Configure npm **trusted publishers** for `@alien-id/agent-id-core` and
-   `@alien-id/agent-id-vault` to authorize `.github/workflows/release.yml`
-   (the `publish` job). Without this, OIDC publish fails `EUNAUTHORIZED`.
+1. Configure npm **trusted publishers** for `@alien-id/agent-id-core`,
+   `@alien-id/agent-id-vault`, and `@alien-id/agent-id-browser` to authorize
+   `.github/workflows/release.yml` (the `publish` job). Without this, OIDC
+   publish fails `EUNAUTHORIZED`. `agent-id-browser` is a **new** publish
+   target — its trusted-publisher entry must be created before the first
+   release, and since 7.3.1 is not yet on npm the publish job will pick it up
+   on the next push to `main`.
 2. Create the **`npm-publish` GitHub Environment** with the maintainer set as
    required reviewers.
 3. Do the one-time **Bootstrap** publish above so the marketplace plugins can

--- a/plugins/agent-id-browser/package.json
+++ b/plugins/agent-id-browser/package.json
@@ -2,8 +2,17 @@
   "name": "@alien-id/agent-id-browser",
   "version": "7.3.1",
   "type": "module",
-  "private": true,
   "description": "Universal browser automation with the profile sealed in the agent vault.",
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "lib",
+    "bin",
+    "hooks",
+    "skills",
+    ".claude-plugin"
+  ],
   "bin": {
     "agent-id-browser": "./bin/cli.mjs"
   },


### PR DESCRIPTION
## Why

The Lethe desktop app currently bundles `@alien-id/agent-id-browser` from a hand-repacked tarball committed to another repo (`lethe-hosted/deploy/agent-id-browser.tgz`). That tarball drifts behind source (repo is at 7.3.1, the vendored copy was 7.2.0) and updates only via manual repacks. Publishing the package to npm lets external consumers depend on it the same way they already do for `agent-id-core` / `agent-id-vault`.

## What

- `plugins/agent-id-browser/package.json`: drop `"private": true`; add `publishConfig.access=public` and an explicit `files` allowlist (`lib`, `bin`, `hooks`, `skills`, `.claude-plugin`) — parity with core/vault, plus `hooks` which the marketplace runtime needs.
- `.changeset/config.json`: remove `@alien-id/agent-id-browser` from `ignore`, so changesets versions/publishes it. The `detect`/`publish-topological` scripts already select by `!private`, so no script changes needed — topo order becomes **core → vault → browser**.
- `RELEASING.md`: document the now dual-channel package (marketplace **and** npm), the cascade (core/vault bumps now patch browser), the changeset scope, and the new trusted-publisher operator task.

Verified: `bun scripts/publish-topological.ts --dry-run` lists browser in order; `bun install --frozen-lockfile` reports no changes.

## ⚠️ This reverses a documented decision

`RELEASING.md` previously listed browser as intentionally **marketplace-only / private**. This PR makes it public on npm. Please confirm that's desired — a browser-automation package has a larger public support/supply-chain surface (the repo's `.npmrc` hardening still applies).

## Operator step required before first release

`agent-id-browser` is a **new** npm publish target. Create its **npm trusted-publisher** entry authorizing `.github/workflows/release.yml` **before** merging — otherwise the OIDC `publish` job fails `EUNAUTHORIZED`. Since 7.3.1 is not on npm yet, `detect` will set `shouldPublish` on the next push to `main` and publish it (subject to the `npm-publish` environment approval). No changeset is included: the first publish ships the existing 7.3.1, mirroring how core/vault were bootstrapped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)