### PR TITLE
fix(browser): restore npm publishability lost in the #69 merge

### DIFF
--- a/plugins/agent-id-browser/package.json
+++ b/plugins/agent-id-browser/package.json
@@ -1,8 +1,17 @@
 {
   "name": "@alien-id/agent-id-browser",
   "version": "7.5.1",
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "lib",
+    "bin",
+    "hooks",
+    "skills",
+    ".claude-plugin"
+  ],
   "type": "module",
-  "private": true,
   "description": "Universal browser automation with the profile sealed in the agent vault.",
   "bin": {
     "agent-id-browser": "./bin/cli.mjs"


### PR DESCRIPTION
#69's branch forked before b89979e (publish agent-id-browser to npm), and its package.json conflict resolution took the branch side wholesale — reintroducing `"private": true` and dropping `publishConfig` + the `files` whitelist. `detect.shouldPublish` therefore stayed `false` and 7.5.1 never reached the npm-publish gate. Restores the three fields; version stays 7.5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)