### PR TITLE
feat(browser): tell the agent who must act when a login stalls

### DIFF
--- a/.changeset/lucky-pandas-shave.md
+++ b/.changeset/lucky-pandas-shave.md
@@ -1,0 +1,57 @@
+---
+"@alien-id/agent-id-browser": minor
+"@alien-id/agent-id-core": minor
+---
+
+auto-login waits for device-approval prompts instead of failing
+
+A "tap Yes on your phone" challenge shares body copy with a 2FA step but has no
+input — the sign-in completes when the owner approves on their own device. It was
+classified `otp-required`, so auto-login went looking for a code that never
+appears and stalled until the round budget ran out.
+
+`classifyLogin` now returns `confirm-on-device` for a push prompt or number-match
+challenge, checked before `otp-required` and only when the page has no code input
+(an SMS step shows both). On that outcome auto-login raises a card through the
+host and polls until the page advances, with its own budget rather than the
+ordinary settle rounds.
+
+Notices are a new one-way message on the existing secure-prompt socket
+(`agent-id-core/lib/notice.mjs`): the host raises the named event and replies at
+once. Event names are namespaced under `browser.` and the host enforces it, so a
+child cannot forge identity or secure-input lifecycle events. Delivery is best
+effort — with no host configured, `notifyHost` resolves `false` and the login is
+unaffected.
+
+Device approval is the cheapest challenge to satisfy: unlike a password or a TOTP
+seed it needs no secret stored anywhere.
+
+## a failed login says what to DO, not "try headed login"
+
+Every auto-login failure ended with the same advice: sign in yourself with headed
+`login`. On a host with no display that is a dead end — headed login refuses
+without a GUI session and points back at auto-login. The two pointed at each
+other, so the agent bounced between them, or asked the owner for a password that
+an account created through "Sign in with Google" does not have.
+
+Failures now carry a machine-readable `action` (`lib/escalation.mjs`), and there
+are only three: `owner_must_drive` (a human has to work the page — bot challenge,
+or an IdP that refuses automation), `owner_must_confirm` (the credential is fine;
+an approval on another device never arrived), and `fix_credential` (the stored
+values are wrong or incomplete). A device-approval timeout in particular no longer
+tells the agent to re-check credentials that were never the problem.
+
+## read/fetch no longer answer from a stale profile
+
+`read` and `fetch` unsealed a *copy* of the sealed profile even when a session
+was open. A live session's cookies only reach the vault on `close`, so the copy
+was stale: reading a site the session was signed into returned `loggedOut` and a
+redirect to the login page for a session that was working fine. Since that result
+feeds `sessionExpired`, it could raise a "sign in again" prompt for a healthy
+login — the worst kind of false alarm, because it teaches the owner to ignore the
+real one.
+
+Both now run as session actions when a session is open, falling back to the
+one-shot only when there is none. A session started by an older build reports
+`SESSION_TOO_OLD` naming the `close`/`open` cycle rather than falling back, since
+falling back would reintroduce exactly the stale read.

--- a/plugins/agent-id-browser/bin/cli.mjs
+++ b/plugins/agent-id-browser/bin/cli.mjs
@@ -51,6 +51,8 @@ import {
 } from "../lib/profile-store.mjs";
 import { launchContext } from "../lib/launch.mjs";
 import { DEFAULT_PROFILE, loginHint, noProfileHint, profileName } from "../lib/hints.mjs";
+import { sessionReplyError } from "../lib/session-route.mjs";
+import { escalationFor } from "../lib/escalation.mjs";
 import { autoLogin } from "../lib/auto-login.mjs";
 import { looksLoggedOut } from "../lib/session.mjs";
 import { runSession, callSession } from "../lib/session-server.mjs";
@@ -456,23 +458,20 @@ async function cmdAutoLogin(flags) {
 
       if (!result || !result.ok) {
         const outcome = result ? result.outcome : "unknown";
-        // A bot-block wall (e.g. Reddit's "blocked by network security") can't be
-        // cleared by an automated credential submission — the login handshake is
-        // exactly where anti-automation bites. A human driving a headed login
-        // clears it and the session seals with the SAME access level.
-        const message =
-          outcome === "blocked"
-            ? `Auto-login for '${credName}' was blocked by an anti-automation wall (bot ` +
-              "challenge / network-security block). This hits the login handshake specifically; " +
-              `sign in yourself once with headed \`login --name ${targetProfile}` +
-              `${requestedAccess ? ` --access ${requestedAccess}` : ""}\` — it seals the same session.`
-            : `Auto-login for '${credName}' did not complete (${outcome}). ` +
-              "Verify the credentials / loginUrl, add a `recipe` to the credential, or bootstrap " +
-              `once with headed \`login --name ${targetProfile}\`.`;
+        // `action` is the contract: prose advice used to send the agent to
+        // headed `login`, which refuses on a host with no display and points
+        // straight back here. See lib/escalation.mjs.
+        const { action, reason, message } = escalationFor(outcome, {
+          credName,
+          profile: targetProfile,
+        });
         outputJson({
           ok: false,
           error: "AUTO_LOGIN_FAILED",
           outcome,
+          action,
+          reason,
+          profile: targetProfile,
           finalUrl: result ? result.finalUrl : null,
           message,
         });
@@ -521,14 +520,41 @@ async function cmdAutoLogin(flags) {
   }
 }
 
+/**
+ * Run a read-style action against the LIVE session when one is open, falling
+ * back to the one-shot profile copy when there is none.
+ *
+ * A one-shot unseals a *copy* of the sealed profile, and the live session's
+ * cookies only reach the vault on `close`. So while a session is open the copy
+ * is stale: reading a site the session is signed into reported `loggedOut` and
+ * a redirect to /logout, for a session that was perfectly healthy. That result
+ * feeds `sessionExpired`, so the stale copy could raise a "sign in again" card
+ * for a live login — the worst kind of false alarm, because it teaches the owner
+ * to ignore the real one.
+ */
+async function liveOrOneShot(flags, name, action, params, oneShot) {
+  const stateDir = resolveStateDir(flags);
+  let result;
+  try {
+    result = await callSession(stateDir, name, action, params);
+  } catch (err) {
+    // No session is the ordinary case; anything else is a real failure.
+    if (err && err.code === "NO_SESSION") return oneShot();
+    throw err;
+  }
+  const error = sessionReplyError(result, { name, action });
+  if (error) throw error;
+  return result;
+}
+
 async function cmdRead(flags) {
   const name = profileName(flags.name);
   if (!flags.url) return outputError("--url is required");
   const url = String(flags.url);
   const maxChars = Number(flags["max-chars"] || 4000);
 
-  try {
-    const out = await withProfile({
+  const oneShot = () =>
+    withProfile({
       flags,
       name,
       headless: resolveHeadless(flags),
@@ -554,6 +580,9 @@ async function cmdRead(flags) {
         };
       },
     });
+
+  try {
+    const out = await liveOrOneShot(flags, name, "read", { url, maxChars }, oneShot);
     if (out.loggedOut) {
       outputJson({
         ok: true,
@@ -576,8 +605,8 @@ async function cmdFetch(flags) {
   const url = String(flags.url);
   const maxChars = Number(flags["max-chars"] || 8000);
 
-  try {
-    const out = await withProfile({
+  const oneShot = () =>
+    withProfile({
       flags,
       name,
       headless: resolveHeadless(flags),
@@ -605,6 +634,9 @@ async function cmdFetch(flags) {
         };
       },
     });
+
+  try {
+    const out = await liveOrOneShot(flags, name, "fetch", { url, maxChars }, oneShot);
     if (out.loggedOut) {
       outputJson({
         ok: true,

--- a/plugins/agent-id-browser/lib/auto-login.mjs
+++ b/plugins/agent-id-browser/lib/auto-login.mjs
@@ -25,6 +25,7 @@
 
 import { generateTotp } from "@alien-id/agent-id-core/lib/totp.mjs";
 import { collectSecret } from "@alien-id/agent-id-core/lib/secure-prompt.mjs";
+import { notifyHost } from "@alien-id/agent-id-core/lib/notice.mjs";
 import { classifyLogin } from "./login-detect.mjs";
 import { humanClick, humanDriver, humanType } from "./human-input.mjs";
 
@@ -363,6 +364,63 @@ async function heuristicLogin(page, { username, password }) {
 }
 
 /**
+ * Surface a "confirm on your phone" card once, then wait for the page to move
+ * on by itself. Returns true when the challenge cleared, false on timeout.
+ *
+ * The prompt text is lifted from the page so the card can echo a number-match
+ * challenge ("tap 42"), which is useless to the owner if we paraphrase it.
+ */
+async function awaitDeviceConfirmation(page, cred, { log, settleMs, budgetMs }) {
+  const hint = await page
+    .evaluate(() => (document.body ? document.body.innerText : ""))
+    .catch(() => "");
+  const prompt = String(hint)
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => /tap (?:yes|\d{1,3})\b|check your phone|sent a (?:notification|prompt)/i.test(line));
+
+  log("auto-login: awaiting device confirmation");
+  await notifyHost("browser.confirmation_required", {
+    profile: cred.profile || cred.name || null,
+    cred: cred.name || null,
+    url: page.url(),
+    prompt: prompt || null,
+    message:
+      "Approve the sign-in on your phone to continue. Nothing needs to be typed here.",
+  });
+
+  // The card has no natural end: the owner approves on a device the harness
+  // cannot see, so without this the "approve on your phone" prompt would sit
+  // there after they already did. Mirrors `secure_input.resolved`.
+  const resolve = async (outcome) => {
+    await notifyHost("browser.confirmation_resolved", {
+      profile: cred.profile || cred.name || null,
+      cred: cred.name || null,
+      outcome,
+    });
+  };
+
+  const deadline = Date.now() + budgetMs;
+  while (Date.now() < deadline) {
+    await page.waitForTimeout(settleMs);
+    const state = classifyLogin(await detectPageState(page));
+    // Anything other than "still asking" ends the wait — including a block or a
+    // denial, which the main loop then classifies on its own terms.
+    if (state !== "confirm-on-device" && state !== "unknown") {
+      await resolve("approved");
+      return true;
+    }
+    if (!stillOnLoginPage(page.url(), cred.loginUrl)) {
+      await resolve("approved");
+      return true;
+    }
+  }
+  log("auto-login: device confirmation timed out");
+  await resolve("timeout");
+  return false;
+}
+
+/**
  * Drive a full auto-login against `cred` (a `login` record). Returns
  * { ok, outcome, finalUrl }. Does NOT seal the profile — the caller does that
  * after closing the context. `page` is a patchright Page.
@@ -374,6 +432,11 @@ export async function autoLogin({
   log = () => {},
   maxRounds = 6,
   settleMs = 1500,
+  // A device-approval prompt is answered by a human reaching for their phone,
+  // so it gets its own budget: the ordinary rounds are far too short, and
+  // spending them here would report a timeout while the owner is still walking
+  // to the desk.
+  confirmWaitMs = 180000,
 }) {
   if (!cred.loginUrl) throw new Error(`login '${cred.name}': loginUrl is required for auto-login`);
   const getOtp = () => resolveOtp(cred, { env, log });
@@ -427,6 +490,20 @@ export async function autoLogin({
       log("auto-login: form cleared but still on the login page — awaiting redirect");
     } else if (outcome === "failed") {
       return { ok: false, outcome, finalUrl: page.url() };
+    } else if (outcome === "confirm-on-device") {
+      // Nothing to type: the owner approves on their own device and the page
+      // advances by itself. Tell them once, then poll until it does. This is
+      // the cheapest challenge to satisfy — unlike a password or a TOTP seed it
+      // needs no secret stored anywhere, so it is a good outcome, not a failure.
+      const confirmed = await awaitDeviceConfirmation(page, cred, {
+        log,
+        settleMs,
+        budgetMs: confirmWaitMs,
+      });
+      if (!confirmed) {
+        return { ok: false, outcome: "confirm-timeout", finalUrl: page.url() };
+      }
+      continue;
     } else if (outcome === "otp-required") {
       if (cred.otp === "none") {
         return { ok: false, outcome: "otp-unexpected", finalUrl: page.url() };

--- a/plugins/agent-id-browser/lib/escalation.mjs
+++ b/plugins/agent-id-browser/lib/escalation.mjs
@@ -1,0 +1,91 @@
+// Alien Agent ID — what the agent should DO when a login does not complete.
+//
+// Every failed auto-login used to end with the same advice: "sign in yourself
+// once with headed `login`". On a host with no display that is a dead end —
+// headed login refuses without a GUI session and points back at auto-login, so
+// the agent bounces between the two, or asks the owner for a password that does
+// not exist (an account created through "Sign in with Google" has none).
+//
+// So an outcome maps to a machine-readable `action` instead of prose, and there
+// are only three:
+//
+//   owner_must_drive   — no credential can fix this; a human has to work the
+//                        page (bot challenge, an identity provider that refuses
+//                        automation). The agent asks for the browser viewport.
+//   owner_must_confirm — the credential is fine; the owner has to approve on
+//                        another device and did not in time. Retrying is
+//                        correct, once they are ready.
+//   fix_credential     — the stored credential is wrong or incomplete. Neither
+//                        a human at the browser nor a retry helps until it is
+//                        corrected.
+//
+// Pure + dependency-free so it unit-tests without a browser.
+
+export const OWNER_MUST_DRIVE = "owner_must_drive";
+export const OWNER_MUST_CONFIRM = "owner_must_confirm";
+export const FIX_CREDENTIAL = "fix_credential";
+
+/**
+ * Map an `autoLogin` outcome to the action the agent should take.
+ *
+ * Returns { action, reason, message }. `reason` is a stable slug for clients;
+ * `message` is what the model reads, and says exactly one next step.
+ */
+export function escalationFor(outcome, { credName = "", profile = "" } = {}) {
+  switch (outcome) {
+    // The login handshake is exactly where anti-automation bites. No credential
+    // clears it — only a human working the page.
+    case "blocked":
+      return {
+        action: OWNER_MUST_DRIVE,
+        reason: "bot_challenge",
+        message:
+          `Auto-login for '${credName}' hit an anti-automation wall (bot challenge / ` +
+          "network-security block). No stored credential can clear this. Ask the owner to " +
+          `finish the sign-in in the browser view for profile '${profile}', then continue.`,
+      };
+    // The owner never approved the push prompt. Their credentials are fine, so
+    // re-checking them is wasted work and re-prompting for a password is wrong.
+    case "confirm-timeout":
+      return {
+        action: OWNER_MUST_CONFIRM,
+        reason: "device_approval_timeout",
+        message:
+          `Auto-login for '${credName}' reached the "approve on your phone" step, but no ` +
+          "approval arrived in time. The stored credentials are FINE — do not re-check them " +
+          "and do not ask for the password. Ask the owner to approve the prompt on their " +
+          "device, then run auto-login again.",
+      };
+    // A second factor was demanded that the credential says it does not have.
+    case "otp-unexpected":
+      return {
+        action: FIX_CREDENTIAL,
+        reason: "otp_required_but_not_configured",
+        message:
+          `The site asked '${credName}' for a second factor, but the credential is set to ` +
+          "`otp: none`. Update it with a TOTP seed (`vault set-totp`) or set `otp: interactive` " +
+          "so the owner can be asked for the current code.",
+      };
+    case "failed":
+      return {
+        action: FIX_CREDENTIAL,
+        reason: "credentials_rejected",
+        message:
+          `The site rejected the stored credentials for '${credName}'. Ask the owner to ` +
+          "re-enter them (`vault_add` with overwrite) rather than retrying the same values.",
+      };
+    // Timed out or never resolved: could be a changed form, an unusual flow, or
+    // an identity provider that refuses automation. A human at the page both
+    // fixes it and reveals which it was.
+    default:
+      return {
+        action: OWNER_MUST_DRIVE,
+        reason: "login_did_not_complete",
+        message:
+          `Auto-login for '${credName}' did not complete (${outcome}). This is common for ` +
+          "big-IdP sign-in (Google, Microsoft), which refuses automated credential entry. " +
+          `Ask the owner to sign in once in the browser view for profile '${profile}'; the ` +
+          "session then seals and later visits are headless.",
+      };
+  }
+}

--- a/plugins/agent-id-browser/lib/login-detect.mjs
+++ b/plugins/agent-id-browser/lib/login-detect.mjs
@@ -9,6 +9,8 @@
 //   "blocked"      — a bot-block / human-verification interstitial (a network
 //                    -security wall, CAPTCHA, "unusual traffic"). The form is
 //                    gone but we are NOT in — must not be mistaken for success.
+//   "confirm-on-device" — the owner must approve on another device (a push
+//                    prompt); nothing is typed here, so the caller waits
 //   "otp-required" — a second-factor affordance is present (a one-time-code input,
 //                    an OTP-ish field name, or body copy describing 2FA)
 //   "failed"       — a credential error is shown and there is no OTP affordance
@@ -34,6 +36,16 @@ const OTP_FIELD_RE =
 // Body copy that describes a 2FA / verification step.
 const OTP_BODY_RE =
   /(verification code|one[- ]?time (?:code|password|passcode)|two[- ]?factor|2-step|authenticator app|enter the code|security code|\b6[- ]?digit\b|check your phone|approve.*sign)/i;
+
+// Body copy for a challenge the owner answers on ANOTHER device: a push prompt
+// ("tap Yes on your phone"), a number match ("tap 42"), or an app notification.
+// Distinct from OTP because nothing is ever typed on this page — the sign-in
+// completes by itself once the owner approves, so the caller must WAIT rather
+// than hunt for a code that does not exist. Several of these phrases also live
+// in OTP_BODY_RE, which is why the classifier checks this first and only when
+// there is no code input on the page (an SMS step shows both).
+const CONFIRM_BODY_RE =
+  /(check your phone|tap (?:yes|\d{1,3})\b|approve (?:this |the )?sign[- ]?in|sent a (?:notification|prompt) to|open the .{0,24}app on your|confirm (?:it.?s|its) you on your|2-step verification.*(?:notification|prompt))/i;
 
 // Body / inline text that signals the credentials were rejected.
 const ERROR_RE =
@@ -61,7 +73,8 @@ const BLOCK_RE =
  *   bodyText         — visible page text
  *   errorText        — optional focused error text (role=alert etc.)
  *
- * Returns "otp-required" | "failed" | "logged-in" | "unknown".
+ * Returns "blocked" | "confirm-on-device" | "otp-required" | "failed"
+ *       | "logged-in" | "unknown".
  */
 export function classifyLogin({
   hasPasswordField = false,
@@ -73,16 +86,23 @@ export function classifyLogin({
 } = {}) {
   const isBlocked =
     blocked === true || BLOCK_RE.test(bodyText) || BLOCK_RE.test(String(errorText || ""));
-  const otpAffordance =
+  const codeInput =
     hasOtpField ||
-    (Array.isArray(otpFieldNames) && otpFieldNames.some((n) => OTP_FIELD_RE.test(String(n || "")))) ||
-    OTP_BODY_RE.test(bodyText);
+    (Array.isArray(otpFieldNames) && otpFieldNames.some((n) => OTP_FIELD_RE.test(String(n || ""))));
+  const otpAffordance = codeInput || OTP_BODY_RE.test(bodyText);
+  // Device approval only when there is nothing to type: an SMS step can show
+  // "check your phone" AND a code field, and that one is an ordinary OTP.
+  const confirmAffordance = !codeInput && CONFIRM_BODY_RE.test(bodyText);
   const hasError = ERROR_RE.test(String(errorText || "")) || ERROR_RE.test(bodyText);
 
   // A bot-block / human-verification wall: the form is gone but we are NOT in.
   // Checked FIRST — otherwise the missing password field reads as success and an
   // unauthenticated session gets sealed (the bug this outcome was added for).
   if (isBlocked) return "blocked";
+  // Device approval before OTP: both share body copy, but this one has no input,
+  // so treating it as "otp-required" sends the caller looking for a code that
+  // will never appear and the login stalls until it times out.
+  if (confirmAffordance) return "confirm-on-device";
   // An OTP affordance is the strongest signal the password step succeeded and a
   // second factor is now being requested — check it next.
   if (otpAffordance) return "otp-required";
@@ -94,4 +114,4 @@ export function classifyLogin({
   return "unknown";
 }
 
-export { OTP_FIELD_RE, OTP_BODY_RE, ERROR_RE, BLOCK_RE };
+export { OTP_FIELD_RE, OTP_BODY_RE, CONFIRM_BODY_RE, ERROR_RE, BLOCK_RE };

--- a/plugins/agent-id-browser/lib/session-route.mjs
+++ b/plugins/agent-id-browser/lib/session-route.mjs
@@ -1,0 +1,37 @@
+// Alien Agent ID — routing a read-style command to the live session.
+//
+// `read` / `fetch` exist both as session actions and as one-shot CLI commands.
+// The one-shot unseals a COPY of the sealed profile, and a live session's
+// cookies only reach the vault on `close` — so while a session is open the copy
+// is stale, and reading a site the session is signed into reports `loggedOut`
+// with a redirect to the login page. That feeds `sessionExpired`, so the stale
+// copy could raise a "sign in again" card for a healthy session: the worst kind
+// of false alarm, because it teaches the owner to ignore the real one.
+//
+// Kept in a pure module so it unit-tests without importing bin/cli.mjs (which
+// runs the CLI on load), same as hints.mjs.
+
+/**
+ * Classify a reply from `callSession`.
+ *
+ * `callSession` RESOLVES with the session's reply, so an action-level failure
+ * arrives as a value rather than a throw — spreading it into a success envelope
+ * reports `ok:false` alongside `sessionExpired:false`, a failure dressed as a
+ * clean read. Returns an Error to throw, or null when the reply is usable.
+ */
+export function sessionReplyError(result, { name, action } = {}) {
+  if (!result || result.ok !== false) return null;
+  const message = String(result.error || "session action failed");
+  // A session started by an older build has no such action. The caller must NOT
+  // fall back to the one-shot here: it would answer from the stale sealed copy,
+  // which is the bug this routing exists to prevent.
+  if (/unknown action/i.test(message)) {
+    const error = new Error(
+      `the open session '${name}' predates the '${action}' action — ` +
+        `run \`close --name ${name}\` then \`open --name ${name}\` to pick it up`,
+    );
+    error.code = "SESSION_TOO_OLD";
+    return error;
+  }
+  return new Error(message);
+}

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -37,7 +37,9 @@ import {
   applyAccessGuard,
   assertActionAllowed,
   contextOptionsForAccess,
+  guardDecision,
 } from "./access-guard.mjs";
+import { looksLoggedOut } from "./session.mjs";
 import {
   humanClick,
   humanHover,
@@ -649,6 +651,58 @@ async function dispatch(state, msg, policy = null) {
     case "back":
       await page.goBack({ waitUntil: "domcontentloaded" }).catch(() => {});
       return { url: page.url() };
+    // `read` / `fetch` also exist as one-shot CLI commands that unseal a COPY of
+    // the profile. That copy is stale while a session is open — the live cookies
+    // only reach the vault on `close` — so a one-shot reports "logged out" for a
+    // session that is signed in. The CLI routes to these when a session exists.
+    case "read": {
+      const resp = p.url
+        ? await page.goto(String(p.url), { waitUntil: "domcontentloaded", timeout: 30000 })
+        : null;
+      const finalUrl = page.url();
+      const title = await page.title().catch(() => "");
+      let text = "";
+      try {
+        text = await page.evaluate(() => (document.body ? document.body.innerText : ""));
+      } catch {
+        /* page navigated/destroyed mid-read — leave text empty */
+      }
+      const httpStatus = resp ? resp.status() : null;
+      return {
+        httpStatus,
+        finalUrl,
+        title,
+        loggedOut: looksLoggedOut({ finalUrl, bodyText: text, httpStatus }),
+        text: String(text).slice(0, Number(p.maxChars || 8000)),
+      };
+    }
+    case "fetch": {
+      const url = String(p.url);
+      // ctx.request bypasses route interception, so the policy is checked here
+      // the same way the one-shot path checks it. A null policy means the
+      // profile carries no restriction at all — the same convention the action
+      // allowlist above follows.
+      const decision = policy
+        ? guardDecision(policy, { method: "GET", url, postData: null })
+        : { allowed: true };
+      if (!decision.allowed) {
+        throw new Error(`access level blocks GET ${url} (${decision.reason})`);
+      }
+      const resp = await state.ctx.request.get(url, { timeout: 30000 });
+      const httpStatus = resp.status();
+      let body = "";
+      try {
+        body = await resp.text();
+      } catch {
+        /* binary or empty body */
+      }
+      return {
+        httpStatus,
+        finalUrl: resp.url(),
+        loggedOut: looksLoggedOut({ finalUrl: resp.url(), bodyText: body, httpStatus }),
+        body: String(body).slice(0, Number(p.maxChars || 8000)),
+      };
+    }
     case "snapshot": {
       state.frames.clear();
       const main = await page.evaluate(snapshotInPage, "");

--- a/plugins/agent-id-browser/skills/agent-id-browser/SKILL.md
+++ b/plugins/agent-id-browser/skills/agent-id-browser/SKILL.md
@@ -126,6 +126,25 @@ via whatever surface is registered (browser / mobile / hosted / CLI). For custom
 multi-step forms, drive it yourself with `snapshot` + `fill-secret` / `fill-otp`
 (§2) — the general, selector-free path the agent reasons through.
 
+A **device-approval** challenge ("tap Yes on your phone", "tap 42") is handled
+differently: nothing is typed on the page, so `auto-login` raises a card telling
+the owner to approve on their own device and then polls until the page advances.
+Tell the owner to approve and wait — do not re-run the login. It needs no stored
+secret at all, which makes it the cheapest 2FA to live with. A `confirm-timeout`
+outcome means the approval never arrived.
+
+When auto-login fails it returns an `action`, and that field — not the prose —
+decides what you do next. There are exactly three:
+
+| `action` | What it means | Do |
+|---|---|---|
+| `owner_must_drive` | No credential can finish this: a bot challenge, or an IdP that refuses automation (Google, Microsoft). | Ask the owner to sign in themselves in the browser view for the named profile, then stop. |
+| `owner_must_confirm` | Credentials are fine; an approval on another device never arrived. | Ask the owner to approve, then retry. Do **not** re-check the credentials. |
+| `fix_credential` | The stored credential is wrong or incomplete. | Correct it (`vault_add` with overwrite, or `set-totp`). Retrying the same values will not help. |
+
+Never answer `owner_must_drive` by asking for a password. An account created
+through "Sign in with Google" has none, so the owner cannot give you one.
+
 **Domain allowlist (security):** a `login` credential is only typed into hosts on
 its `domains` list (default-deny, the same control the proxy enforces); a foreign
 origin is **refused**, and a sealed in-vault-generated secret can never be typed

--- a/plugins/agent-id-core/lib/notice.mjs
+++ b/plugins/agent-id-core/lib/notice.mjs
@@ -1,0 +1,72 @@
+// Alien Agent ID — one-way notices to the host.
+//
+// The secure-prompt socket normally means "ask the owner to type something and
+// block until they do". A notice is the other half: tell the owner something and
+// carry on. It exists for challenges answered somewhere the harness cannot see —
+// a "tap Yes on your phone" prompt is approved in Google's own app, so the
+// browser child must surface a card and keep polling the page, not ask for a
+// value that will never be typed here.
+//
+// The host raises the named event on its client stream and replies 200
+// immediately. Event names are namespaced (`browser.*`) and the host enforces
+// that, so a child cannot forge identity or secure-input lifecycle events.
+//
+// Best effort by construction: a missing socket, a refusing host, or a slow
+// reply must never fail the operation being reported on. Every path resolves.
+
+import http from "node:http";
+import { statSync } from "node:fs";
+
+const HOSTED_SOCK_ENV = "AGENT_ID_SECURE_PROMPT_SOCK";
+const NOTICE_TIMEOUT_MS = 3000;
+
+function hostedSocketPath(env) {
+  const p = env[HOSTED_SOCK_ENV];
+  if (!p || typeof p !== "string" || p.includes("://")) return null;
+  try {
+    return statSync(p).isSocket() ? p : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Raise `event` (must be under `browser.`) with `data` on the host's client
+ * stream. Resolves true when the host accepted it, false in every other case —
+ * including when there is no host at all, which is the normal standalone case.
+ */
+export function notifyHost(event, data = {}, { env = process.env } = {}) {
+  const socketPath = hostedSocketPath(env);
+  if (!socketPath) return Promise.resolve(false);
+  const payload = JSON.stringify({ kind: "notice", event, data });
+  return new Promise((resolve) => {
+    let settled = false;
+    const done = (value) => {
+      if (!settled) {
+        settled = true;
+        resolve(value);
+      }
+    };
+    const req = http.request(
+      {
+        socketPath,
+        path: "/",
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(payload),
+        },
+      },
+      (res) => {
+        res.resume(); // drain so the socket can close
+        res.on("end", () => done(res.statusCode === 200));
+      },
+    );
+    req.on("error", () => done(false));
+    req.setTimeout(NOTICE_TIMEOUT_MS, () => {
+      req.destroy();
+      done(false);
+    });
+    req.end(payload);
+  });
+}

--- a/tests/test-escalation.mjs
+++ b/tests/test-escalation.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+// Unit tests for login escalation (lib/escalation.mjs).
+//
+// The bug this guards: every failed auto-login used to advise "sign in yourself
+// with headed `login`", but headed login refuses without a display and points
+// back at auto-login. The two pointed at each other, so on a hosted host the
+// agent bounced between them or asked for a password that an SSO-only account
+// does not have. An `action` field replaces the prose.
+//
+// Run: node --test tests/test-escalation.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  escalationFor,
+  OWNER_MUST_DRIVE,
+  OWNER_MUST_CONFIRM,
+  FIX_CREDENTIAL,
+} from "../plugins/agent-id-browser/lib/escalation.mjs";
+
+const ctx = { credName: "acme", profile: "main" };
+
+test("a bot challenge needs a human at the page", () => {
+  const e = escalationFor("blocked", ctx);
+  assert.equal(e.action, OWNER_MUST_DRIVE);
+  assert.equal(e.reason, "bot_challenge");
+});
+
+test("an unresolved login escalates rather than looping on headed login", () => {
+  const e = escalationFor("timeout", ctx);
+  assert.equal(e.action, OWNER_MUST_DRIVE);
+  // The old advice sent the agent to a command that refuses without a display.
+  assert.doesNotMatch(e.message, /headed/i);
+});
+
+test("a device-approval timeout must not blame the credentials", () => {
+  const e = escalationFor("confirm-timeout", ctx);
+  assert.equal(e.action, OWNER_MUST_CONFIRM);
+  assert.equal(e.reason, "device_approval_timeout");
+  // Re-checking a password that was never wrong is exactly the wasted work
+  // the generic branch used to cause.
+  assert.match(e.message, /credentials are FINE/i);
+  assert.match(e.message, /do not ask for the password/i);
+});
+
+test("a rejected password is a credential problem, not a viewport one", () => {
+  const e = escalationFor("failed", ctx);
+  assert.equal(e.action, FIX_CREDENTIAL);
+});
+
+test("an unexpected OTP tells you which credential field is missing", () => {
+  const e = escalationFor("otp-unexpected", ctx);
+  assert.equal(e.action, FIX_CREDENTIAL);
+  assert.match(e.message, /set-totp|interactive/);
+});
+
+test("every outcome yields one of the three actions", () => {
+  const actions = new Set([OWNER_MUST_DRIVE, OWNER_MUST_CONFIRM, FIX_CREDENTIAL]);
+  for (const outcome of ["blocked", "confirm-timeout", "failed", "otp-unexpected", "weird", ""]) {
+    const e = escalationFor(outcome, ctx);
+    assert.ok(actions.has(e.action), `${outcome} → ${e.action}`);
+    assert.ok(e.reason && e.message, `${outcome} needs a reason and a message`);
+  }
+});

--- a/tests/test-login-detect.mjs
+++ b/tests/test-login-detect.mjs
@@ -124,3 +124,63 @@ test("blocked: Google's real 'unusual traffic from your network' wall is caught"
     "blocked",
   );
 });
+
+// ── Device approval ─────────────────────────────────────────────────────────
+//
+// A push prompt shares body copy with OTP ("check your phone", "approve … sign
+// in") but has no input: the sign-in completes when the owner taps Yes on their
+// own device. Classifying it as "otp-required" sent the caller hunting for a
+// code that never appears, so the login stalled until it timed out. It is also
+// the cheapest challenge to satisfy — no secret has to be stored anywhere.
+
+test("confirm-on-device: Google's push prompt is not mistaken for an OTP step", () => {
+  assert.equal(
+    classifyLogin({
+      hasPasswordField: false,
+      bodyText:
+        "2-Step Verification\nCheck your phone\nGoogle sent a notification to your iPhone. Tap Yes to sign in.",
+    }),
+    "confirm-on-device",
+  );
+});
+
+test("confirm-on-device: a number-match challenge", () => {
+  assert.equal(
+    classifyLogin({
+      hasPasswordField: false,
+      bodyText: "Open the Gmail app on your phone and tap 42 to sign in.",
+    }),
+    "confirm-on-device",
+  );
+});
+
+test("otp-required still wins when the page has a code field (SMS shows both)", () => {
+  assert.equal(
+    classifyLogin({
+      hasPasswordField: false,
+      hasOtpField: true,
+      bodyText: "Check your phone. Enter the 6-digit code we texted you.",
+    }),
+    "otp-required",
+  );
+});
+
+test("otp-required still wins for an authenticator code with no device prompt", () => {
+  assert.equal(
+    classifyLogin({
+      hasPasswordField: false,
+      bodyText: "Enter the verification code from your authenticator app",
+    }),
+    "otp-required",
+  );
+});
+
+test("blocked outranks a device prompt", () => {
+  assert.equal(
+    classifyLogin({
+      hasPasswordField: false,
+      bodyText: "Check your phone. But first, verify you are human.",
+    }),
+    "blocked",
+  );
+});

--- a/tests/test-session-route.mjs
+++ b/tests/test-session-route.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+// Unit tests for routing read/fetch to a live session (lib/session-route.mjs).
+// Pure — no browser.
+//
+// Run: node --test tests/test-session-route.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { sessionReplyError } from "../plugins/agent-id-browser/lib/session-route.mjs";
+
+test("a successful reply is not an error", () => {
+  assert.equal(
+    sessionReplyError({ finalUrl: "https://claude.ai/new", loggedOut: false }, {
+      name: "main",
+      action: "read",
+    }),
+    null,
+  );
+});
+
+test("an explicit ok:true reply is not an error", () => {
+  assert.equal(sessionReplyError({ ok: true, text: "hi" }, { name: "main", action: "read" }), null);
+});
+
+// callSession RESOLVES with the session's reply, so a failure arrives as a
+// value. Returning it unchanged spread `ok:false` into the success envelope and
+// reported a failure as a clean read with `sessionExpired:false`.
+test("an ok:false reply becomes an error rather than a value", () => {
+  const error = sessionReplyError(
+    { ok: false, error: "navigation timed out" },
+    { name: "main", action: "read" },
+  );
+  assert.ok(error instanceof Error);
+  assert.match(error.message, /navigation timed out/);
+});
+
+test("an ok:false reply with no message still errors", () => {
+  const error = sessionReplyError({ ok: false }, { name: "main", action: "read" });
+  assert.ok(error instanceof Error);
+  assert.match(error.message, /session action failed/);
+});
+
+// A session opened by an older build has no such action. Falling back to the
+// one-shot would answer from the stale sealed copy — the bug this routing
+// exists to prevent — so the caller must be told to cycle the session instead.
+test("an unknown action names the fix and is tagged SESSION_TOO_OLD", () => {
+  const error = sessionReplyError(
+    { ok: false, error: "unknown action: read" },
+    { name: "work", action: "read" },
+  );
+  assert.equal(error.code, "SESSION_TOO_OLD");
+  assert.match(error.message, /close --name work/);
+  assert.match(error.message, /open --name work/);
+});
+
+test("a null reply is not treated as a failure", () => {
+  assert.equal(sessionReplyError(null, { name: "main", action: "fetch" }), null);
+});


### PR DESCRIPTION
Every failed auto-login ended with the same advice: sign in yourself with headed `login`. On a host with no display that is a dead end — headed login refuses without a GUI session and points back at auto-login — so the agent bounced between the two, or asked for a password that an account created through "Sign in with Google" does not have.

## What changes

Failures now carry a machine-readable `action` (`lib/escalation.mjs`) with exactly three values: `owner_must_drive`, `owner_must_confirm`, `fix_credential`. The agent reads one field instead of parsing prose.

**Device approval.** `classifyLogin` returns `confirm-on-device` for a push prompt or number match. It shares body copy with 2FA but has no input, so it was read as `otp-required` and the login stalled hunting for a code that never appears. `auto-login` now raises a card and waits on its own budget, and emits `browser.confirmation_resolved` so the card does not outlive the approval. This is the cheapest challenge to satisfy — unlike a password or a TOTP seed it needs no secret stored anywhere.

**Notices** are a one-way message on the existing secure-prompt socket (`core/lib/notice.mjs`), for challenges answered somewhere the harness cannot see. Names are namespaced under `browser.` and the host enforces it, so a child cannot forge identity or secure-input lifecycle events. Best effort: with no host configured `notifyHost` resolves `false` and the login is unaffected.

**`read`/`fetch` run as session actions** when a session is open. They unsealed a *copy* of the profile, and live cookies only reach the vault on `close`, so reading a signed-in site reported `loggedOut` and a redirect to `/logout`. That feeds `sessionExpired`, so a healthy session could raise a "sign in again" card — the worst false alarm, since it teaches the owner to ignore the real one. A session from an older build reports `SESSION_TOO_OLD` rather than falling back, because falling back would reintroduce the stale read.

## Testing

604 passing, 0 failing. New: `test-escalation.mjs` (every outcome maps to one of the three actions), `test-session-route.mjs` (an `ok:false` reply becomes an error rather than being spread into a success envelope), and five cases in `test-login-detect.mjs` covering push prompt, number match, SMS-still-counts-as-OTP, authenticator-still-counts-as-OTP, and blocked-outranks-everything.

Verified against live Google sign-in in a sealed headless profile.

## Note

The `confirm-on-device` matcher was tested against reconstructed Google copy, not a live push prompt. The regexes are deliberately narrow, so the likelier failure is a real prompt not matching rather than something matching wrongly; the page text in a `confirm-timeout` result is what to feed back in.

Ships a changeset marking `agent-id-browser` and `agent-id-core` **minor**.