### PR TITLE
fix(browser): bound ctx.close() on the login timeout path

### DIFF
--- a/.changeset/quiet-pandas-settle.md
+++ b/.changeset/quiet-pandas-settle.md
@@ -1,0 +1,16 @@
+---
+"@alien-id/agent-id-browser": patch
+---
+
+login seals the profile when its own timeout fires
+
+`login` waits for either the window closing or `--timeout-sec`. On the timeout
+path the browser is usually already gone at the transport level, and
+`ctx.close()` against a dead connection never settles — it does not throw, so
+the surrounding `try/catch` does not help. The await simply never returned, and
+`sealProfile()` on the next line was never reached: the command hung forever and
+the sign-in the owner had just completed was discarded, leaving the next run
+logged out with nothing to explain why.
+
+The close is now bounded the way the read path already bounds it, so the seal
+always runs.

--- a/plugins/agent-id-browser/bin/cli.mjs
+++ b/plugins/agent-id-browser/bin/cli.mjs
@@ -318,11 +318,10 @@ async function cmdLogin(flags) {
         /* about:blank or slow page — fine, the user drives from here */
       }
       await waitForUserClose(ctx, Number(flags["timeout-sec"] || 600) * 1000);
-      try {
-        await ctx.close();
-      } catch {
-        /* already closed by the user */
-      }
+      await Promise.race([
+        ctx.close().catch(() => {}),
+        new Promise((resolve) => setTimeout(resolve, 5000)),
+      ]);
 
       const { bytes } = await sealProfile({ stateDir, file, dekHex: dek, sourceDir: work });
       vault.add({


### PR DESCRIPTION
Closes #76 