### PR TITLE
feat(browser): live viewport stream, typed form tools, serialized input (7.5.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -69,7 +69,7 @@
     {
       "name": "agent-id-browser",
       "description": "Alien Browser with an auto-created anonymous L0 profile for public pages and vault-sealed logged-in profiles. Includes compact form inspection and one-call verified filling for fields, checks, selects, and uploads, plus fine-grained refs, tabs, dialogs, downloads, screenshots, and live viewport control.",
-      "version": "7.5.0",
+      "version": "7.5.1",
       "source": "./plugins/agent-id-browser",
       "category": "identity",
       "keywords": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -68,8 +68,8 @@
     },
     {
       "name": "agent-id-browser",
-      "description": "Universal browser the agent drives fine-grained (click, type, fill forms, upload files, navigate, switch tabs, reach into iframes, handle dialogs, capture downloads, screenshot, run JS) via an accessibility snapshot with element refs, with the logged-in profile sealed in the agent vault. One-time headed login; headless thereafter. Drives the user's installed Chrome via patchright (installed at runtime into the plugin data dir on first session; no browser download). For authenticated sites that block API/OAuth/cookie approaches.",
-      "version": "7.3.1",
+      "description": "Alien Browser with an auto-created anonymous L0 profile for public pages and vault-sealed logged-in profiles. Includes compact form inspection and one-call verified filling for fields, checks, selects, and uploads, plus fine-grained refs, tabs, dialogs, downloads, screenshots, and live viewport control.",
+      "version": "7.5.0",
       "source": "./plugins/agent-id-browser",
       "category": "identity",
       "keywords": [

--- a/plugins/agent-id-browser/.claude-plugin/plugin.json
+++ b/plugins/agent-id-browser/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-id-browser",
-  "version": "7.5.0",
+  "version": "7.5.1",
   "description": "Alien Browser with anonymous L0 public browsing, vault-sealed login profiles, and compact verified form filling.",
   "author": {
     "name": "Alien",

--- a/plugins/agent-id-browser/.claude-plugin/plugin.json
+++ b/plugins/agent-id-browser/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-id-browser",
-  "version": "7.3.1",
-  "description": "Universal browser the agent drives, with the logged-in profile sealed in the agent vault. One-time headed login; headless automated reads/fetches thereafter.",
+  "version": "7.5.0",
+  "description": "Alien Browser with anonymous L0 public browsing, vault-sealed login profiles, and compact verified form filling.",
   "author": {
     "name": "Alien",
     "email": "support@alien.org"

--- a/plugins/agent-id-browser/CHANGELOG.md
+++ b/plugins/agent-id-browser/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @alien-id/agent-id-browser
 
+## 7.5.1
+
+### Patch Changes
+
+- [#69](https://github.com/alien-id/agent-id/pull/69) Stream viewer input applies through a promise chain in arrival order — a same-tick move/press/release burst could previously reorder (unawaited page.mouse calls) and drop the click. Suspend/page checks re-run at apply time, so a credential fill starting mid-queue still gates the queued tail.
+- [#69](https://github.com/alien-id/agent-id/pull/69) `open --url <START>` navigates before the ready line ("ready" now means "up and on the page"); the outcome rides in the ready JSON as `navigation:{url,status}`, and a bad or slow URL is non-fatal.
+
+## 7.5.0
+
+### Minor Changes
+
+- [#69](https://github.com/alien-id/agent-id/pull/69) Typed form tools: `form-inspect` (compact controls with labels/types/requirements/options; never returns text/password values) and `form-fill --spec` (atomic multi-control fill — fields/checks/selects/uploads, max 50 — with per-control verification and native validation reporting).
+- [#69](https://github.com/alien-id/agent-id/pull/69) The shared `main` profile auto-creates as an anonymous L0 browser-profile, so public browsing needs no login or prior setup. Explicitly named profiles remain opt-in account boundaries and never auto-create.
+
+## 7.4.0
+
+### Minor Changes
+
+- [#69](https://github.com/alien-id/agent-id/pull/69) Live viewport stream for open sessions (watch / pair-browse): a per-session localhost WS server streams CDP screencast JPEG frames and accepts mouse/keyboard input via page.mouse/keyboard — no CDP debug port, the profile seal stays intact. The feed and input suspend (depth-counted) during `fill-secret`/`fill-otp`; the session file gains `streamPort`/`streamToken`.
+
 ## 7.3.2
 
 ### Patch Changes

--- a/plugins/agent-id-browser/bin/cli.mjs
+++ b/plugins/agent-id-browser/bin/cli.mjs
@@ -2,8 +2,9 @@
 
 // Alien Agent ID — Browser plugin CLI.
 //
-// A universal browser the agent can drive, with the logged-in profile sealed in
-// the vault. By DEFAULT every command shares ONE session ("main") — sign into
+// A universal browser the agent can drive, with an anonymous-or-logged-in
+// profile sealed in the vault. By DEFAULT every command shares ONE session
+// ("main") — public browsing auto-creates it; sign into
 // Google once and every "Sign in with Google" site reuses it. `login` is ADDITIVE:
 // re-run it to add more sites to the same session. Pass --name to opt into a
 // SEPARATE, isolated session (a second account, a sandbox). After a HEADED login
@@ -46,9 +47,10 @@ import {
   sealProfile,
   unsealProfile,
   sealedProfileExists,
+  ensureAnonymousDefaultProfile,
 } from "../lib/profile-store.mjs";
 import { launchContext } from "../lib/launch.mjs";
-import { DEFAULT_PROFILE, loginHint, noProfileHint } from "../lib/hints.mjs";
+import { DEFAULT_PROFILE, loginHint, noProfileHint, profileName } from "../lib/hints.mjs";
 import { autoLogin } from "../lib/auto-login.mjs";
 import { looksLoggedOut } from "../lib/session.mjs";
 import { runSession, callSession } from "../lib/session-server.mjs";
@@ -209,7 +211,7 @@ async function withProfile({ flags, name, headless, action }) {
   const stateDir = resolveStateDir(flags);
   const vault = await openVaultUnlocked(flags);
   try {
-    const cred = vault.get(name);
+    const cred = await ensureAnonymousDefaultProfile({ vault, stateDir, name });
     if (!cred || cred.type !== "browser-profile") {
       const e = new Error(`no browser-profile named '${name}' — ${noProfileHint(name)}`);
       e.code = "NO_PROFILE";
@@ -254,7 +256,7 @@ async function withProfile({ flags, name, headless, action }) {
 // ─── Commands ─────────────────────────────────────────────────────────────────────
 
 async function cmdLogin(flags) {
-  const name = String(flags.name || DEFAULT_PROFILE);
+  const name = profileName(flags.name);
   const stateDir = resolveStateDir(flags);
   const startUrl = flags.url ? String(flags.url) : "about:blank";
   const access = flags.access != null ? String(flags.access) : null;
@@ -402,16 +404,16 @@ async function cmdAutoLogin(flags) {
       return outputError(`login '${credName}' has no loginUrl — set one so auto-login knows where to start`);
     }
 
-    const profileName = String(flags.name || cred.profile || DEFAULT_PROFILE);
+    const targetProfile = profileName(flags.name || cred.profile);
     // A login and its sealed browser-profile are two records in ONE name
     // namespace — sealing into the login's own name would overwrite it.
-    if (profileName === credName) {
+    if (targetProfile === credName) {
       return outputError(
-        `target profile '${profileName}' must differ from the login credential '${credName}' ` +
+        `target profile '${targetProfile}' must differ from the login credential '${credName}' ` +
           "(they share the vault namespace) — pass --name <other> or set the cred's `profile`",
       );
     }
-    const existing = vault.get(profileName);
+    const existing = vault.get(targetProfile);
     const reuse = existing && existing.type === "browser-profile" ? existing : null;
 
     // The session's access level is the STRICTEST of: the login credential's
@@ -427,8 +429,8 @@ async function cmdAutoLogin(flags) {
     }
     if (reuse && requestedAccess && isAccessRelaxation(reuse, { ...reuse, access: requestedAccess })) {
       return outputError(
-        `session '${profileName}' has access level '${effectiveAccess(reuse)}' — auto-login cannot ` +
-          `widen it. The owner can: agent-id-vault set-access --name ${profileName} --access ${requestedAccess}`,
+        `session '${targetProfile}' has access level '${effectiveAccess(reuse)}' — auto-login cannot ` +
+          `widen it. The owner can: agent-id-vault set-access --name ${targetProfile} --access ${requestedAccess}`,
       );
     }
     const sessionAccess = strictestAccess(
@@ -436,7 +438,7 @@ async function cmdAutoLogin(flags) {
       reuse ? effectiveAccess(reuse) : "rw",
     );
 
-    const file = reuse ? reuse.profileFile : `${profileName}.tar.enc`;
+    const file = reuse ? reuse.profileFile : `${targetProfile}.tar.enc`;
     const dek = reuse ? reuse.dek : newDek();
     const headless = resolveHeadless(flags) ?? true;
 
@@ -462,11 +464,11 @@ async function cmdAutoLogin(flags) {
           outcome === "blocked"
             ? `Auto-login for '${credName}' was blocked by an anti-automation wall (bot ` +
               "challenge / network-security block). This hits the login handshake specifically; " +
-              `sign in yourself once with headed \`login --name ${profileName}` +
+              `sign in yourself once with headed \`login --name ${targetProfile}` +
               `${requestedAccess ? ` --access ${requestedAccess}` : ""}\` — it seals the same session.`
             : `Auto-login for '${credName}' did not complete (${outcome}). ` +
               "Verify the credentials / loginUrl, add a `recipe` to the credential, or bootstrap " +
-              `once with headed \`login --name ${profileName}\`.`;
+              `once with headed \`login --name ${targetProfile}\`.`;
         outputJson({
           ok: false,
           error: "AUTO_LOGIN_FAILED",
@@ -482,7 +484,7 @@ async function cmdAutoLogin(flags) {
       const { bytes } = await sealProfile({ stateDir, file, dekHex: dek, sourceDir: work });
       vault.add({
         ...(reuse || {}),
-        name: profileName,
+        name: targetProfile,
         type: "browser-profile",
         domains: ["*"],
         description: reuse?.description || `Auto-login session for '${credName}' (agent-id-browser)`,
@@ -502,12 +504,12 @@ async function cmdAutoLogin(flags) {
       outputJson({
         ok: true,
         cred: credName,
-        profile: profileName,
+        profile: targetProfile,
         outcome: result.outcome,
         finalUrl: result.finalUrl,
         access: sessionAccess,
         sealedBytes: bytes,
-        message: `Logged in and sealed session '${profileName}'. Reuse it: \`read --name ${profileName} --url …\`.`,
+        message: `Logged in and sealed session '${targetProfile}'. Reuse it: \`read --name ${targetProfile} --url …\`.`,
       });
     } finally {
       await fs.rm(work, { recursive: true, force: true });
@@ -520,7 +522,7 @@ async function cmdAutoLogin(flags) {
 }
 
 async function cmdRead(flags) {
-  const name = String(flags.name || DEFAULT_PROFILE);
+  const name = profileName(flags.name);
   if (!flags.url) return outputError("--url is required");
   const url = String(flags.url);
   const maxChars = Number(flags["max-chars"] || 4000);
@@ -569,7 +571,7 @@ async function cmdRead(flags) {
 }
 
 async function cmdFetch(flags) {
-  const name = String(flags.name || DEFAULT_PROFILE);
+  const name = profileName(flags.name);
   if (!flags.url) return outputError("--url is required");
   const url = String(flags.url);
   const maxChars = Number(flags["max-chars"] || 8000);
@@ -621,7 +623,7 @@ async function cmdFetch(flags) {
 
 async function cmdStatus(flags) {
   const stateDir = resolveStateDir(flags);
-  const only = flags.name ? String(flags.name) : null;
+  const only = flags.name ? profileName(flags.name) : null;
   let vault;
   try {
     // Don't drive an Alien-app prompt just to report status — agent-key/passphrase only.
@@ -664,7 +666,7 @@ async function cmdStatus(flags) {
 // ─── Interactive session: open / close / actions ─────────────────────────────────
 
 async function cmdOpen(flags) {
-  const name = String(flags.name || DEFAULT_PROFILE);
+  const name = profileName(flags.name);
   const stateDir = resolveStateDir(flags);
   let vault;
   try {
@@ -677,7 +679,7 @@ async function cmdOpen(flags) {
   let headlessDefault;
   let policy = null;
   try {
-    const cred = vault.get(name);
+    const cred = await ensureAnonymousDefaultProfile({ vault, stateDir, name });
     if (!cred || cred.type !== "browser-profile") {
       const e = new Error(`no browser-profile named '${name}' — ${noProfileHint(name)}`);
       e.code = "NO_PROFILE";
@@ -722,7 +724,7 @@ async function cmdOpen(flags) {
 
 async function cmdClose(flags) {
   const stateDir = resolveStateDir(flags);
-  const name = String(flags.name || DEFAULT_PROFILE);
+  const name = profileName(flags.name);
   try {
     const r = await callSession(stateDir, name, "close", {});
     outputJson({ ok: true, closed: name, ...r });
@@ -760,7 +762,7 @@ async function cmdSessions(flags) {
 function actionCmd(action, map, timeoutMs) {
   return async (flags) => {
     const stateDir = resolveStateDir(flags);
-    const name = String(flags.name || DEFAULT_PROFILE);
+    const name = profileName(flags.name);
     try {
       const params = map ? map(flags) : {};
       const r = await callSession(stateDir, name, action, params, timeoutMs);
@@ -791,6 +793,8 @@ runCli({
     close: cmdClose,
     sessions: cmdSessions,
     snapshot: actionCmd("snapshot"),
+    "form-inspect": actionCmd("form-inspect"),
+    "form-fill": actionCmd("form-fill", (f) => JSON.parse(f.spec || "{}"), 120000),
     navigate: actionCmd("navigate", (f) => ({ url: requireUrl(f) })),
     back: actionCmd("back"),
     "page-text": actionCmd("text", (f) => ({ maxChars: f["max-chars"] })),
@@ -862,9 +866,15 @@ runCli({
         "          one-shot authenticated HTTP GET via the session (API / feed)\n" +
         "  status  [--name N]      list sealed sessions\n\n" +
         "Interactive session (--name optional; defaults to 'main'):\n" +
-        "  open    --name N [--headed]   start a persistent session (run in background)\n" +
+        "  open    --name N [--headed]   start a persistent session (run in background);\n" +
+        "          missing default 'main' auto-creates as an anonymous L0 profile\n" +
         "  snapshot --name N             accessibility tree with element refs; iframe\n" +
         "          elements get frame-prefixed refs (f1e3); reports open tabs when >1\n" +
+        "  form-inspect --name N           compact form controls + labels/types/requirements\n" +
+        "  form-fill --name N --spec '{\"fields\":[{\"ref\":\"e1\",\"value\":\"A\"}],\n" +
+        "          \"checks\":[{\"ref\":\"e2\",\"checked\":true}],\"selects\":[...],\n" +
+        "          \"uploads\":[{\"ref\":\"e3\",\"files\":[\"/a.pdf\"]}]}'\n" +
+        "          atomic fast fill with per-control verification; max 50 controls\n" +
         "  click   --name N --ref eN                   dblclick --name N --ref eN\n" +
         "  check   --name N --ref eN                   uncheck  --name N --ref eN\n" +
         "  type    --name N --ref eN --text T [--submit]\n" +

--- a/plugins/agent-id-browser/bin/cli.mjs
+++ b/plugins/agent-id-browser/bin/cli.mjs
@@ -715,7 +715,7 @@ async function cmdOpen(flags) {
         `${policy && effectiveAccess(policy) === "ro" ? ", READ-ONLY" : ""}). Keep this process ` +
         `running (background it); issue actions, then \`close --name ${name}\`.`,
     );
-    await runSession({ stateDir, name, headless, dekHex, profileFile, workDir, policy }); // blocks until close
+    await runSession({ stateDir, name, headless, dekHex, profileFile, workDir, policy, startUrl: flags.url }); // blocks until close
   } catch (err) {
     await fs.rm(workDir, { recursive: true, force: true }).catch(() => {});
     handleErr(err);
@@ -866,7 +866,8 @@ runCli({
         "          one-shot authenticated HTTP GET via the session (API / feed)\n" +
         "  status  [--name N]      list sealed sessions\n\n" +
         "Interactive session (--name optional; defaults to 'main'):\n" +
-        "  open    --name N [--headed]   start a persistent session (run in background);\n" +
+        "  open    --name N [--headed] [--url START]   start a persistent session (run in\n" +
+        "          background); navigates to START before reporting ready;\n" +
         "          missing default 'main' auto-creates as an anonymous L0 profile\n" +
         "  snapshot --name N             accessibility tree with element refs; iframe\n" +
         "          elements get frame-prefixed refs (f1e3); reports open tabs when >1\n" +

--- a/plugins/agent-id-browser/lib/access-guard.mjs
+++ b/plugins/agent-id-browser/lib/access-guard.mjs
@@ -29,7 +29,7 @@ import {
 // DOM-interactive stays available; mutations die at the network gate.
 // `upload` is denied too: feeding the owner's local files into a page is a
 // write in spirit (and page JS could exfiltrate the content over allowed GETs).
-const RO_DENIED_ACTIONS = Object.freeze(["eval", "fill-secret", "fill-otp", "upload"]);
+const RO_DENIED_ACTIONS = Object.freeze(["eval", "fill-secret", "fill-otp", "upload", "form-fill"]);
 
 // Pure — unit-tests without a browser. Throws on a denied action.
 export function assertActionAllowed(rec, action) {

--- a/plugins/agent-id-browser/lib/hints.mjs
+++ b/plugins/agent-id-browser/lib/hints.mjs
@@ -3,6 +3,19 @@
 
 export const DEFAULT_PROFILE = "main";
 
+// Session names become filenames under browser-sessions/browser-profiles.
+// Keep the public name identical to the filesystem slug rather than trying to
+// sanitize a dangerous value differently at each call site.
+export function profileName(value = DEFAULT_PROFILE) {
+  const name = String(value || DEFAULT_PROFILE);
+  if (!/^[A-Za-z0-9_-]{1,64}$/.test(name)) {
+    const error = new Error("browser profile name must be 1-64 letters, digits, '_' or '-'");
+    error.code = "INVALID_PROFILE_NAME";
+    throw error;
+  }
+  return name;
+}
+
 // Re-authenticate an EXISTING profile (headed). Used when a sealed session has
 // gone stale (logged out) — headed `login` re-signs into the same session.
 export const loginHint = (name) =>

--- a/plugins/agent-id-browser/lib/profile-store.mjs
+++ b/plugins/agent-id-browser/lib/profile-store.mjs
@@ -72,6 +72,42 @@ export async function sealedProfileExists(stateDir, file) {
   }
 }
 
+// Bootstrap the shared default cookie jar for an L0 identity. Public browsing
+// must not require a fake login credential, while explicitly named profiles
+// remain opt-in account boundaries and therefore never auto-create.
+export async function ensureAnonymousDefaultProfile({ vault, stateDir, name, defaultName = "main" }) {
+  const existing = vault.get(name);
+  if (existing) return existing;
+  if (name !== defaultName) {
+    const error = new Error(`no browser-profile named '${name}'`);
+    error.code = "NO_PROFILE";
+    throw error;
+  }
+
+  const file = `${defaultName}.tar.enc`;
+  const dek = newDek();
+  const empty = await fs.mkdtemp(path.join(os.tmpdir(), "agentid-banon-"));
+  try {
+    await sealProfile({ stateDir, file, dekHex: dek, sourceDir: empty });
+  } finally {
+    await fs.rm(empty, { recursive: true, force: true });
+  }
+  const record = vault.add({
+    name: defaultName,
+    type: "browser-profile",
+    domains: ["*"],
+    description: "Anonymous L0 browser profile (agent-id-browser)",
+    dek,
+    profileFile: file,
+    headless: true,
+    exportable: false,
+    bootstrap: "anonymous-l0",
+    lastSyncedAt: Date.now(),
+  });
+  await vault.save();
+  return record;
+}
+
 // tar the profile dir (excluding caches) → AES-256-GCM seal with the DEK →
 // write the sidecar (0600). Returns the sealed byte count.
 export async function sealProfile({ stateDir, file, dekHex, sourceDir }) {

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -117,6 +117,94 @@ export function snapshotInPage(prefix) {
   return { url: location.href, title: document.title, elements: out };
 }
 
+// Compact, form-specific observation. Unlike the generic accessibility
+// snapshot it includes CSS-hidden checkbox/radio/file inputs because modern
+// forms commonly render a styled label over the real control. Values from text
+// inputs are deliberately never returned; validation reports lengths/matches,
+// not the contents the user or vault supplied.
+export function formSnapshotInPage(prefix) {
+  const pre = prefix || "";
+  const SEL = [
+    "input:not([type=hidden])", "textarea", "select", "button",
+    "[role=textbox]", "[role=combobox]", "[role=checkbox]", "[role=radio]",
+    "[contenteditable=true]",
+  ].join(",");
+  for (const old of document.querySelectorAll("[data-aibref]")) old.removeAttribute("data-aibref");
+
+  const clip = (value, max = 120) =>
+    String(value || "").replace(/\s+/g, " ").trim().slice(0, max);
+  const labelledBy = (el) =>
+    clip(
+      (el.getAttribute("aria-labelledby") || "")
+        .split(/\s+/)
+        .filter(Boolean)
+        .map((id) => document.getElementById(id)?.textContent || "")
+        .join(" "),
+    );
+  const labelOf = (el) => {
+    const native = Array.from(el.labels || []).map((label) => label.textContent || "").join(" ");
+    const wrapped = el.closest("label")?.textContent || "";
+    const legend = el.closest("fieldset")?.querySelector("legend")?.textContent || "";
+    return clip(
+      el.getAttribute("aria-label") || labelledBy(el) || native || wrapped ||
+        el.getAttribute("placeholder") || el.getAttribute("title") ||
+        el.getAttribute("name") || legend,
+    );
+  };
+  const visibleOf = (el) => {
+    const r = el.getBoundingClientRect();
+    const st = window.getComputedStyle(el);
+    return r.width > 0 && r.height > 0 && st.visibility !== "hidden" && st.display !== "none";
+  };
+
+  const controls = [];
+  let i = 0;
+  for (const el of document.querySelectorAll(SEL)) {
+    const tag = el.tagName.toLowerCase();
+    const type = clip(
+      el.getAttribute("type") || (tag === "input" ? el.type || "text" : tag === "select" ? "select" : tag),
+      40,
+    ).toLowerCase();
+    const visible = visibleOf(el);
+    // Hidden native controls remain actionable through setChecked/setInputFiles.
+    if (!visible && !["checkbox", "radio", "file"].includes(type)) continue;
+    const ref = pre + "e" + ++i;
+    el.setAttribute("data-aibref", ref);
+    const form = el.closest("form");
+    const role = el.getAttribute("role") || tag;
+    const entry = {
+      ref,
+      role,
+      type,
+      label: labelOf(el),
+      ...(el.getAttribute("name") ? { name: clip(el.getAttribute("name"), 100) } : {}),
+      ...(el.required ? { required: true } : {}),
+      ...(el.disabled || el.getAttribute("aria-disabled") === "true" ? { disabled: true } : {}),
+      ...(el.readOnly ? { readonly: true } : {}),
+      ...(!visible ? { hidden: true } : {}),
+      ...(form ? { form: clip(form.getAttribute("name") || form.id || form.getAttribute("action") || "form", 160) } : {}),
+    };
+    if (type === "checkbox" || type === "radio" || role === "checkbox" || role === "radio") {
+      entry.checked = el.checked === true || el.getAttribute("aria-checked") === "true";
+    }
+    if (tag === "select") {
+      entry.multiple = !!el.multiple;
+      entry.options = Array.from(el.options).slice(0, 100).map((option) => ({
+        value: clip(option.value, 160),
+        label: clip(option.label || option.textContent, 160),
+        ...(option.disabled ? { disabled: true } : {}),
+        ...(option.selected ? { selected: true } : {}),
+      }));
+    }
+    if (type === "file") {
+      entry.multiple = !!el.multiple;
+      if (el.accept) entry.accept = clip(el.accept, 200);
+    }
+    controls.push(entry);
+  }
+  return { url: location.href, title: document.title, controls };
+}
+
 const sel = (ref) => `[data-aibref="${String(ref).replace(/["\\]/g, "")}"]`;
 const ACTION_TIMEOUT = 15000;
 const MAX_FRAMES = 12; // iframes snapshotted per page (ad-heavy pages have dozens)
@@ -195,6 +283,11 @@ export function clampClipToViewport(clip, viewport) {
 // points into. Child-frame refs are only valid until the next snapshot —
 // same contract as the refs themselves.
 function frameForRef(state, ref) {
+  if (!state.refsValid) {
+    throw new Error(
+      `ref '${ref}' is stale (${state.refsInvalidReason || "page changed"}) — run form-inspect or snapshot again`,
+    );
+  }
   const id = frameRefId(ref);
   if (!id) return state.current;
   const frame = state.frames.get(id);
@@ -202,6 +295,19 @@ function frameForRef(state, ref) {
     throw new Error(`frame for ref '${ref}' is gone — re-snapshot and retry`);
   }
   return frame;
+}
+
+function invalidateRefs(state, reason = "page changed") {
+  state.refsValid = false;
+  state.refsInvalidReason = reason;
+  state.frames.clear();
+}
+
+function activateRefs(state) {
+  state.refGeneration += 1;
+  state.refsValid = true;
+  state.refsInvalidReason = null;
+  return state.refGeneration;
 }
 
 // A field the vault typed a secret into is tagged with this attribute (see
@@ -290,12 +396,13 @@ function attachPage(state, page) {
         entry.error = String(err && err.message ? err.message : err).slice(0, 200);
       });
   });
+  page.on("framenavigated", () => invalidateRefs(state, "page navigated"));
   page.on("close", () => {
     if (state.current !== page) return;
     const left = state.ctx.pages().filter((pg) => pg !== page);
     if (left.length) {
       state.current = left[left.length - 1];
-      state.frames.clear();
+      invalidateRefs(state, "current tab changed");
     }
   });
 }
@@ -343,6 +450,172 @@ export function assertFillAllowed(rec, host, field = null) {
   }
 }
 
+async function uploadFiles(page, target, ref, files) {
+  const paths = (Array.isArray(files) ? files : []).map(String).filter(Boolean);
+  if (!paths.length) throw new Error("upload needs at least one file");
+  for (const file of paths) {
+    try {
+      await fs.access(file);
+    } catch {
+      throw new Error(`upload: file not found: ${file}`);
+    }
+  }
+  const selector = sel(ref);
+  const isFileInput = await target
+    .$eval(selector, (el) => el.tagName === "INPUT" && el.type === "file")
+    .catch(() => false);
+  if (isFileInput) {
+    await target.setInputFiles(selector, paths, { timeout: ACTION_TIMEOUT });
+  } else {
+    const [chooser] = await Promise.all([
+      page.waitForEvent("filechooser", { timeout: ACTION_TIMEOUT }),
+      target.click(selector, { timeout: ACTION_TIMEOUT }),
+    ]);
+    await chooser.setFiles(paths);
+  }
+  return paths.length;
+}
+
+function safeFormError(error, secret = "") {
+  let message = String(error?.message || error || "form operation failed").replace(/\s+/g, " ");
+  if (secret) message = message.split(secret).join("[value]");
+  return message.slice(0, 300);
+}
+
+async function validateTaggedControls(state) {
+  if (!state.refsValid) return { stale: true, invalid: [] };
+  const targets = [state.current, ...new Set(state.frames.values())];
+  const invalid = [];
+  for (const target of targets) {
+    const entries = await target
+      .$$eval("[data-aibref]", (elements) =>
+        elements
+          .filter((el) => el.willValidate === true && el.checkValidity() === false)
+          .map((el) => ({
+            ref: el.getAttribute("data-aibref"),
+            reason: String(el.validationMessage || "invalid").slice(0, 160),
+          })),
+      )
+      .catch(() => []);
+    invalid.push(...entries);
+  }
+  return { valid: invalid.length === 0, invalid };
+}
+
+// Atomic, fast form executor: one model/tool round-trip fills ordinary fields,
+// toggles styled controls, selects options, and attaches files. Every operation
+// is checked after it runs and failures are returned individually so one bad
+// field cannot discard the successful half of a long application form.
+export async function fillForm(state, p) {
+  const fields = Array.isArray(p.fields) ? p.fields : [];
+  const checks = Array.isArray(p.checks) ? p.checks : [];
+  const selects = Array.isArray(p.selects) ? p.selects : [];
+  const uploads = Array.isArray(p.uploads) ? p.uploads : [];
+  const operationCount = fields.length + checks.length + selects.length + uploads.length;
+  if (!operationCount) throw new Error("form-fill needs fields, checks, selects, or uploads");
+  if (operationCount > 50) throw new Error("form-fill: max 50 controls");
+  if (!state.refsValid) frameForRef(state, fields[0]?.ref || checks[0]?.ref || selects[0]?.ref || uploads[0]?.ref || "?");
+
+  const results = [];
+  for (const field of fields) {
+    const ref = String(field?.ref || "");
+    const value = String(field?.value ?? "");
+    try {
+      const target = frameForRef(state, ref);
+      const locator = target.locator(sel(ref));
+      const secretTarget = await locator.evaluate(
+        (el, attr) => (el.tagName === "INPUT" && el.type === "password") || el.hasAttribute(attr),
+        SECRET_TAINT_ATTR,
+      );
+      if (secretTarget) throw new Error("password/secret fields require fill-secret or fill-otp");
+      await locator.fill(value, { timeout: ACTION_TIMEOUT });
+      const matches = await locator.evaluate((el, expected) => {
+        const actual = "value" in el ? el.value : el.textContent || "";
+        return { matches: actual === expected, length: String(actual).length };
+      }, value);
+      if (!matches.matches) throw new Error("page did not retain the supplied value");
+      results.push({ ref, kind: "field", ok: true, length: matches.length });
+    } catch (error) {
+      results.push({ ref, kind: "field", ok: false, error: safeFormError(error, value) });
+    }
+  }
+  for (const check of checks) {
+    const ref = String(check?.ref || "");
+    const checked = check?.checked !== false;
+    try {
+      const locator = frameForRef(state, ref).locator(sel(ref));
+      const native = await locator.evaluate((el) => ({
+        native: el.tagName === "INPUT" && ["checkbox", "radio"].includes(el.type),
+        visible: !!(el.getBoundingClientRect().width && el.getBoundingClientRect().height) &&
+          getComputedStyle(el).visibility !== "hidden" && getComputedStyle(el).display !== "none",
+      }));
+      if (native.native && !native.visible) {
+        // Styled controls often hide the native input completely. Playwright's
+        // check action still insists on visibility even with force in patched
+        // drivers, so update the real control and emit the same bubbling events
+        // frameworks observe.
+        await locator.evaluate((el, desired) => {
+          const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "checked")?.set;
+          if (setter) setter.call(el, desired);
+          else el.checked = desired;
+          el.dispatchEvent(new Event("input", { bubbles: true }));
+          el.dispatchEvent(new Event("change", { bubbles: true }));
+        }, checked);
+      } else if (native.native) {
+        await locator.setChecked(checked, { timeout: ACTION_TIMEOUT });
+      } else {
+        const before = (await locator.getAttribute("aria-checked")) === "true";
+        if (before !== checked) await locator.click({ timeout: ACTION_TIMEOUT });
+      }
+      const actual = native.native
+        ? await locator.isChecked()
+        : (await locator.getAttribute("aria-checked")) === "true";
+      if (actual !== checked) throw new Error("page did not retain the checked state");
+      results.push({ ref, kind: "check", ok: true, checked: actual });
+    } catch (error) {
+      results.push({ ref, kind: "check", ok: false, error: safeFormError(error) });
+    }
+  }
+  for (const select of selects) {
+    const ref = String(select?.ref || "");
+    const values = (Array.isArray(select?.values) ? select.values : [select?.value]).filter((v) => v != null).map(String);
+    try {
+      const selected = await frameForRef(state, ref).selectOption(sel(ref), values, { timeout: ACTION_TIMEOUT });
+      const matches = values.every((value) => selected.includes(value));
+      if (!matches) throw new Error("page did not retain the selected option(s)");
+      results.push({ ref, kind: "select", ok: true, selected });
+    } catch (error) {
+      results.push({ ref, kind: "select", ok: false, error: safeFormError(error) });
+    }
+  }
+  for (const upload of uploads) {
+    const ref = String(upload?.ref || "");
+    try {
+      const count = await uploadFiles(state.current, frameForRef(state, ref), ref, upload?.files);
+      results.push({ ref, kind: "upload", ok: true, files: count });
+    } catch (error) {
+      results.push({ ref, kind: "upload", ok: false, error: safeFormError(error) });
+    }
+  }
+
+  const failed = results.filter((result) => !result.ok).length;
+  let submitted = false;
+  if (!failed && p.submit) {
+    const ref = String(p.submit);
+    await frameForRef(state, ref).click(sel(ref), { timeout: ACTION_TIMEOUT });
+    submitted = true;
+  }
+  const validation = await validateTaggedControls(state);
+  return {
+    ok: failed === 0 && validation.invalid.length === 0,
+    completed: results.length - failed,
+    failed,
+    results,
+    validation,
+    ...(submitted ? { submitted: true } : {}),
+  };
+}
+
 async function dispatch(state, msg, policy = null) {
   const p = msg.params || {};
   const page = state.current;
@@ -386,13 +659,50 @@ async function dispatch(state, msg, policy = null) {
         }
       }
       const tabs = state.ctx.pages().length;
+      const generation = activateRefs(state);
       return {
         ...main,
+        generation,
         ...(frames.length ? { frames } : {}),
         ...(skipped ? { framesSkipped: skipped } : {}),
         ...(tabs > 1 ? { tabs, tab: state.ctx.pages().indexOf(page) } : {}),
       };
     }
+    case "form-inspect": {
+      state.frames.clear();
+      const main = await page.evaluate(formSnapshotInPage, "");
+      const frames = [];
+      let skipped = 0;
+      let fCount = 0;
+      for (const frame of page.frames()) {
+        if (frame === page.mainFrame()) continue;
+        if (fCount >= MAX_FRAMES) {
+          skipped++;
+          continue;
+        }
+        let snap;
+        try {
+          snap = await frame.evaluate(formSnapshotInPage, `f${fCount + 1}`);
+        } catch {
+          continue;
+        }
+        fCount++;
+        state.frames.set(`f${fCount}`, frame);
+        if (snap.controls.length) {
+          frames.push({ frame: `f${fCount}`, url: String(snap.url).slice(0, 200), controls: snap.controls.length });
+          main.controls.push(...snap.controls);
+        }
+      }
+      const generation = activateRefs(state);
+      return {
+        ...main,
+        generation,
+        ...(frames.length ? { frames } : {}),
+        ...(skipped ? { framesSkipped: skipped } : {}),
+      };
+    }
+    case "form-fill":
+      return fillForm(state, p);
     case "text":
       return { text: String(await page.evaluate(() => (document.body ? document.body.innerText : ""))).slice(0, Number(p.maxChars || 6000)) };
     case "click":
@@ -417,10 +727,7 @@ async function dispatch(state, msg, policy = null) {
     case "fill": {
       const fields = Array.isArray(p.fields) ? p.fields : [];
       for (const f of fields) {
-        await humanType(page, sel(f.ref), String(f.value ?? ""), {
-          timeout: ACTION_TIMEOUT,
-          root: frameForRef(state, f.ref),
-        });
+        await frameForRef(state, f.ref).fill(sel(f.ref), String(f.value ?? ""), { timeout: ACTION_TIMEOUT });
       }
       return { filled: fields.map((f) => f.ref) };
     }
@@ -529,31 +836,9 @@ async function dispatch(state, msg, policy = null) {
       // native chooser). Refused on read-only sessions: sending the owner's
       // local file content to a site is a write in spirit, even though the
       // resulting POST would also die at the network gate.
-      const files = (Array.isArray(p.files) ? p.files : []).map(String).filter(Boolean);
-      if (!files.length) throw new Error("upload needs --files /path/a[,/path/b]");
-      for (const f of files) {
-        try {
-          await fs.access(f);
-        } catch {
-          throw new Error(`upload: file not found: ${f}`);
-        }
-      }
       const t = frameForRef(state, p.ref);
-      const s = sel(p.ref);
-      const isFileInput = await t
-        .$eval(s, (el) => el.tagName === "INPUT" && el.type === "file")
-        .catch(() => false);
-      if (isFileInput) {
-        await t.setInputFiles(s, files, { timeout: ACTION_TIMEOUT });
-      } else {
-        // Not a bare <input type=file>: click it and feed the native chooser.
-        const [chooser] = await Promise.all([
-          page.waitForEvent("filechooser", { timeout: ACTION_TIMEOUT }),
-          t.click(s, { timeout: ACTION_TIMEOUT }),
-        ]);
-        await chooser.setFiles(files);
-      }
-      return { uploaded: p.ref, files: files.length };
+      const count = await uploadFiles(page, t, p.ref, p.files);
+      return { uploaded: p.ref, files: count };
     }
     case "drag": {
       const from = frameForRef(state, p.ref);
@@ -841,7 +1126,7 @@ async function dispatch(state, msg, policy = null) {
       const pg = await state.ctx.newPage();
       if (p.url) await pg.goto(String(p.url), { waitUntil: "domcontentloaded", timeout: 30000 });
       state.current = pg;
-      state.frames.clear();
+      invalidateRefs(state, "current tab changed");
       return { index: state.ctx.pages().indexOf(pg), url: pg.url() };
     }
     case "tab-switch": {
@@ -851,7 +1136,7 @@ async function dispatch(state, msg, policy = null) {
         throw new Error(`no tab ${p.index} (open tabs: 0..${pages.length - 1})`);
       }
       state.current = pages[index];
-      state.frames.clear();
+      invalidateRefs(state, "current tab changed");
       await state.current.bringToFront().catch(() => {});
       return { index, url: state.current.url(), title: await state.current.title().catch(() => "") };
     }
@@ -978,11 +1263,15 @@ export async function runSession({
     stateDir,
     current: page,
     frames: new Map(),
+    refsValid: false,
+    refsInvalidReason: "no snapshot yet",
+    refGeneration: 0,
     downloads: [],
     console: [],
     dialog: { mode: "dismiss", text: null },
     lastDialog: null,
   };
+  state.invalidateRefs = (reason) => invalidateRefs(state, reason);
   for (const pg of ctx.pages()) attachPage(state, pg);
   ctx.on("page", (pg) => attachPage(state, pg));
 

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -29,6 +29,7 @@ import crypto from "node:crypto";
 
 import { launchContext } from "./launch.mjs";
 import { sealProfile } from "./profile-store.mjs";
+import { startStreamServer } from "./stream-server.mjs";
 import { openVault, loadAgentPrivateKey } from "@alien-id/agent-id-vault/lib/vault.mjs";
 import { SECRET_FIELDS, hostMatchesAllowlist } from "@alien-id/agent-id-vault/lib/store.mjs";
 import { resolveOtp } from "./auto-login.mjs";
@@ -432,6 +433,9 @@ async function dispatch(state, msg, policy = null) {
       const credName = String(p.cred).slice(0, dot);
       const field = String(p.cred).slice(dot + 1);
       const target = frameForRef(state, p.ref);
+      // Viewport-stream blackout while the value is on its way into the page —
+      // watchers see nothing and viewer input is ignored until resume.
+      state.stream?.suspend();
       const vault = await openVaultAgentKey(msg._stateDir);
       try {
         const rec = vault.get(credName);
@@ -461,6 +465,7 @@ async function dispatch(state, msg, policy = null) {
         await markSecretField(target, sel(p.ref));
       } finally {
         vault.lock();
+        state.stream?.resume();
       }
       return { filled: p.ref, cred: p.cred };
     }
@@ -469,38 +474,45 @@ async function dispatch(state, msg, policy = null) {
       // stored seed, or asked via the secure prompt — and type it.
       const credName = String(p.cred || "");
       const target = frameForRef(state, p.ref);
-      const vault = await openVaultAgentKey(msg._stateDir);
-      let code;
+      // Same viewport-stream blackout as fill-secret: an OTP is typed into a
+      // visible text/tel input, so watchers must not see the keystrokes.
+      state.stream?.suspend();
       try {
-        const rec = vault.get(credName);
-        if (!rec) throw new Error(`no credential "${credName}"`);
-        // Audience binding: a live OTP code must not be typed into a foreign
-        // origin — top page AND (for an iframe field) the frame itself.
-        assertFillAllowed(rec, hostOfUrl(page.url()));
-        if (target !== page) assertFillAllowed(rec, hostOfUrl(target.url()));
-        const otpCred =
-          rec.type === "totp"
-            ? { name: credName, otp: "totp", totpSecret: rec.secret, period: rec.period, digits: rec.digits, algorithm: rec.algorithm }
-            : rec;
-        code = await resolveOtp(otpCred, {});
+        const vault = await openVaultAgentKey(msg._stateDir);
+        let code;
+        try {
+          const rec = vault.get(credName);
+          if (!rec) throw new Error(`no credential "${credName}"`);
+          // Audience binding: a live OTP code must not be typed into a foreign
+          // origin — top page AND (for an iframe field) the frame itself.
+          assertFillAllowed(rec, hostOfUrl(page.url()));
+          if (target !== page) assertFillAllowed(rec, hostOfUrl(target.url()));
+          const otpCred =
+            rec.type === "totp"
+              ? { name: credName, otp: "totp", totpSecret: rec.secret, period: rec.period, digits: rec.digits, algorithm: rec.algorithm }
+              : rec;
+          code = await resolveOtp(otpCred, {});
+        } finally {
+          vault.lock();
+        }
+        // Same leak guard as fill-secret: never surface the value-bearing error.
+        try {
+          await humanType(page, sel(p.ref), code, {
+            timeout: ACTION_TIMEOUT,
+            submit: p.submit !== false,
+            root: target,
+          });
+        } catch {
+          throw new Error(`fill-otp: could not fill "${p.ref}" — element not visible/editable (re-snapshot and retry)`);
+        }
+        // A derived OTP isn't sealed at fill time (see assertFillAllowed), so the
+        // read-back guard is what protects it: tag the field so its value can't be
+        // read back regardless of the input's type (OTP inputs are text/tel).
+        await markSecretField(target, sel(p.ref));
+        return { filled: p.ref, otp: true };
       } finally {
-        vault.lock();
+        state.stream?.resume();
       }
-      // Same leak guard as fill-secret: never surface the value-bearing error.
-      try {
-        await humanType(page, sel(p.ref), code, {
-          timeout: ACTION_TIMEOUT,
-          submit: p.submit !== false,
-          root: target,
-        });
-      } catch {
-        throw new Error(`fill-otp: could not fill "${p.ref}" — element not visible/editable (re-snapshot and retry)`);
-      }
-      // A derived OTP isn't sealed at fill time (see assertFillAllowed), so the
-      // read-back guard is what protects it: tag the field so its value can't be
-      // read back regardless of the input's type (OTP inputs are text/tel).
-      await markSecretField(target, sel(p.ref));
-      return { filled: p.ref, otp: true };
     }
     case "select":
       await frameForRef(state, p.ref).selectOption(sel(p.ref), p.values, { timeout: ACTION_TIMEOUT });
@@ -974,6 +986,15 @@ export async function runSession({
   for (const pg of ctx.pages()) attachPage(state, pg);
   ctx.on("page", (pg) => attachPage(state, pg));
 
+  // Live viewport stream ("watch Lethe browse" / pair browsing). Its port +
+  // token ride in the session file so the host runtime can relay it to the
+  // owner's client; the feed and viewer input are suspended while fill-secret
+  // / fill-otp inject credential values (see those dispatch cases).
+  const stream = await startStreamServer(state, {
+    log: (m) => process.stderr.write(`${m}\n`),
+  });
+  state.stream = stream;
+
   // Single, idempotent shutdown: close the browser, RESEAL the refreshed profile,
   // wipe the plaintext working copy, remove the session file, then exit. Guarded
   // so the ctx "close" event (which ctx.close() itself fires) can't re-enter and
@@ -986,6 +1007,7 @@ export async function runSession({
     try { await sealProfile({ stateDir, file: profileFile, dekHex, sourceDir: workDir }); } catch { /* best effort */ }
     try { await fs.rm(workDir, { recursive: true, force: true }); } catch { /* best effort */ }
     try { await fs.rm(sessionFilePath(stateDir, name), { force: true }); } catch { /* best effort */ }
+    try { stream.close(); } catch { /* not listening */ }
     try { server.close(); } catch { /* not listening */ }
     process.exit(0);
   }
@@ -1022,7 +1044,15 @@ export async function runSession({
   await fs.mkdir(sessionsDir(stateDir), { recursive: true, mode: 0o700 });
   await fs.writeFile(
     sessionFilePath(stateDir, name),
-    JSON.stringify({ port, token, pid: process.pid, headless, startedAt: Date.now() }),
+    JSON.stringify({
+      port,
+      token,
+      pid: process.pid,
+      headless,
+      startedAt: Date.now(),
+      streamPort: stream.port,
+      streamToken: stream.token,
+    }),
     { mode: 0o600 },
   );
   // Readiness signal: the agent runs `open` in the background and waits for this

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -1240,6 +1240,7 @@ export async function runSession({
   profileFile,
   workDir,
   policy = null,
+  startUrl = null,
 }) {
   const ctx = await launchContext({
     profileDir: workDir,
@@ -1344,9 +1345,23 @@ export async function runSession({
     }),
     { mode: 0o600 },
   );
+  // Optional start page: navigate BEFORE the ready line so "ready" means "up
+  // and on the requested page". Non-fatal — a bad/slow URL still yields a
+  // usable session; the outcome rides along in the ready JSON.
+  let navigation = null;
+  if (startUrl) {
+    try {
+      const resp = await page.goto(String(startUrl), { waitUntil: "domcontentloaded", timeout: 30000 });
+      navigation = { url: page.url(), status: resp ? resp.status() : null };
+    } catch (err) {
+      navigation = { url: String(startUrl), error: String(err?.message || err) };
+    }
+  }
   // Readiness signal: the agent runs `open` in the background and waits for this
   // line before issuing actions.
-  process.stdout.write(JSON.stringify({ ok: true, ready: true, session: name, headless, port }) + "\n");
+  process.stdout.write(
+    JSON.stringify({ ok: true, ready: true, session: name, headless, port, ...(navigation ? { navigation } : {}) }) + "\n",
+  );
 
   // Reseal + clean up if the browser dies or we're terminated. finalize() handles
   // the exit itself, so these just invoke it (idempotent).

--- a/plugins/agent-id-browser/lib/stream-server.mjs
+++ b/plugins/agent-id-browser/lib/stream-server.mjs
@@ -166,6 +166,10 @@ export async function startStreamServer(state, { log = () => {} } = {}) {
   let cdpPage = null;
   let suspended = 0; // depth-counted: nested fills keep it suspended
   let closed = false;
+  // Input events apply strictly in arrival order. page.mouse/keyboard calls are
+  // async; firing them unawaited lets a press overtake the move before it (or a
+  // release overtake the press), which drops clicks sent in a burst.
+  let inputChain = Promise.resolve();
 
   function broadcast(obj) {
     if (clients.size === 0) return;
@@ -258,10 +262,17 @@ export async function startStreamServer(state, { log = () => {} } = {}) {
       // Input is disabled while a credential fill is in flight — the viewer
       // must not be able to interact with a form mid-injection.
       if (suspended > 0) return;
-      const page = state.current;
-      if (!page || page.isClosed?.()) return;
       if (mutatesPage(msg)) state.invalidateRefs?.("owner used live browser control");
-      applyInput(page, msg).catch(() => {});
+      // Queue, don't fire-and-forget: the suspend/page checks re-run at apply
+      // time so a fill starting mid-queue still blacks out the queued tail.
+      inputChain = inputChain
+        .then(() => {
+          if (suspended > 0) return;
+          const page = state.current;
+          if (!page || page.isClosed?.()) return;
+          return applyInput(page, msg);
+        })
+        .catch(() => {});
     });
     socket.on("data", parse);
 

--- a/plugins/agent-id-browser/lib/stream-server.mjs
+++ b/plugins/agent-id-browser/lib/stream-server.mjs
@@ -141,6 +141,16 @@ async function applyInput(page, msg) {
   }
 }
 
+// Pointer movement alone does not change page state. Clicks, wheel events, and
+// keyboard input can navigate or mutate a form, so refs observed by the agent
+// must be invalidated before viewer control is applied.
+function mutatesPage(msg) {
+  return (
+    (msg.type === "input_mouse" && ["mousePressed", "mouseWheel"].includes(msg.eventType)) ||
+    (msg.type === "input_keyboard" && ["keyDown", "char"].includes(msg.eventType))
+  );
+}
+
 // ── Stream server ─────────────────────────────────────────────────────────────
 
 /**
@@ -250,6 +260,7 @@ export async function startStreamServer(state, { log = () => {} } = {}) {
       if (suspended > 0) return;
       const page = state.current;
       if (!page || page.isClosed?.()) return;
+      if (mutatesPage(msg)) state.invalidateRefs?.("owner used live browser control");
       applyInput(page, msg).catch(() => {});
     });
     socket.on("data", parse);

--- a/plugins/agent-id-browser/lib/stream-server.mjs
+++ b/plugins/agent-id-browser/lib/stream-server.mjs
@@ -1,0 +1,295 @@
+// Live viewport stream for an open session — the "watch Lethe browse" feed.
+//
+// A minimal WebSocket server (hand-rolled, no dependency — same ethos as the
+// line-JSON TCP protocol in session-server.mjs) on 127.0.0.1, gated by a
+// per-session random token (`?token=` on the upgrade URL). It pushes CDP
+// screencast frames of the CURRENT tab as JSON text frames and accepts input
+// events back, using the same message shapes as agent-browser's stream so one
+// viewer client works against both browser stacks:
+//
+//   server → client   {"type":"frame","data":"<base64 jpeg>","metadata":{...}}
+//                     {"type":"status", ...}
+//   client → server   {"type":"input_mouse","eventType":"mousePressed",...}
+//                     {"type":"input_keyboard","eventType":"keyDown",...}
+//
+// SEAL PRESERVED: this never opens a CDP debug port — frames come from a
+// patchright CDPSession over the existing pipe, input goes through
+// page.mouse/page.keyboard. fill-secret / fill-otp SUSPEND the feed while a
+// credential value is being injected (session-server calls suspend/resume),
+// so a watcher never sees more than the existing `screenshot` verb could show
+// outside those windows.
+
+import crypto from "node:crypto";
+import http from "node:http";
+
+const WS_MAGIC = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+const RETARGET_POLL_MS = 500;
+const JPEG_QUALITY = 70;
+
+// ── WS wire helpers (server side: outgoing unmasked, incoming masked) ────────
+
+function encodeTextFrame(payload) {
+  const data = Buffer.from(payload, "utf8");
+  let header;
+  if (data.length < 126) {
+    header = Buffer.from([0x81, data.length]);
+  } else if (data.length < 65536) {
+    header = Buffer.alloc(4);
+    header[0] = 0x81;
+    header[1] = 126;
+    header.writeUInt16BE(data.length, 2);
+  } else {
+    header = Buffer.alloc(10);
+    header[0] = 0x81;
+    header[1] = 127;
+    header.writeBigUInt64BE(BigInt(data.length), 2);
+  }
+  return Buffer.concat([header, data]);
+}
+
+function encodeControlFrame(opcode, payload = Buffer.alloc(0)) {
+  return Buffer.concat([Buffer.from([0x80 | opcode, payload.length]), payload]);
+}
+
+// Incremental parser for client frames. Client→server frames are always
+// masked (RFC 6455 §5.1). Yields {opcode, payload} per complete frame;
+// fragmented text is reassembled.
+function makeFrameParser(onFrame) {
+  let buf = Buffer.alloc(0);
+  let fragments = null;
+  return (chunk) => {
+    buf = Buffer.concat([buf, chunk]);
+    for (;;) {
+      if (buf.length < 2) return;
+      const fin = (buf[0] & 0x80) !== 0;
+      const opcode = buf[0] & 0x0f;
+      const masked = (buf[1] & 0x80) !== 0;
+      let len = buf[1] & 0x7f;
+      let off = 2;
+      if (len === 126) {
+        if (buf.length < 4) return;
+        len = buf.readUInt16BE(2);
+        off = 4;
+      } else if (len === 127) {
+        if (buf.length < 10) return;
+        len = Number(buf.readBigUInt64BE(2));
+        off = 10;
+      }
+      const maskOff = off;
+      if (masked) off += 4;
+      if (buf.length < off + len) return;
+      let payload = buf.subarray(off, off + len);
+      if (masked) {
+        const mask = buf.subarray(maskOff, maskOff + 4);
+        const un = Buffer.alloc(len);
+        for (let i = 0; i < len; i++) un[i] = payload[i] ^ mask[i & 3];
+        payload = un;
+      }
+      buf = buf.subarray(off + len);
+      if (opcode === 0x0 && fragments) {
+        fragments.push(payload);
+        if (fin) {
+          onFrame({ opcode: 0x1, payload: Buffer.concat(fragments) });
+          fragments = null;
+        }
+      } else if (!fin) {
+        fragments = [payload];
+      } else {
+        onFrame({ opcode, payload });
+      }
+    }
+  };
+}
+
+// ── Input mapping (viewer events → playwright page APIs) ─────────────────────
+
+const KEY_ALIASES = { " ": "Space" };
+
+async function applyInput(page, msg) {
+  if (msg.type === "input_mouse") {
+    const x = Number(msg.x) || 0;
+    const y = Number(msg.y) || 0;
+    const button = ["left", "middle", "right"].includes(msg.button) ? msg.button : "left";
+    const clickCount = Number(msg.clickCount) || 1;
+    switch (msg.eventType) {
+      case "mouseMoved":
+        return page.mouse.move(x, y);
+      case "mousePressed":
+        await page.mouse.move(x, y);
+        return page.mouse.down({ button, clickCount });
+      case "mouseReleased":
+        return page.mouse.up({ button, clickCount });
+      case "mouseWheel":
+        return page.mouse.wheel(Number(msg.deltaX) || 0, Number(msg.deltaY) || 0);
+      default:
+        return;
+    }
+  }
+  if (msg.type === "input_keyboard") {
+    const key = KEY_ALIASES[msg.key] ?? msg.key;
+    if (!key || typeof key !== "string") return;
+    switch (msg.eventType) {
+      case "keyDown":
+        return page.keyboard.down(key);
+      case "keyUp":
+        return page.keyboard.up(key);
+      case "char":
+        return page.keyboard.insertText(String(msg.text ?? key));
+      default:
+        return;
+    }
+  }
+}
+
+// ── Stream server ─────────────────────────────────────────────────────────────
+
+/**
+ * Start the viewport stream for a session. `state` is session-server's live
+ * state ({ctx, current, ...}) — the feed follows `state.current` (poll-based,
+ * so tab-new / tab-switch / tab-close all retarget without hooks).
+ * Returns { port, token, suspend, resume, close }.
+ */
+export async function startStreamServer(state, { log = () => {} } = {}) {
+  const token = crypto.randomBytes(24).toString("hex");
+  const clients = new Set();
+  let cdp = null; // active CDPSession for the screencast
+  let cdpPage = null;
+  let suspended = 0; // depth-counted: nested fills keep it suspended
+  let closed = false;
+
+  function broadcast(obj) {
+    if (clients.size === 0) return;
+    const frame = encodeTextFrame(JSON.stringify(obj));
+    for (const sock of clients) sock.write(frame);
+  }
+
+  async function stopScreencast() {
+    const session = cdp;
+    cdp = null;
+    cdpPage = null;
+    if (!session) return;
+    try { await session.send("Page.stopScreencast"); } catch { /* page gone */ }
+    try { await session.detach(); } catch { /* already detached */ }
+  }
+
+  async function startScreencast() {
+    if (closed || clients.size === 0) return;
+    const page = state.current;
+    if (!page || page.isClosed?.() || (cdp && cdpPage === page)) return;
+    await stopScreencast();
+    let session;
+    try {
+      session = await state.ctx.newCDPSession(page);
+    } catch (err) {
+      log(`stream: cdp attach failed: ${err.message || err}`);
+      return;
+    }
+    cdp = session;
+    cdpPage = page;
+    session.on("Page.screencastFrame", (ev) => {
+      // Ack ALWAYS (even suspended/stale) or Chrome stops sending frames.
+      session.send("Page.screencastFrameAck", { sessionId: ev.sessionId }).catch(() => {});
+      if (suspended > 0 || session !== cdp) return;
+      broadcast({ type: "frame", data: ev.data, metadata: ev.metadata });
+    });
+    try {
+      await session.send("Page.startScreencast", {
+        format: "jpeg",
+        quality: JPEG_QUALITY,
+        maxWidth: 1600,
+        maxHeight: 1200,
+      });
+    } catch (err) {
+      log(`stream: screencast start failed: ${err.message || err}`);
+      await stopScreencast();
+    }
+  }
+
+  // Follow the current tab; also (re)starts after a resume-forced restart.
+  const retarget = setInterval(() => {
+    if (closed || clients.size === 0 || suspended > 0) return;
+    if (state.current !== cdpPage) void startScreencast();
+  }, RETARGET_POLL_MS);
+  retarget.unref?.();
+
+  const server = http.createServer((req, res) => {
+    res.writeHead(426).end(); // this port only speaks WebSocket
+  });
+
+  server.on("upgrade", (req, socket) => {
+    const url = new URL(req.url ?? "/", "http://localhost");
+    const key = req.headers["sec-websocket-key"];
+    if (url.searchParams.get("token") !== token || !key) {
+      socket.end("HTTP/1.1 403 Forbidden\r\n\r\n");
+      return;
+    }
+    const accept = crypto.createHash("sha1").update(key + WS_MAGIC).digest("base64");
+    socket.write(
+      "HTTP/1.1 101 Switching Protocols\r\n" +
+        "Upgrade: websocket\r\nConnection: Upgrade\r\n" +
+        `Sec-WebSocket-Accept: ${accept}\r\n\r\n`,
+    );
+    clients.add(socket);
+    socket.write(encodeTextFrame(JSON.stringify({ type: "status", source: "alien", screencasting: true })));
+
+    const parse = makeFrameParser(({ opcode, payload }) => {
+      if (opcode === 0x8) {
+        socket.write(encodeControlFrame(0x8));
+        socket.end();
+        return;
+      }
+      if (opcode === 0x9) {
+        socket.write(encodeControlFrame(0xa, payload));
+        return;
+      }
+      if (opcode !== 0x1) return;
+      let msg;
+      try { msg = JSON.parse(payload.toString("utf8")); } catch { return; }
+      // Input is disabled while a credential fill is in flight — the viewer
+      // must not be able to interact with a form mid-injection.
+      if (suspended > 0) return;
+      const page = state.current;
+      if (!page || page.isClosed?.()) return;
+      applyInput(page, msg).catch(() => {});
+    });
+    socket.on("data", parse);
+
+    const drop = () => {
+      clients.delete(socket);
+      if (clients.size === 0) void stopScreencast(); // save CPU when unwatched
+    };
+    socket.on("close", drop);
+    socket.on("error", drop);
+
+    void startScreencast(); // first watcher starts the feed
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+
+  return {
+    port: server.address().port,
+    token,
+    /** Hide the feed while a secret is typed into the page. Depth-counted. */
+    suspend() {
+      suspended++;
+      broadcast({ type: "status", source: "alien", suspended: true });
+    },
+    resume() {
+      suspended = Math.max(0, suspended - 1);
+      if (suspended === 0) {
+        broadcast({ type: "status", source: "alien", suspended: false });
+        // Restart to force a fresh keyframe — otherwise a static page after the
+        // fill would leave the viewer on the pre-fill frame indefinitely.
+        void stopScreencast().then(() => startScreencast());
+      }
+    },
+    close() {
+      closed = true;
+      clearInterval(retarget);
+      void stopScreencast();
+      for (const sock of clients) sock.destroy();
+      clients.clear();
+      server.close();
+    },
+  };
+}

--- a/plugins/agent-id-browser/package.json
+++ b/plugins/agent-id-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alien-id/agent-id-browser",
-  "version": "7.5.0",
+  "version": "7.5.1",
   "type": "module",
   "private": true,
   "description": "Universal browser automation with the profile sealed in the agent vault.",

--- a/plugins/agent-id-browser/package.json
+++ b/plugins/agent-id-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alien-id/agent-id-browser",
-  "version": "7.3.1",
+  "version": "7.4.0",
   "type": "module",
   "private": true,
   "description": "Universal browser automation with the profile sealed in the agent vault.",

--- a/plugins/agent-id-browser/package.json
+++ b/plugins/agent-id-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alien-id/agent-id-browser",
-  "version": "7.4.0",
+  "version": "7.5.0",
   "type": "module",
   "private": true,
   "description": "Universal browser automation with the profile sealed in the agent vault.",

--- a/plugins/agent-id-browser/skills/agent-id-browser/SKILL.md
+++ b/plugins/agent-id-browser/skills/agent-id-browser/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: agent-id-browser
-description: Drive a real, logged-in browser whose session is sealed in the agent vault — fine-grained control (click, type, fill forms, upload files, press keys, select, hover, drag, navigate, screenshot, run JS, switch tabs, reach into iframes, handle dialogs, capture downloads) via an accessibility snapshot with element refs, plus one-shot read/fetch. By default all sites share ONE session — sign into Google once and every "Sign in with Google" site reuses it; pass --name only for a separate isolated session. Two ways to log in: a HEADED Chrome login when a desktop browser is available, OR an agent-driven HEADLESS login from a stored `login` credential (auto-login, or snapshot + fill-secret/fill-otp) where the password and any 2FA code are entered over an abstracted secure-entry channel (browser form, mobile app, hosted harness, or CLI) — never via chat, never seen by the agent. Afterwards the agent drives the session HEADLESS. Sessions can be sealed READ-ONLY (--access ro): the session process blocks write requests at the network layer, so the agent can read mail/feeds/messages but never send, post, or delete. Use for authenticated sites that block API/OAuth/cookie access (e.g. Gmail/Workspace) or any task needing a real logged-in browser — the agent never sees a credential, it drives the browser.
+description: Drive Alien Browser with an anonymous L0 profile created automatically for public pages, or a logged-in profile sealed in the agent vault. Inspect forms compactly and fill/verify up to 50 fields, checks, selects, and file uploads in one call; use fine-grained refs, screenshots, tabs, dialogs, and downloads for the rest. By default all sites share ONE session; pass --name only for a separate isolated session. Credentials and 2FA use the secure vault injection path and are never seen by the agent. Sessions may be sealed READ-ONLY, where writes are blocked at the network layer.
 license: MIT
 metadata:
   author: Alien Wallet
-  version: "7.2.0"
+  version: "7.5.0"
 allowed-tools: Bash(node *agent-id-browser/bin/cli.mjs:*) Read
 ---
 
@@ -28,6 +28,11 @@ it to add another site to the same session; existing logins are kept.
   nothing with `main`. Don't create one per site; that's what reintroduces the
   double-login.
 - **Start over:** `login --fresh` discards the current session and logs in clean.
+
+On first public browse, `open`, `read`, or `fetch` creates `main` automatically
+as an empty **anonymous L0** profile and seals it. Do not create a credential or
+run `auto-login` just to visit a public page; login setup is only for sites that
+actually require an account.
 
 patchright is **installed automatically** into the plugin's data dir on first
 session (a SessionStart hook; ~17 MB, no browser download — it drives your
@@ -143,7 +148,7 @@ the page makes is classified — `GET`/`HEAD`/`OPTIONS` and POST-tunneled reads
 (GraphQL `query`, JMAP `*/get`, JSON-RPC reads) pass; **writes are aborted at
 the wire**, so clicking "Send" fails harmlessly. WebSockets and service
 workers are disabled (they would bypass inspection), and `eval`,
-`fill-secret`, `fill-otp`, `upload` are refused. Everything observational —
+`fill-secret`, `fill-otp`, `upload`, and `form-fill` are refused. Everything observational —
 `navigate`, `snapshot`, `click`, `type` (e.g. a search box), `page-text`,
 `screenshot`, `read`, `fetch` — works normally.
 
@@ -174,7 +179,27 @@ background** (it stays running) and wait for its `{"ready":true,...}` line:
 CLI open            # background; add --headed to watch
 ```
 
-**Observe** — get an accessibility snapshot; every actionable element has a `ref`.
+**For forms, prefer the compact two-call path.** It is much faster and cheaper
+than one LLM turn per field, and it verifies what the page retained:
+
+```bash
+CLI form-inspect
+# → { controls:[{ref:"e1",type:"text",label:"First name",required:true},
+#               {ref:"e2",type:"checkbox",label:"Agree",checked:false},
+#               {ref:"e3",type:"file",label:"Resume",accept:".pdf"}] }
+CLI form-fill --spec '{
+  "fields":[{"ref":"e1","value":"Ada"}],
+  "checks":[{"ref":"e2","checked":true}],
+  "selects":[{"ref":"e4","values":["masters"]}],
+  "uploads":[{"ref":"e3","files":["/workspace/resume.pdf"]}]
+}'
+```
+
+One bad control does not stop the rest: the result reports per-control success,
+failed refs, and native required/validity errors. It never returns text/password
+values. Use `fill-secret`/`fill-otp` separately for credentials.
+
+**Observe other UI** — get an accessibility snapshot; every actionable element has a `ref`.
 Elements inside iframes get frame-prefixed refs (`f1e3`) and work with every
 action; when more than one tab is open the snapshot reports `tabs`:
 
@@ -190,7 +215,7 @@ CLI snapshot
 ```bash
 CLI click  --ref e5                    # dblclick / check / uncheck take --ref too
 CLI type   --ref e8 --text "hello@there.com" [--submit]
-CLI fill   --fields '[{"ref":"e8","value":"a"},{"ref":"e9","value":"b"}]'
+CLI fill   --fields '[{"ref":"e8","value":"a"},{"ref":"e9","value":"b"}]' # compatibility; form-fill is preferred
 CLI fill-secret --ref e8 --cred acme.password [--submit]   # inject a vaulted secret by ref
 CLI fill-otp    --ref e9 --cred acme                       # type the current 2FA code
 CLI upload --ref e7 --files /path/report.pdf,/path/pic.png # file input OR picker button
@@ -291,7 +316,9 @@ CLI batch --actions '[{"action":"click","params":{"ref":"e1"}},{"action":"snapsh
 
 **Re-snapshot after anything that changes the page** (click/navigate/submit) —
 refs (including frame refs) are only valid until the next snapshot/navigation.
-After an action that navigates, `wait` for expected text, then `snapshot` again.
+Live-viewer mouse/keyboard control also invalidates all refs immediately; a stale
+ref error means the owner changed the page, so inspect/snapshot again. After an
+action that navigates, `wait` for expected text, then `snapshot` again.
 
 **Finish** — always close; this reseals the (refreshed) session and wipes the
 plaintext working copy:
@@ -344,8 +371,8 @@ return `"sessionExpired": true` with `"action": "re_login"`. On that signal,
   `AGENT_ID_SECURE_PROMPT=browser|tty|hosted` pins a backend.
 - The session is unsealed to a temp working dir only while a session/read runs,
   re-sealed (capturing new logins + rotated cookies) when it ends, and wiped.
-- **Human-like input.** `click`/`type`/`fill`/`hover`/`scroll` (and auto-login's
-  form filling) drive the page with real cursor travel and key-by-key typing
+- **Human-like interactive input.** `click`/`type`/`hover`/`scroll` (and auto-login's
+  credential entry) drive the page with real cursor travel and key-by-key typing
   rather than instantaneous synthetic events — because you're a real Chrome on
   the user's real IP, behaviour is the only residual bot signal, and robotic
   motion against a pristine fingerprint is itself the tell. It costs a little

--- a/tests/test-access-policy.mjs
+++ b/tests/test-access-policy.mjs
@@ -323,8 +323,8 @@ describe("isAccessRestricted", () => {
 describe("browser guard (pure pieces)", () => {
   const ro = { access: "ro" };
 
-  it("assertActionAllowed refuses eval/fill-secret/fill-otp/upload on ro only", () => {
-    for (const action of ["eval", "fill-secret", "fill-otp", "upload"]) {
+  it("assertActionAllowed refuses secret/file/form writes on ro only", () => {
+    for (const action of ["eval", "fill-secret", "fill-otp", "upload", "form-fill"]) {
       assert.throws(() => assertActionAllowed(ro, action), /read-only session/);
       assertActionAllowed({ access: "rw" }, action); // no throw
       assertActionAllowed({}, action);

--- a/tests/test-browser-hints.mjs
+++ b/tests/test-browser-hints.mjs
@@ -11,7 +11,15 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { DEFAULT_PROFILE, loginHint, noProfileHint } from "../plugins/agent-id-browser/lib/hints.mjs";
+import { DEFAULT_PROFILE, loginHint, noProfileHint, profileName } from "../plugins/agent-id-browser/lib/hints.mjs";
+
+test("profileName accepts safe slugs and rejects traversal", () => {
+  assert.equal(profileName(), DEFAULT_PROFILE);
+  assert.equal(profileName("work-2_A"), "work-2_A");
+  assert.throws(() => profileName("../../etc/passwd"), /1-64 letters/);
+  assert.throws(() => profileName("a/b"), /1-64 letters/);
+  assert.throws(() => profileName("x".repeat(65)), /1-64 letters/);
+});
 
 test("loginHint: bare for the default profile, named otherwise", () => {
   assert.equal(loginHint(DEFAULT_PROFILE), "`login`");

--- a/tests/test-browser-profile-bootstrap.mjs
+++ b/tests/test-browser-profile-bootstrap.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  ensureAnonymousDefaultProfile,
+  sealedProfileExists,
+  unsealProfile,
+} from "../plugins/agent-id-browser/lib/profile-store.mjs";
+
+function mockVault() {
+  const records = new Map();
+  let saves = 0;
+  return {
+    get: (name) => records.get(name) || null,
+    add: (record) => {
+      records.set(record.name, record);
+      return record;
+    },
+    save: async () => {
+      saves++;
+    },
+    records,
+    saveCount: () => saves,
+  };
+}
+
+test("first use creates one sealed anonymous L0 default profile", async () => {
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "agentid-anon-profile-"));
+  const vault = mockVault();
+  try {
+    const record = await ensureAnonymousDefaultProfile({ vault, stateDir, name: "main" });
+    assert.equal(record.type, "browser-profile");
+    assert.equal(record.bootstrap, "anonymous-l0");
+    assert.equal(record.exportable, false);
+    assert.equal(record.headless, true);
+    assert.match(record.dek, /^[0-9a-f]{64}$/);
+    assert.equal(await sealedProfileExists(stateDir, record.profileFile), true);
+    assert.equal(vault.saveCount(), 1);
+
+    const restored = path.join(stateDir, "restored");
+    await unsealProfile({
+      stateDir,
+      file: record.profileFile,
+      dekHex: record.dek,
+      destDir: restored,
+    });
+    assert.deepEqual(await fs.readdir(restored), []);
+
+    const same = await ensureAnonymousDefaultProfile({ vault, stateDir, name: "main" });
+    assert.equal(same, record);
+    assert.equal(vault.saveCount(), 1, "bootstrap must be idempotent");
+  } finally {
+    await fs.rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("named profiles never auto-create", async () => {
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "agentid-named-profile-"));
+  const vault = mockVault();
+  try {
+    await assert.rejects(
+      () => ensureAnonymousDefaultProfile({ vault, stateDir, name: "work" }),
+      (error) => error?.code === "NO_PROFILE",
+    );
+    assert.equal(vault.records.size, 0);
+    assert.equal(vault.saveCount(), 0);
+  } finally {
+    await fs.rm(stateDir, { recursive: true, force: true });
+  }
+});

--- a/tests/test-browser-secret-readback.mjs
+++ b/tests/test-browser-secret-readback.mjs
@@ -28,6 +28,8 @@ import path from "node:path";
 import { resolvePatchright, launchContext } from "../plugins/agent-id-browser/lib/launch.mjs";
 import {
   snapshotInPage,
+  formSnapshotInPage,
+  fillForm,
   refusePasswordRead,
   markSecretField,
   SECRET_TAINT_ATTR,
@@ -40,9 +42,13 @@ const patchrightAvailable = !!resolvePatchright();
 // visible label). The OTP/benign fields carry a value but NO aria-label /
 // placeholder / name, so el.value is the only fallback that could surface them.
 const FORM = `<!doctype html><meta charset=utf-8><title>login</title><form>
-  <input id="pw" type="password" value="hunter2">
+  <label for="pw">Password</label><input id="pw" type="password" value="hunter2" required>
   <input id="otp" type="text" autocomplete="one-time-code" value="778899">
-  <input id="who" type="text" value="alice@example.com">
+  <input id="who" name="full_name" type="text" value="alice@example.com">
+  <label for="plain">Plain text</label><input id="plain" name="plain">
+  <label><input id="agree" type="checkbox" style="display:none"> Agree to terms</label>
+  <label for="resume">Resume</label><input id="resume" type="file" style="display:none" accept=".pdf">
+  <select id="degree" name="degree"><option value="bs">Bachelor's</option><option value="ms">Master's</option></select>
   <input id="go" type="submit" value="Sign in">
 </form>`;
 
@@ -80,6 +86,74 @@ test("snapshot never surfaces a text field's value, but keeps a submit's label",
 
   // A submit button's value is a visible caption, not user content — still shown.
   assert.ok(names.includes("Sign in"), "a submit button's value is its label and stays visible");
+});
+
+test("form snapshot is compact, labelled, and includes hidden native controls", { skip }, async () => {
+  const snap = await page.evaluate(formSnapshotInPage, "");
+  assert.ok(Array.isArray(snap.controls));
+  assert.ok(!JSON.stringify(snap).includes("hunter2"), "password value must never appear");
+  assert.ok(!JSON.stringify(snap).includes("alice@example.com"), "text value must never appear");
+
+  const password = snap.controls.find((control) => control.type === "password");
+  assert.equal(password.label, "Password");
+  assert.equal(password.required, true);
+
+  const plain = snap.controls.find((control) => control.name === "plain");
+  assert.equal(plain.type, "text", "an input without an explicit type defaults to text");
+
+  const checkbox = snap.controls.find((control) => control.type === "checkbox");
+  assert.equal(checkbox.hidden, true);
+  assert.match(checkbox.label, /Agree to terms/);
+
+  const upload = snap.controls.find((control) => control.type === "file");
+  assert.equal(upload.hidden, true);
+  assert.equal(upload.accept, ".pdf");
+
+  const degree = snap.controls.find((control) => control.type === "select");
+  assert.deepEqual(degree.options.map((option) => option.value), ["bs", "ms"]);
+});
+
+test("atomic form fill handles text, hidden checks, selects, and verifies each", { skip }, async () => {
+  const snap = await page.evaluate(formSnapshotInPage, "");
+  const text = snap.controls.find((control) => control.name === "full_name");
+  const checkbox = snap.controls.find((control) => control.type === "checkbox");
+  const degree = snap.controls.find((control) => control.name === "degree");
+  const state = {
+    current: page,
+    frames: new Map(),
+    refsValid: true,
+    refsInvalidReason: null,
+  };
+  const result = await fillForm(state, {
+    fields: [{ ref: text.ref, value: "Grace Hopper" }],
+    checks: [{ ref: checkbox.ref, checked: true }],
+    selects: [{ ref: degree.ref, values: ["ms"] }],
+  });
+  assert.equal(result.ok, true, JSON.stringify(result));
+  assert.equal(result.completed, 3);
+  assert.equal(result.failed, 0);
+  assert.ok(result.results.every((entry) => entry.ok));
+  assert.deepEqual(
+    await page.evaluate(() => ({
+      who: document.querySelector("#who").value,
+      agree: document.querySelector("#agree").checked,
+      degree: document.querySelector("#degree").value,
+    })),
+    { who: "Grace Hopper", agree: true, degree: "ms" },
+  );
+});
+
+test("ordinary form fill refuses password fields without echoing the value", { skip }, async () => {
+  const snap = await page.evaluate(formSnapshotInPage, "");
+  const password = snap.controls.find((control) => control.type === "password");
+  const result = await fillForm(
+    { current: page, frames: new Map(), refsValid: true, refsInvalidReason: null },
+    { fields: [{ ref: password.ref, value: "never-echo-this" }] },
+  );
+  assert.equal(result.ok, false);
+  assert.equal(result.failed, 1);
+  assert.match(result.results[0].error, /fill-secret|fill-otp/);
+  assert.ok(!JSON.stringify(result).includes("never-echo-this"));
 });
 
 test("read-back guard: password refused, benign text allowed, tainted field refused", { skip }, async () => {


### PR DESCRIPTION
Brings the browser plugin from 7.3.1 to 7.5.1 — the exact source of the tgz deployed to lethe-hosted prod on 2026-07-16.

## What's in here

**7.4.0 — live viewport stream** (`b1a260e`, was local-only until now)
- `lib/stream-server.mjs`: per-session WS server streaming CDP screencast JPEG frames; input via page.mouse/keyboard. No CDP debug port — the seal stays intact.
- Feed + input suspend (depth-counted) during fill-secret / fill-otp; session file gains `streamPort`/`streamToken`.

**7.5.0 — typed form tools + anonymous L0 default profile**
- `form-inspect`: compact form controls with labels/types/requirements/options; never returns text/password values.
- `form-fill --spec`: atomic multi-control fill (fields/checks/selects/uploads, max 50) with per-control verification and native validation reporting.
- The shared `main` profile auto-creates as an anonymous L0 browser-profile — public browsing needs no login or setup.

**7.5.1 — two fixes found during lethe-hosted e2e**
- Stream viewer input now applies through a promise chain in arrival order: page.mouse/keyboard calls are async, and firing them unawaited let a same-tick move/press/release burst reorder and drop the click. Suspend/page checks re-run at apply time so a credential fill starting mid-queue still gates the queued tail.
- `open --url` navigates before the ready line ('ready' now means 'up and on the page'); outcome rides in the ready JSON as `navigation:{url,status}`; bad/slow URLs are non-fatal.

## Verification
- Local harness (isolated vault, system Chrome via patchright): form-fill 5/5 verified controls; stream first frame ~22 ms after connect; burst-click regression now passes (~108 ms to submit); `open --url` lands with status 200 in the ready line.
- Prod e2e through the full lethe-hosted chain (web WS relay → runtime relay → stream server): 101 in ~120 ms, first frame 264 ms, viewport resize visible in frame metadata.

Versions are pre-bumped in-branch (package.json = source of truth, manifests synced via `bun run sync-plugin-versions`), so `detect.shouldPublish` flips true on merge and the npm-publish gate does the rest. No changeset added — the pending `olive-jars-repeat.md` docs patch stays for the next Version PR cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)