### PR TITLE
fix(browser): survive a parent that closes the std pipes

### DIFF
--- a/.changeset/deaf-parents-quiet-pipes.md
+++ b/.changeset/deaf-parents-quiet-pipes.md
@@ -1,0 +1,16 @@
+---
+"@alien-id/agent-id-browser": patch
+---
+
+A session daemon no longer dies when its parent stops listening to its std pipes
+
+The `open` daemon writes diagnostics to stderr for its whole lifetime — the
+read-only access-guard logs every blocked request there, and a busy site
+(LinkedIn fires dozens of telemetry POSTs seconds after load) produces a burst
+of them. A host that closes the pipe after reading the ready line turned that
+first burst into an unhandled `write EPIPE` that killed the live session: open
+reported ready, the first navigate succeeded, and every call after it got
+`session unreachable: ECONNREFUSED`.
+
+The CLI now swallows `error` events on `process.stdout`/`process.stderr`.
+Losing diagnostics must never cost the session.

--- a/plugins/agent-id-browser/bin/cli.mjs
+++ b/plugins/agent-id-browser/bin/cli.mjs
@@ -69,6 +69,15 @@ import {
   guardDecision,
 } from "../lib/access-guard.mjs";
 
+// A long-lived `open` daemon outlives its parent's interest in the std pipes:
+// once the host has read the ready line it may close them, and the next
+// diagnostic write (e.g. the access-guard logging a blocked request) would
+// otherwise raise an unhandled EPIPE and kill the live session. Swallow pipe
+// errors instead — losing diagnostics must never cost the session.
+for (const stream of [process.stdout, process.stderr]) {
+  stream.on("error", () => {});
+}
+
 // Bridge the plugin path vars into the environment. Claude Code SUBSTITUTES
 // ${CLAUDE_PLUGIN_DATA}/${CLAUDE_PLUGIN_ROOT} into skill text but only EXPORTS
 // them to hook/MCP processes — not to ordinary skill Bash commands. So the skill


### PR DESCRIPTION
## Summary

The `open` daemon dies with an unhandled `write EPIPE` when its parent closes the std pipes after reading the ready line. Trigger found in the wild: the Lethe desktop runtime (lethe 0.28.0) drops the daemon stderr pipe once ready, the `linkedin` profile is sealed read-only, and linkedin.com fires dozens of telemetry POSTs on load — the access-guard logs each blocked request to stderr, the first burst hits the closed pipe, and the session dies seconds after a successful navigate. Signature: `open` ready → first navigate ok → every later call `session unreachable: ECONNREFUSED`, respawn loop.

Fix: swallow `error` events on `process.stdout`/`process.stderr` in the CLI entry. Losing diagnostics must never cost the session.

## Verification

Python harness mimicking the host (spawn `open --name linkedin`, read ready, close stderr, navigate to linkedin.com): unpatched 7.6.0 daemon exits rc=1 within 1s of navigate; patched daemon survives, serves `page-text`, and `close` reseals cleanly.

The complementary host-side fix (drain stderr for the daemon lifetime) lands in lethe separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)