### PR TITLE
agent-id-proxy: oauth2 client_secret from per-connector config, not the vault cred

### DIFF
--- a/plugins/agent-id-proxy/bin/cli.mjs
+++ b/plugins/agent-id-proxy/bin/cli.mjs
@@ -50,6 +50,7 @@ import {
 import { collectViaForm } from "@alien-id/agent-id-core/lib/secure-form.mjs";
 
 import { createProxy, DEFAULT_IDLE_TIMEOUT_MS } from "../lib/proxy.mjs";
+import { loadOauthSecretsFile } from "../lib/oauth.mjs";
 import { buildPairingPayload, pickReachableHost } from "../lib/pairing.mjs";
 import { normalizeFingerprint } from "../lib/control-tls.mjs";
 
@@ -420,6 +421,20 @@ async function cmdStart(flags) {
   const grantTtlMs =
     flags["grant-ttl"] != null ? parseDuration(flags["grant-ttl"]) : 60 * 60_000;
 
+  // Per-connector OAuth client secrets (platform secrets — issue #72): a 0600
+  // JSON file mapping clientId → clientSecret, named by path so the secret
+  // itself never rides argv. Read once at spawn; the host respawns the proxy
+  // to pick up a rotation.
+  const oauthSecretsFile =
+    flags["oauth-secrets-file"] || process.env.AGENT_ID_OAUTH_SECRETS_FILE || null;
+  if (oauthSecretsFile === true) {
+    outputError("--oauth-secrets-file needs a path");
+    return;
+  }
+  const oauthClientSecrets = oauthSecretsFile
+    ? await loadOauthSecretsFile(String(oauthSecretsFile))
+    : null;
+
   const proxy = createProxy({
     vault,
     stateDir,
@@ -429,6 +444,7 @@ async function cmdStart(flags) {
     control,
     requireConsent,
     grantTtlMs,
+    oauthClientSecrets,
     blockPrivateHosts: !!flags["block-private-hosts"],
     onLock: (reason) => {
       if (controlEnabled) {
@@ -663,6 +679,9 @@ function printHelp() {
       "        [--await-mobile]",
       "        [--require-consent] [--approval-timeout 2m] [--grant-ttl 1h]",
       "        [--block-private-hosts]",
+      "        [--oauth-secrets-file F]   0600 JSON {clientId: clientSecret} consulted for",
+      "                          oauth2 creds that carry no clientSecret of their own",
+      "                          (platform-managed connectors; env: AGENT_ID_OAUTH_SECRETS_FILE)",
       "  pair [--control-host H]   show a QR for a phone to scan (control URL + token)",
       "  status",
       "  stop",

--- a/plugins/agent-id-proxy/lib/oauth.mjs
+++ b/plugins/agent-id-proxy/lib/oauth.mjs
@@ -10,6 +10,7 @@
 // network call (RFC 6749 §6) and parses the response; the proxy owns caching,
 // expiry, and persistence of a rotated refresh token.
 
+import fs from "node:fs/promises";
 import http from "node:http";
 import https from "node:https";
 
@@ -115,4 +116,47 @@ export async function refreshAccessToken({
     expiresInSec,
     refreshToken: typeof parsed.refresh_token === "string" ? parsed.refresh_token : null,
   };
+}
+
+/**
+ * Load the per-connector client-secret config a host passes at daemon spawn:
+ * a JSON object mapping clientId → clientSecret.
+ *
+ * These are PLATFORM secrets (the OAuth app's client_secret), which
+ * deliberately never enter the vault: a vault credential for a
+ * platform-managed connector carries only the user's refresh token, so N
+ * tenant vaults never hold N copies of a company secret and rotation means
+ * rewriting one file and respawning — not rewriting every vault.
+ *
+ * The file must be private (mode 0600 — no group/other bits); it is named by
+ * path (flag or env), so the secret itself never appears on argv.
+ */
+export async function loadOauthSecretsFile(filePath) {
+  const stat = await fs.stat(filePath);
+  if (process.platform !== "win32" && (stat.mode & 0o077) !== 0) {
+    throw new Error(
+      `oauth secrets file ${filePath} must not be group/world accessible (chmod 600 it)`,
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(await fs.readFile(filePath, "utf8"));
+  } catch (err) {
+    throw new Error(`oauth secrets file ${filePath} is not valid JSON: ${err.message}`);
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      `oauth secrets file ${filePath} must be a JSON object mapping clientId to clientSecret`,
+    );
+  }
+  for (const [clientId, secret] of Object.entries(parsed)) {
+    if (typeof secret !== "string" || !secret) {
+      throw new Error(
+        `oauth secrets file ${filePath}: entry '${clientId}' must be a non-empty string`,
+      );
+    }
+  }
+  // Null prototype so a clientId like "__proto__" can never resolve to
+  // something inherited instead of a configured secret.
+  return Object.assign(Object.create(null), parsed);
 }

--- a/plugins/agent-id-proxy/lib/proxy.mjs
+++ b/plugins/agent-id-proxy/lib/proxy.mjs
@@ -148,6 +148,11 @@ export function createProxy({
   // How long an approved (credential, host) grant stays valid. Infinity = for
   // the life of the process.
   grantTtlMs = 60 * 60 * 1000,
+  // Per-connector OAuth client secrets: clientId → clientSecret, from the
+  // host's 0600 secrets file (see loadOauthSecretsFile). Consulted only when
+  // an oauth2 credential carries no clientSecret of its own, so
+  // personal/standalone creds behave exactly as before.
+  oauthClientSecrets = null,
 }) {
   const controlEnabled = !!control;
   if (controlEnabled && !stateDir) {
@@ -348,12 +353,20 @@ export function createProxy({
     if (!inFlight) {
       inFlight = (async () => {
         const refreshToken = cached?.refreshToken || cred.refreshToken;
+        // The cred's own secret wins (personal/standalone use); a
+        // platform-managed cred carries none and resolves via the host's
+        // per-connector config. Hard boundary: user secrets in the vault,
+        // platform secrets in host config — never both in one place.
+        const clientSecret =
+          cred.clientSecret ||
+          (oauthClientSecrets && cred.clientId ? oauthClientSecrets[cred.clientId] : null) ||
+          null;
         let res;
         try {
           res = await refreshAccessToken({
             tokenEndpoint: cred.tokenEndpoint,
             clientId: cred.clientId,
-            clientSecret: cred.clientSecret || null,
+            clientSecret,
             refreshToken,
             scope: cred.scope || null,
           });

--- a/tests/test-proxy-oauth2.mjs
+++ b/tests/test-proxy-oauth2.mjs
@@ -20,7 +20,11 @@ import path from "node:path";
 
 import { initVault, openVault } from "../plugins/agent-id-vault/lib/vault.mjs";
 import { createProxy } from "../plugins/agent-id-proxy/lib/proxy.mjs";
-import { refreshAccessToken, OAuthError } from "../plugins/agent-id-proxy/lib/oauth.mjs";
+import {
+  loadOauthSecretsFile,
+  refreshAccessToken,
+  OAuthError,
+} from "../plugins/agent-id-proxy/lib/oauth.mjs";
 
 // ── Fake upstream: records the Authorization header it received ────────────────
 function startUpstream() {
@@ -210,5 +214,127 @@ describe("oauth2 credential through the proxy", () => {
     assert.equal(r.status, 401);
     assert.equal(JSON.parse(r.body).error, "oauth_refresh_token_invalid");
     token.cfg.mode = "ok";
+  });
+});
+
+describe("loadOauthSecretsFile (unit)", () => {
+  let dir;
+  before(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "agentid-oauth-secrets-"));
+  });
+  after(async () => {
+    if (dir) await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  async function write(name, content, mode) {
+    const p = path.join(dir, name);
+    await fs.writeFile(p, content, { mode });
+    return p;
+  }
+
+  it("loads a 0600 JSON object keyed by clientId", async () => {
+    const p = await write("ok.json", '{"cid-1":"secret-1","cid-2":"secret-2"}', 0o600);
+    const secrets = await loadOauthSecretsFile(p);
+    assert.equal(secrets["cid-1"], "secret-1");
+    assert.equal(secrets["cid-2"], "secret-2");
+  });
+
+  it(
+    "refuses a group/world-accessible file",
+    { skip: process.platform === "win32" },
+    async () => {
+      const p = await write("loose.json", '{"cid":"s"}', 0o644);
+      await assert.rejects(() => loadOauthSecretsFile(p), /chmod 600/);
+    },
+  );
+
+  it("refuses non-object JSON and non-string values", async () => {
+    const arr = await write("arr.json", '["cid"]', 0o600);
+    await assert.rejects(() => loadOauthSecretsFile(arr), /JSON object/);
+    const bad = await write("bad.json", '{"cid":42}', 0o600);
+    await assert.rejects(() => loadOauthSecretsFile(bad), /non-empty string/);
+    const garbled = await write("garbled.json", "not json", 0o600);
+    await assert.rejects(() => loadOauthSecretsFile(garbled), /not valid JSON/);
+  });
+
+  it("does not resolve secrets through the prototype chain", async () => {
+    const p = await write("proto.json", '{"cid":"s"}', 0o600);
+    const secrets = await loadOauthSecretsFile(p);
+    assert.equal(secrets["toString"], undefined);
+    assert.equal(secrets["__proto__"], undefined);
+  });
+});
+
+describe("config-supplied client secret (platform connectors)", () => {
+  let stateDir, upstream, token, proxy, proxyPort;
+  const clock = 2_000_000_000_000;
+
+  before(async () => {
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "agentid-oauth2-cfg-"));
+    upstream = await startUpstream();
+    token = await startTokenEndpoint();
+
+    await initVault({ stateDir, passphrase: "test-pass" });
+    const vault = await openVault({ stateDir, passphrase: "test-pass" });
+    const base = {
+      type: "oauth2",
+      domains: [upstream.host.split(":")[0]],
+      upstreamScheme: "http",
+      tokenEndpoint: token.url,
+      refreshToken: "rt-1",
+    };
+    // Platform-seeded: no clientSecret on the cred — the config supplies it.
+    vault.add({ ...base, name: "platform", clientId: "cid-platform" });
+    // Personal: the cred's own secret must keep winning over the config.
+    vault.add({
+      ...base,
+      name: "personal",
+      clientId: "cid-personal",
+      clientSecret: "personal-secret",
+    });
+    // No secret anywhere: refresh proceeds without client_secret (public client).
+    vault.add({ ...base, name: "bare", clientId: "cid-bare" });
+    await vault.save();
+
+    proxy = createProxy({
+      vault,
+      stateDir,
+      logPath: path.join(stateDir, "proxy.log"),
+      now: () => clock,
+      oauthClientSecrets: {
+        "cid-platform": "config-secret",
+        "cid-personal": "config-should-lose",
+      },
+    });
+    const addr = await proxy.listen();
+    proxyPort = addr.port;
+  });
+
+  after(async () => {
+    await proxy?.close();
+    upstream?.server.close();
+    token?.server.close();
+    if (stateDir) await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  it("a cred without clientSecret refreshes with the config-supplied secret", async () => {
+    const r = await callProxy({ port: proxyPort, path: `/platform/${upstream.host}/v1/a` });
+    assert.equal(r.status, 200);
+    assert.equal(token.stats.lastBody.get("client_id"), "cid-platform");
+    assert.equal(token.stats.lastBody.get("client_secret"), "config-secret");
+  });
+
+  it("a cred with its own clientSecret behaves exactly as today (cred wins)", async () => {
+    const r = await callProxy({ port: proxyPort, path: `/personal/${upstream.host}/v1/b` });
+    assert.equal(r.status, 200);
+    assert.equal(token.stats.lastBody.get("client_id"), "cid-personal");
+    assert.equal(token.stats.lastBody.get("client_secret"), "personal-secret");
+  });
+
+  it("no secret on the cred or in the config sends none (current behavior)", async () => {
+    const r = await callProxy({ port: proxyPort, path: `/bare/${upstream.host}/v1/c` });
+    assert.equal(r.status, 200);
+    assert.equal(token.stats.lastBody.get("client_id"), "cid-bare");
+    assert.equal(token.stats.lastBody.get("client_secret"), null);
   });
 });


### PR DESCRIPTION
Closes #72.

New `start` flag `--oauth-secrets-file <path>` (env: `AGENT_ID_OAUTH_SECRETS_FILE`): a 0600 JSON file mapping `clientId` → `clientSecret`, read once at spawn. The host (lethe-mux) writes it from the platform secret store and passes it at daemon spawn — the secret itself never rides argv.

Refresh precedence, exactly as proposed in the issue:
1. `cred.clientSecret` if present — personal/standalone creds behave exactly as today;
2. else look up `cred.clientId` in the config;
3. else current behavior (no `client_secret` sent).

Platform-seeded creds carry only the user's refresh token, so the OAuth app's secret never enters tenant vaults, and rotation is one file + respawn instead of rewriting every vault.

Details:
- The loader refuses group/world-accessible files (`chmod 600`), validates the JSON shape, and returns a null-prototype map so a `clientId` like `__proto__` can never resolve through inheritance.
- The install path decided in the issue (git clone at pinned ref → `npm pack` → install tgz, no npm publish) is already what lethe-mux's Dockerfile does for the proxy; no release-process change here.
- Tests: `loadOauthSecretsFile` unit coverage (perms, shape, prototype chain) plus proxy-level coverage of all three precedence outcomes against the fake token endpoint. All 99 proxy tests pass.

The consumer side (writing the file from platform config and passing the flag) lands in lethe-mux separately; older proxies ignore the unknown flag, so the two can merge in either order.

