### PR TITLE
docs(browser): :memo: correct JPEG screenshot rationale and stale PNG refs

### DIFF
--- a/.changeset/olive-jars-repeat.md
+++ b/.changeset/olive-jars-repeat.md
@@ -1,0 +1,9 @@
+---
+"@alien-id/agent-id-browser": patch
+---
+
+Correct the JPEG screenshot rationale in the browser skill and code comments.
+The shipped guidance claimed JPEG cut the dominant per-step cost of vision
+actions; images are billed by pixel dimensions, not bytes, so encoding does not
+change token cost. Point at the lever that does (shrinking the image), and drop
+the stale "read the PNG" wording now that the default output is JPEG.

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -134,7 +134,7 @@ export function safeFilename(name) {
   return (cleaned || "file").slice(0, 80);
 }
 
-// Screenshot pixels → viewport (CSS) pixels. The PNG is captured at the context's
+// Screenshot pixels → viewport (CSS) pixels. The image is captured at the context's
 // devicePixelRatio (retina = 2×); page.mouse takes CSS px, so divide by dpr.
 // `--css` skips this (coords already CSS px). Pure — exported for tests.
 export function imageToViewport(x, y, dpr) {
@@ -173,9 +173,11 @@ export function regionToClip(region, dpr) {
   };
 }
 
-// Screenshot encoding. Default to JPEG: a JPEG is a fraction of the equivalent
-// retina PNG, so the model ingests the image far faster (the dominant cost of a
-// vision step). Emit lossless PNG only when the caller's --path asks for it by a
+// Screenshot encoding. Default to JPEG: a fraction of the equivalent retina PNG's
+// bytes, so it's quicker to read off disk and send. This buys transfer latency,
+// NOT tokens — images bill by pixel dimensions (⌈w/28⌉ × ⌈h/28⌉ visual tokens),
+// so the same shot costs the same either way; shrink the image to spend less.
+// Emit lossless PNG only when the caller's --path asks for it by a
 // `.png` extension. `quality` (JPEG only — invalid for PNG) is tunable via
 // AGENT_ID_SCREENSHOT_QUALITY, clamped to 1..100, default 80 (kept high so `zoom`
 // crops of tiny text/icons stay legible). Pure — exported for tests.

--- a/plugins/agent-id-browser/skills/agent-id-browser/SKILL.md
+++ b/plugins/agent-id-browser/skills/agent-id-browser/SKILL.md
@@ -213,7 +213,7 @@ CLI wait   --text "Inbox"          # or --url SUBSTR | --load networkidle | --ms
 cheaper (a snapshot is smaller than a screenshot on heavy pages), deterministic,
 and robust to layout shifts. Reach for coordinates ONLY when the snapshot can't
 express the target — a `<canvas>`, a map, a custom-rendered widget, a drag on a
-visual slider. The loop is: `screenshot` → read the PNG → point at a pixel.
+visual slider. The loop is: `screenshot` → read the image → point at a pixel.
 
 ```bash
 CLI screenshot --path /tmp/shot.jpg
@@ -233,7 +233,7 @@ CLI zoom --region 1700,150,1980,300    # cropped closer view — read tiny icons
 All coordinate actions — `click-xy`, `move-xy`, `drag-xy`, `scroll-xy`,
 `probe-xy`, and `zoom --region` — take **screenshot pixels** and divide by `dpr`
 for you (retina screenshots are 2× the viewport), so pass what you see in the
-PNG. Add `--css` only if your coords are already CSS pixels (e.g. from a
+image. Add `--css` only if your coords are already CSS pixels (e.g. from a
 `getBoundingClientRect` via `eval`). Coords address the **viewport**: scroll the
 target into view first, and use a viewport screenshot (not `--full`) as the
 reference — a full-page shot is taller than the clickable area. `type-text` and
@@ -245,9 +245,14 @@ inserts the whole text at once like a paste (fast for long text, immune to
 per-key handlers mangling input).
 `probe-xy` is read-only (works on ro sessions) — use it to confirm a click landed
 on the intended element, or to recover a `ref` for a ref-based follow-up.
-Screenshots are **JPEG by default** (a fraction of a retina PNG's size, so the
-model reads them far faster); pass a `--path` ending in `.png` for lossless PNG,
-and tune JPEG quality with `AGENT_ID_SCREENSHOT_QUALITY` (1–100, default 80).
+Screenshots are **JPEG by default** — a fraction of a retina PNG's bytes, so
+they're quicker to read off disk and send. This does **not** cut token cost:
+images are billed by pixel dimensions (`⌈w/28⌉ × ⌈h/28⌉` visual tokens), so a
+JPEG and a PNG of the same shot cost the same. To spend fewer tokens, shrink the
+image (`zoom --region` a crop, or a smaller viewport) — not the encoding.
+Pass a `--path` ending in `.png` for lossless PNG when JPEG artifacts around
+sharp text would hurt, and tune quality with `AGENT_ID_SCREENSHOT_QUALITY`
+(1–100, default 80).
 
 **Batch coordinate sequences** — `batch` runs any of these (incl. `click-xy` /
 `drag-xy` / `scroll-xy`) in ONE round trip; add `--delay MS` to pace steps for


### PR DESCRIPTION
Follow-up to #65, which merged while this was under review — these doc corrections missed that merge and need their own PR.

#65 justified the JPEG default as cutting "the dominant per-step cost of coordinate (vision) actions since the model has to ingest the image every round trip." The premise is wrong: images are billed by **pixel dimensions** (`⌈w/28⌉ × ⌈h/28⌉` visual tokens per [the vision docs](https://platform.claude.com/docs/en/build-with-claude/vision)), not by bytes. A JPEG and a PNG of the same screenshot cost **identical tokens**, so the switch saves none.

The change is still worth having — a smaller file is quicker to read off disk, base64, and send — but that is transfer latency, not token cost. This PR states that accurately and points at the lever that does reduce tokens (shrinking the image), so the next reader does not reach for encoding to solve a cost problem.

Also drops the leftover "read the PNG" / "pass what you see in the PNG" wording now that the default output is JPEG.

**No runtime change** — comments and skill docs only. Patch changeset included since #66 published `agent-id-browser` to npm, so the corrected guidance ships to users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)