### PR TITLE
fix(browser): add repository field required by npm provenance

### DIFF
--- a/plugins/agent-id-browser/package.json
+++ b/plugins/agent-id-browser/package.json
@@ -11,6 +11,11 @@
     "skills",
     ".claude-plugin"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/alien-id/agent-id.git",
+    "directory": "plugins/agent-id-browser"
+  },
   "type": "module",
   "description": "Universal browser automation with the profile sealed in the agent vault.",
   "bin": {


### PR DESCRIPTION
The 7.5.1 publish failed at the registry: `Error verifying sigstore provenance bundle: package.json "repository.url" is "", expected to match https://github.com/alien-id/agent-id`. Core and vault carry the repository block; browser never did (7.3.1 predates the stricter validation). Adds the same block with `directory: plugins/agent-id-browser`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)