### PR TITLE
fix(browser): one ref space, real comboboxes, no silently-dropped refs

### DIFF
--- a/.changeset/shared-refs-real-comboboxes.md
+++ b/.changeset/shared-refs-real-comboboxes.md
@@ -1,0 +1,43 @@
+---
+"@alien-id/agent-id-browser": minor
+---
+
+Enterprise application forms are drivable: one ref space, real comboboxes, and no silently-dropped refs
+
+Three defects that together made an SAP/Taleo-shaped careers form unfillable. All
+three were observed on live applications, twice burning an agent's whole tool
+budget with no progress.
+
+**Refs meant different things in different tools.** `snapshot` and `form-inspect`
+each cleared every `data-aibref` and renumbered from `e1` — but over different
+element sets: snapshot over links/buttons/inputs, form-inspect over form controls
+only. So `e7` was the First Name input after a form-inspect and a toolbar button
+after a snapshot, and nothing detected the difference: a form-fill built from
+form-inspect refs silently drove the wrong elements, and the stale-ref error
+advised re-running two tools that disagreed. Both modes now number over the UNION
+of their selectors in document order, independently of what each reports, so a ref
+denotes the same element either way.
+
+**Refs are versioned by the observation that minted them.** They now read `3:e7`,
+so a ref held across a re-observation is refused by name instead of resolving
+against whatever currently holds that number. Clearing the attributes per scan is
+not sufficient alone: the next scan re-tags a possibly different element with the
+same `e7`. The check is skipped for unversioned refs and for callers driving
+`fillForm` against a hand-built state, so direct API use keeps working.
+
+**Comboboxes were driven with `selectOption`.** That only works on a native
+`<select>`; against an `<input role=combobox>` it fails every time with "Element
+is not a `<select>` element", and Oracle/Taleo/Workday/SAP render country and
+nationality pickers exactly that way. `form-fill` and the bare `select` action now
+dispatch on what the element actually is: `selectOption` for a real select, and
+for a combobox a click/type/pick that emits real key events via
+`pressSequentially`, because autocompletes ignore a value set in one shot and
+submit blank. The pick is verified against the control's own value, so a rejected
+choice surfaces as a failure instead of a cheerful `ok:true`.
+
+**`type-text`/`fill-text` silently discarded a `--ref`.** They type into whatever
+is focused and have no ref parameter, but the CLI dropped the flag before the
+session server saw it, so `type-text --ref e27 --text Switzerland` aimed at a
+country combobox typed into whatever held focus and reported success — the filter
+never saw the text and the widget answered "There were no results". A ref is now
+refused by name, pointing at the ref-taking tool (`type`/`fill`) instead.

--- a/plugins/agent-id-browser/bin/cli.mjs
+++ b/plugins/agent-id-browser/bin/cli.mjs
@@ -860,8 +860,19 @@ runCli({
     "move-xy": actionCmd("move-xy", (f) => ({ x: f.x, y: f.y, css: f.css === true })),
     "drag-xy": actionCmd("drag-xy", (f) => ({ x: f.x, y: f.y, tox: f.tox, toy: f.toy, css: f.css === true })),
     "scroll-xy": actionCmd("scroll-xy", (f) => ({ x: f.x, y: f.y, dx: f.dx, dy: f.dy, css: f.css === true })),
-    "type-text": actionCmd("type-text", (f) => ({ text: f.text ?? "", submit: f.submit === true })),
-    "fill-text": actionCmd("fill-text", (f) => ({ text: f.text ?? "", submit: f.submit === true })),
+    // `ref` rides along ONLY so the session server can refuse it by name —
+    // these type into whatever is focused. Dropping it here instead would put
+    // the text somewhere the caller did not ask for and report success.
+    "type-text": actionCmd("type-text", (f) => ({
+      text: f.text ?? "",
+      submit: f.submit === true,
+      ref: f.ref,
+    })),
+    "fill-text": actionCmd("fill-text", (f) => ({
+      text: f.text ?? "",
+      submit: f.submit === true,
+      ref: f.ref,
+    })),
     "probe-xy": actionCmd("probe-xy", (f) => ({ x: f.x, y: f.y, css: f.css === true })),
     resize: actionCmd("resize", (f) => ({ width: f.width, height: f.height })),
     screenshot: actionCmd("screenshot", (f) => ({ path: f.path, fullPage: f.full === true || f.fullPage === true, region: region(f.region) })),
@@ -937,10 +948,11 @@ runCli({
         "  move-xy  --name N --x N --y N [--css]        drag-xy --x N --y N --tox N --toy N\n" +
         "  scroll-xy --name N --x N --y N [--dy N] [--dx N]   wheel at a pixel\n" +
         "          (zoom-toward-point on maps; scroll an inner pane). dy>0 = down.\n" +
-        "  type-text --name N --text T [--submit]       type into the focused element\n" +
-        "          (plaintext only — secrets stay ref-based via fill-secret/fill-otp)\n" +
-        "  fill-text --name N --text T [--submit]       paste into the focused element\n" +
-        "          (one-shot insert, no per-key events — fast for long text)\n" +
+        "  type-text --name N --text T [--submit]       type into the FOCUSED element\n" +
+        "          (no --ref — use `type` for that; plaintext only, secrets stay\n" +
+        "          ref-based via fill-secret/fill-otp)\n" +
+        "  fill-text --name N --text T [--submit]       paste into the FOCUSED element\n" +
+        "          (no --ref — use `fill`; one-shot insert, no per-key events)\n" +
         "  probe-xy --name N --x N --y N                what element is at a pixel\n" +
         "          (tag/role/name/ref — vision→DOM bridge; read-only, ro-safe)\n" +
         "  zoom    --name N --region x0,y0,x1,y1 [--path P]   cropped closer view of\n" +

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -56,17 +56,37 @@ export function sessionFilePath(stateDir, name) {
   return path.join(sessionsDir(stateDir), `${name}.json`);
 }
 
-// Runs in the page (once per frame). Tags visible interactive elements and
-// returns a flat list. `prefix` namespaces refs per frame: "" for the main
-// frame ("e1", "e2", …), "f1" for the first iframe ("f1e1", …) — so a ref is
-// self-describing about which frame it lives in.
+// THE SHARED REF SPACE — keep this selector, and the numbering loop that walks
+// it, byte-identical in snapshotInPage and formSnapshotInPage.
+//
+// Both observation modes tag the DOM, and both clear every existing tag first.
+// When they numbered over *different* element sets (snapshot: links/buttons/
+// inputs; form-inspect: form controls only) the same string meant different
+// elements in each: after a form-inspect "e7" was the First Name input, after a
+// snapshot it was a toolbar button. Nothing detected the difference, so a
+// form-fill using form-inspect refs silently drove the wrong elements — or, if
+// the page had also navigated, bounced off a "ref is stale" error whose advice
+// ("run form-inspect or snapshot again") pointed at two tools that disagreed.
+//
+// The fix is to number over the UNION of both selectors, in document order,
+// independently of what each mode chooses to report. Numbering therefore does
+// NOT skip invisible elements — reporting still does — so ref numbers are
+// sparse in the returned list, and stable across modes. These two functions
+// cannot share a module constant: page functions are serialised into the page
+// and cannot close over module scope. tests/test-browser-ref-space.mjs asserts
+// they stay in agreement.
+//
+// `prefix` namespaces refs per frame: "" for the main frame ("e1", "e2", …),
+// "f1" for the first iframe ("f1e1", …) — so a ref is self-describing about
+// which frame it lives in.
 export function snapshotInPage(prefix) {
   const pre = prefix || "";
   const SEL = [
     "a[href]", "button", "input:not([type=hidden])", "textarea", "select",
-    "[role=button]", "[role=link]", "[role=textbox]", "[role=checkbox]",
-    "[role=radio]", "[role=tab]", "[role=menuitem]", "[role=option]",
-    "[contenteditable=true]", "summary", "[tabindex]:not([tabindex='-1'])",
+    "[role=button]", "[role=link]", "[role=textbox]", "[role=combobox]",
+    "[role=checkbox]", "[role=radio]", "[role=tab]", "[role=menuitem]",
+    "[role=option]", "[contenteditable=true]", "summary",
+    "[tabindex]:not([tabindex='-1'])",
   ].join(",");
   // Clear refs from a previous snapshot first: forms that swap in place (e.g.
   // multi-step IdP logins) leave stale data-aibref attributes, so a reused ref
@@ -79,13 +99,15 @@ export function snapshotInPage(prefix) {
   for (const el of document.querySelectorAll(SEL)) {
     if (seen.has(el)) continue;
     seen.add(el);
+    // Numbered before the visibility test so the counter tracks the shared ref
+    // space rather than this mode's reporting filter.
+    const ref = pre + "e" + ++i;
+    el.setAttribute("data-aibref", ref);
     const r = el.getBoundingClientRect();
     const st = window.getComputedStyle(el);
     if (r.width === 0 || r.height === 0 || st.visibility === "hidden" || st.display === "none") {
       continue;
     }
-    const ref = pre + "e" + ++i;
-    el.setAttribute("data-aibref", ref);
     // el.value is a useful *label* only for button-like inputs (submit/button/
     // reset), where the value IS the visible caption. For any text-entry field
     // el.value is user-entered content that could be a secret — OTP/2FA fields
@@ -126,7 +148,17 @@ export function snapshotInPage(prefix) {
 // not the contents the user or vault supplied.
 export function formSnapshotInPage(prefix) {
   const pre = prefix || "";
+  // Identical to snapshotInPage's selector and numbering loop — see the note
+  // there. This mode reports only form controls, but it must NUMBER the same
+  // union so a ref means the same element in both modes.
   const SEL = [
+    "a[href]", "button", "input:not([type=hidden])", "textarea", "select",
+    "[role=button]", "[role=link]", "[role=textbox]", "[role=combobox]",
+    "[role=checkbox]", "[role=radio]", "[role=tab]", "[role=menuitem]",
+    "[role=option]", "[contenteditable=true]", "summary",
+    "[tabindex]:not([tabindex='-1'])",
+  ].join(",");
+  const REPORTED = [
     "input:not([type=hidden])", "textarea", "select", "button",
     "[role=textbox]", "[role=combobox]", "[role=checkbox]", "[role=radio]",
     "[contenteditable=true]",
@@ -161,7 +193,15 @@ export function formSnapshotInPage(prefix) {
 
   const controls = [];
   let i = 0;
+  const seen = new Set();
   for (const el of document.querySelectorAll(SEL)) {
+    if (seen.has(el)) continue;
+    seen.add(el);
+    // Numbered over the shared union first; only then filtered down to what
+    // this mode reports. Numbering must not depend on the filter.
+    const ref = pre + "e" + ++i;
+    el.setAttribute("data-aibref", ref);
+    if (!el.matches(REPORTED)) continue;
     const tag = el.tagName.toLowerCase();
     const type = clip(
       el.getAttribute("type") || (tag === "input" ? el.type || "text" : tag === "select" ? "select" : tag),
@@ -170,8 +210,6 @@ export function formSnapshotInPage(prefix) {
     const visible = visibleOf(el);
     // Hidden native controls remain actionable through setChecked/setInputFiles.
     if (!visible && !["checkbox", "radio", "file"].includes(type)) continue;
-    const ref = pre + "e" + ++i;
-    el.setAttribute("data-aibref", ref);
     const form = el.closest("form");
     const role = el.getAttribute("role") || tag;
     const entry = {
@@ -524,6 +562,53 @@ async function validateTaggedControls(state) {
 // toggles styled controls, selects options, and attaches files. Every operation
 // is checked after it runs and failures are returned individually so one bad
 // field cannot discard the successful half of a long application form.
+// Drive an ARIA combobox (an <input> that opens a listbox) the way a person
+// does: focus it, type enough to filter, then click the matching option.
+//
+// Deliberately does NOT use `fill()` — autocompletes listen for keystrokes, and
+// a value set in one shot usually leaves the listbox closed and the site's
+// internal model empty, so the form submits blank. `pressSequentially` emits
+// real key events.
+//
+// Only one value is supported: multi-select comboboxes are a different widget
+// (chips/tags) and pretending otherwise would silently drop values.
+async function pickCombobox(target, ref, values) {
+  if (values.length !== 1) {
+    throw new Error("combobox takes exactly one value (multi-select comboboxes are not supported)");
+  }
+  const wanted = values[0];
+  const input = target.locator(sel(ref));
+  await input.click({ timeout: ACTION_TIMEOUT });
+  await input.fill("", { timeout: ACTION_TIMEOUT }).catch(() => {});
+  await input.pressSequentially(wanted, { delay: 25, timeout: ACTION_TIMEOUT });
+
+  // The listbox is usually a sibling/portal rather than a descendant, so look
+  // page-wide for visible options and match on text.
+  const options = target.locator('[role=option]:visible, li[role=option], [role=listbox] li');
+  const exact = options.filter({ hasText: new RegExp(`^\\s*${escapeForRegex(wanted)}\\s*$`, "i") });
+  const chosen = (await exact.count().catch(() => 0)) > 0 ? exact.first() : options.first();
+  try {
+    await chosen.waitFor({ state: "visible", timeout: ACTION_TIMEOUT });
+  } catch {
+    throw new Error(
+      `combobox '${ref}' opened no option list for "${wanted}" — the site may need a different value spelling, or the widget is not a listbox combobox`,
+    );
+  }
+  const label = ((await chosen.innerText().catch(() => "")) || "").replace(/\s+/g, " ").trim().slice(0, 160);
+  await chosen.click({ timeout: ACTION_TIMEOUT });
+
+  // Verify against the control's own value, not against what we clicked: a
+  // combobox that rejects the pick leaves the field empty or reverted, and that
+  // must surface as a failure rather than a cheerful ok:true.
+  const settled = ((await input.inputValue().catch(() => "")) || "").trim();
+  if (!settled) throw new Error(`combobox '${ref}' did not retain a value after picking "${label || wanted}"`);
+  return { value: settled, ...(label && label !== settled ? { option: label } : {}) };
+}
+
+function escapeForRegex(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 export async function fillForm(state, p) {
   const fields = Array.isArray(p.fields) ? p.fields : [];
   const checks = Array.isArray(p.checks) ? p.checks : [];
@@ -598,10 +683,32 @@ export async function fillForm(state, p) {
     const ref = String(select?.ref || "");
     const values = (Array.isArray(select?.values) ? select.values : [select?.value]).filter((v) => v != null).map(String);
     try {
-      const selected = await frameForRef(state, ref).selectOption(sel(ref), values, { timeout: ACTION_TIMEOUT });
-      const matches = values.every((value) => selected.includes(value));
-      if (!matches) throw new Error("page did not retain the selected option(s)");
-      results.push({ ref, kind: "select", ok: true, selected });
+      const target = frameForRef(state, ref);
+      // Dispatch on what the control actually IS. `selectOption` only works on
+      // a native <select>; driving an ARIA combobox with it fails every time
+      // with "Element is not a <select> element", which no amount of retrying
+      // fixes — and enterprise forms (Oracle/Taleo/Workday) render their
+      // country/nationality pickers as <input role="combobox"> autocompletes.
+      const kind = await target.locator(sel(ref)).evaluate((el) =>
+        el.tagName.toLowerCase() === "select"
+          ? "select"
+          : el.getAttribute("role") === "combobox" || el.getAttribute("aria-autocomplete")
+            ? "combobox"
+            : el.tagName.toLowerCase(),
+      );
+      if (kind === "select") {
+        const selected = await target.selectOption(sel(ref), values, { timeout: ACTION_TIMEOUT });
+        const matches = values.every((value) => selected.includes(value));
+        if (!matches) throw new Error("page did not retain the selected option(s)");
+        results.push({ ref, kind: "select", ok: true, selected });
+      } else if (kind === "combobox") {
+        const selected = await pickCombobox(target, ref, values);
+        results.push({ ref, kind: "select", ok: true, control: "combobox", selected });
+      } else {
+        throw new Error(
+          `ref '${ref}' is a <${kind}>, not a select or combobox — use fields for text input, or act/click for a custom widget`,
+        );
+      }
     } catch (error) {
       results.push({ ref, kind: "select", ok: false, error: safeFormError(error) });
     }
@@ -891,9 +998,24 @@ async function dispatch(state, msg, policy = null) {
         state.stream?.resume();
       }
     }
-    case "select":
-      await frameForRef(state, p.ref).selectOption(sel(p.ref), p.values, { timeout: ACTION_TIMEOUT });
+    case "select": {
+      // Same dispatch as form-fill's selects — a bare `select` on an ARIA
+      // combobox would otherwise fail identically here.
+      const target = frameForRef(state, p.ref);
+      const values = (Array.isArray(p.values) ? p.values : [p.values]).filter((v) => v != null).map(String);
+      const kind = await target.locator(sel(p.ref)).evaluate((el) =>
+        el.tagName.toLowerCase() === "select"
+          ? "select"
+          : el.getAttribute("role") === "combobox" || el.getAttribute("aria-autocomplete")
+            ? "combobox"
+            : el.tagName.toLowerCase(),
+      );
+      if (kind === "combobox") {
+        return { selected: p.ref, control: "combobox", ...(await pickCombobox(target, p.ref, values)) };
+      }
+      await target.selectOption(sel(p.ref), values, { timeout: ACTION_TIMEOUT });
       return { selected: p.ref };
+    }
     case "hover":
       await humanHover(page, sel(p.ref), { timeout: ACTION_TIMEOUT, root: frameForRef(state, p.ref) });
       return { hovered: p.ref };

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -79,8 +79,9 @@ export function sessionFilePath(stateDir, name) {
 // `prefix` namespaces refs per frame: "" for the main frame ("e1", "e2", …),
 // "f1" for the first iframe ("f1e1", …) — so a ref is self-describing about
 // which frame it lives in.
-export function snapshotInPage(prefix) {
-  const pre = prefix || "";
+export function snapshotInPage(arg) {
+  const { prefix, generation } = arg && typeof arg === "object" ? arg : { prefix: arg, generation: 0 };
+  const pre = `${generation ?? 0}:${prefix || ""}`;
   const SEL = [
     "a[href]", "button", "input:not([type=hidden])", "textarea", "select",
     "[role=button]", "[role=link]", "[role=textbox]", "[role=combobox]",
@@ -146,8 +147,9 @@ export function snapshotInPage(prefix) {
 // forms commonly render a styled label over the real control. Values from text
 // inputs are deliberately never returned; validation reports lengths/matches,
 // not the contents the user or vault supplied.
-export function formSnapshotInPage(prefix) {
-  const pre = prefix || "";
+export function formSnapshotInPage(arg) {
+  const { prefix, generation } = arg && typeof arg === "object" ? arg : { prefix: arg, generation: 0 };
+  const pre = `${generation ?? 0}:${prefix || ""}`;
   // Identical to snapshotInPage's selector and numbering loop — see the note
   // there. This mode reports only form controls, but it must NUMBER the same
   // union so a ref means the same element in both modes.
@@ -251,8 +253,22 @@ const MAX_FRAMES = 12; // iframes snapshotted per page (ad-heavy pages have doze
 const CONSOLE_CAP = 300; // ring-buffer size for captured console/pageerror entries
 
 // "f1e3" → "f1"; plain main-frame refs ("e3") → null. Exported for tests.
+// A ref carries the observation it came from: "3:e7", "3:f1e2". The generation
+// prefix makes staleness a *synchronous string check* instead of something we
+// discover by acting on whatever now happens to hold that number.
+//
+// Clearing every data-aibref on each scan is not enough on its own: the next
+// scan re-tags a possibly different element with the same "e7", so a ref held
+// across two observations still resolves — silently, to the wrong element. The
+// version prefix is what the agent copies back verbatim, so a ref from an older
+// observation is refused by name rather than executed.
+export function refGenerationOf(ref) {
+  const m = /^(\d+):/.exec(String(ref ?? ""));
+  return m ? Number(m[1]) : null;
+}
+
 export function frameRefId(ref) {
-  const m = /^(f\d+)e\d+$/.exec(String(ref ?? ""));
+  const m = /^(?:\d+:)?(f\d+)e\d+$/.exec(String(ref ?? ""));
   return m ? m[1] : null;
 }
 
@@ -344,6 +360,16 @@ function frameForRef(state, ref) {
       `ref '${ref}' is stale (${state.refsInvalidReason || "page changed"}) — run form-inspect or snapshot again`,
     );
   }
+  // Snapshot versioning: refuse a ref minted by an earlier observation instead
+  // of resolving it against the current tagging. Only meaningful when both
+  // sides carry a generation — an unversioned ref, or a caller driving fillForm
+  // directly against a hand-built state, is let through unchanged.
+  const generation = refGenerationOf(ref);
+  if (generation !== null && typeof state.refGeneration === "number" && generation !== state.refGeneration) {
+    throw new Error(
+      `ref '${ref}' is from observation ${generation}, but the page has been observed again since (now ${state.refGeneration}) — re-run form-inspect (or snapshot) and use the refs it returns`,
+    );
+  }
   const id = frameRefId(ref);
   if (!id) return state.current;
   const frame = state.frames.get(id);
@@ -359,11 +385,14 @@ function invalidateRefs(state, reason = "page changed") {
   state.frames.clear();
 }
 
-function activateRefs(state) {
-  state.refGeneration += 1;
+// Commit the generation the page was just tagged with. The number is chosen
+// *before* the scan (the page functions stamp it into every ref), so it is
+// passed in rather than incremented here.
+function activateRefs(state, generation) {
+  state.refGeneration = generation;
   state.refsValid = true;
   state.refsInvalidReason = null;
-  return state.refGeneration;
+  return generation;
 }
 
 // A field the vault typed a secret into is tagged with this attribute (see
@@ -812,7 +841,9 @@ async function dispatch(state, msg, policy = null) {
     }
     case "snapshot": {
       state.frames.clear();
-      const main = await page.evaluate(snapshotInPage, "");
+      // Chosen before the scan so the page can stamp it into every ref.
+      const generation = state.refGeneration + 1;
+      const main = await page.evaluate(snapshotInPage, { prefix: "", generation });
       const frames = [];
       let skipped = 0;
       let fCount = 0;
@@ -824,7 +855,7 @@ async function dispatch(state, msg, policy = null) {
         }
         let snap;
         try {
-          snap = await f.evaluate(snapshotInPage, `f${fCount + 1}`);
+          snap = await f.evaluate(snapshotInPage, { prefix: `f${fCount + 1}`, generation });
         } catch {
           continue; // detached / navigating frame — nothing was tagged
         }
@@ -836,7 +867,7 @@ async function dispatch(state, msg, policy = null) {
         }
       }
       const tabs = state.ctx.pages().length;
-      const generation = activateRefs(state);
+      activateRefs(state, generation);
       return {
         ...main,
         generation,
@@ -847,7 +878,8 @@ async function dispatch(state, msg, policy = null) {
     }
     case "form-inspect": {
       state.frames.clear();
-      const main = await page.evaluate(formSnapshotInPage, "");
+      const generation = state.refGeneration + 1;
+      const main = await page.evaluate(formSnapshotInPage, { prefix: "", generation });
       const frames = [];
       let skipped = 0;
       let fCount = 0;
@@ -859,7 +891,7 @@ async function dispatch(state, msg, policy = null) {
         }
         let snap;
         try {
-          snap = await frame.evaluate(formSnapshotInPage, `f${fCount + 1}`);
+          snap = await frame.evaluate(formSnapshotInPage, { prefix: `f${fCount + 1}`, generation });
         } catch {
           continue;
         }
@@ -870,7 +902,7 @@ async function dispatch(state, msg, policy = null) {
           main.controls.push(...snap.controls);
         }
       }
-      const generation = activateRefs(state);
+      activateRefs(state, generation);
       return {
         ...main,
         generation,

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -294,6 +294,22 @@ async function liveDpr(page, css) {
   return page.evaluate(() => window.devicePixelRatio || 1).catch(() => 1);
 }
 
+// The focus-typing actions (`type-text`/`fill-text`) type into whatever is
+// focused — they have no ref parameter. Passing one reads as targeting that
+// element, so accepting it silently sends the text wherever focus happened to
+// be and reports success: observed on an SAP careers form, where "Switzerland"
+// typed at a country combobox by ref never reached the filter and the widget
+// answered "There were no results". Name the ref-taking tool instead of
+// dropping the argument.
+export function refuseRef(action, p, alternative) {
+  if (p.ref === undefined || p.ref === null || p.ref === "") return;
+  throw new Error(
+    `${action} types into the FOCUSED element and takes no --ref (got "${p.ref}"). ` +
+      `Use \`${alternative}\` to drive an element by ref, or focus it first ` +
+      `(click/click-xy) and re-run ${action} without --ref.`,
+  );
+}
+
 // Convert an agent-supplied screenshot pixel to a viewport CSS point, rejecting
 // non-numeric coords with an action-specific message.
 function toXY(x, y, dpr, label) {
@@ -1124,6 +1140,7 @@ async function dispatch(state, msg, policy = null) {
       // first if replacing. Only the length leaves the session, never the text.
       // Cadence comes from humanTypeFocused — the same jittered per-key delays as
       // ref-based `type`; a fixed inter-key interval is itself a bot fingerprint.
+      refuseRef("type-text", p, "type --ref eN --text T");
       const text = String(p.text ?? "");
       await humanTypeFocused(page, text, { submit: !!p.submit });
       return { typed: text.length, submit: !!p.submit };
@@ -1137,6 +1154,7 @@ async function dispatch(state, msg, policy = null) {
       // autocomplete). Same contract otherwise: PLAINTEXT ONLY (secrets stay
       // ref-based via fill-secret/fill-otp), APPENDS at the caret (no clear),
       // and only the length leaves the session, never the text.
+      refuseRef("fill-text", p, "fill --fields '[{\"ref\":\"eN\",\"value\":\"V\"}]'");
       const text = String(p.text ?? "");
       await page.keyboard.insertText(text);
       if (p.submit) await page.keyboard.press("Enter");

--- a/tests/test-browser-ref-space.mjs
+++ b/tests/test-browser-ref-space.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+
+// Proof that `snapshot` and `form-inspect` share ONE ref space.
+//
+// They used to number over different element sets — snapshot over links/
+// buttons/inputs, form-inspect over form controls only — and both wiped every
+// existing data-aibref before renumbering from e1. So the same string meant
+// different elements depending on which tool ran last: after a form-inspect
+// "e7" was the First Name input, after a snapshot it was a toolbar button.
+// Nothing detected the difference, so a form-fill built from form-inspect refs
+// silently drove the wrong elements. Observed in the wild on an Oracle/Taleo
+// careers form, where it burned the agent's whole tool budget.
+//
+// The invariant now: a ref denotes the same element in both modes. These two
+// page functions cannot share a module constant (they are serialised into the
+// page), so this test is what keeps their selectors and numbering loops in
+// agreement.
+//
+// LIVE real-browser test — SKIPS automatically when patchright / Chrome are
+// not installed.
+//
+// Run: node --test tests/test-browser-ref-space.mjs
+
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { resolvePatchright, launchContext } from "../plugins/agent-id-browser/lib/launch.mjs";
+import { snapshotInPage, formSnapshotInPage } from "../plugins/agent-id-browser/lib/session-server.mjs";
+
+// A page shaped like the form that broke: chrome/nav elements interleaved with
+// the form controls, so the two modes would disagree if either filtered before
+// numbering. Includes an ARIA combobox (the Taleo-style country picker) and a
+// visually hidden checkbox, which each mode treats differently when REPORTING.
+const PAGE = `<!doctype html><html><body>
+  <a href="/help">Help</a>
+  <button id="nav">Menu</button>
+  <form name="careerform">
+    <input id="first" name="firstName" aria-label="First Name">
+    <input id="last" name="lastName" aria-label="Last Name">
+    <input id="country" role="combobox" aria-label="Country" aria-autocomplete="list">
+    <select id="permit" aria-label="Permit"><option value="B">B</option><option value="C">C</option></select>
+    <input id="agree" type="checkbox" style="display:none">
+    <button id="submit" type="submit">Apply</button>
+  </form>
+  <a href="/privacy">Privacy</a>
+</body></html>`;
+
+const patchrightAvailable = !!resolvePatchright();
+
+let ctx;
+let workDir;
+let page;
+
+before(async () => {
+  if (!patchrightAvailable) return;
+  workDir = await fs.mkdtemp(path.join(os.tmpdir(), "aib-refspace-"));
+  ctx = await launchContext({ profileDir: workDir, headless: true, contextOptions: {} });
+  page = ctx.pages()[0] || (await ctx.newPage());
+  await page.setContent(PAGE, { waitUntil: "domcontentloaded" });
+});
+
+after(async () => {
+  if (ctx) await ctx.close().catch(() => {});
+  if (workDir) await fs.rm(workDir, { recursive: true, force: true }).catch(() => {});
+});
+
+const skip = patchrightAvailable ? false : "patchright/Chrome not installed";
+
+test("a ref denotes the same element in both observation modes", { skip }, async () => {
+
+  // Take each observation independently, exactly as the two tools do — each
+  // clears the previous tagging and renumbers.
+  const snap = await page.evaluate(snapshotInPage, "");
+  const snapById = await page.evaluate(() =>
+    Object.fromEntries(
+      Array.from(document.querySelectorAll("[data-aibref]")).map((el) => [el.id, el.getAttribute("data-aibref")]),
+    ),
+  );
+
+  const form = await page.evaluate(formSnapshotInPage, "");
+  const formById = await page.evaluate(() =>
+    Object.fromEntries(
+      Array.from(document.querySelectorAll("[data-aibref]")).map((el) => [el.id, el.getAttribute("data-aibref")]),
+    ),
+  );
+
+  // The invariant. Every element both modes tag must carry the same ref.
+  for (const [id, ref] of Object.entries(snapById)) {
+    if (!(id in formById)) continue;
+    assert.equal(formById[id], ref, `element #${id} changed ref between modes (${ref} → ${formById[id]})`);
+  }
+
+  // And specifically the case that broke: the first form field must not
+  // collide with a nav control that precedes it in document order.
+  assert.ok(snapById.first, "first-name input should be tagged by snapshot");
+  assert.equal(formById.first, snapById.first);
+  assert.notEqual(formById.first, snapById.nav);
+
+  // Reported sets still differ — form-inspect describes controls, snapshot
+  // describes everything interactive — even though the refs agree.
+  const formRefs = form.controls.map((c) => c.ref);
+  assert.ok(formRefs.includes(formById.country), "combobox should be reported by form-inspect");
+  assert.ok(
+    snap.elements.some((e) => e.ref === snapById.nav),
+    "nav button should be reported by snapshot",
+  );
+});
+
+test("form-inspect reports the combobox as a combobox", { skip }, async () => {
+  const form = await page.evaluate(formSnapshotInPage, "");
+  const country = form.controls.find((c) => c.label === "Country");
+  assert.ok(country, "country control should be reported");
+  // form-fill dispatches on this: role=combobox must not be driven with
+  // selectOption, which only works on a native <select>.
+  assert.equal(country.role, "combobox");
+  const permit = form.controls.find((c) => c.label === "Permit");
+  assert.equal(permit.role, "select");
+  assert.ok(Array.isArray(permit.options) && permit.options.length === 2);
+});

--- a/tests/test-browser-ref-space.mjs
+++ b/tests/test-browser-ref-space.mjs
@@ -28,7 +28,12 @@ import os from "node:os";
 import path from "node:path";
 
 import { resolvePatchright, launchContext } from "../plugins/agent-id-browser/lib/launch.mjs";
-import { snapshotInPage, formSnapshotInPage } from "../plugins/agent-id-browser/lib/session-server.mjs";
+import {
+  snapshotInPage,
+  formSnapshotInPage,
+  refGenerationOf,
+  frameRefId,
+} from "../plugins/agent-id-browser/lib/session-server.mjs";
 
 // A page shaped like the form that broke: chrome/nav elements interleaved with
 // the form controls, so the two modes would disagree if either filtered before
@@ -73,44 +78,70 @@ test("a ref denotes the same element in both observation modes", { skip }, async
 
   // Take each observation independently, exactly as the two tools do — each
   // clears the previous tagging and renumbers.
-  const snap = await page.evaluate(snapshotInPage, "");
+  const snap = await page.evaluate(snapshotInPage, { prefix: "", generation: 1 });
   const snapById = await page.evaluate(() =>
     Object.fromEntries(
       Array.from(document.querySelectorAll("[data-aibref]")).map((el) => [el.id, el.getAttribute("data-aibref")]),
     ),
   );
 
-  const form = await page.evaluate(formSnapshotInPage, "");
+  const form = await page.evaluate(formSnapshotInPage, { prefix: "", generation: 2 });
   const formById = await page.evaluate(() =>
     Object.fromEntries(
       Array.from(document.querySelectorAll("[data-aibref]")).map((el) => [el.id, el.getAttribute("data-aibref")]),
     ),
   );
 
-  // The invariant. Every element both modes tag must carry the same ref.
+  // The version prefix is expected to differ (these are two observations);
+  // the invariant under test is the ELEMENT NUMBERING behind it.
+  const bare = (ref) => String(ref).replace(/^\d+:/, "");
+
+  // Every element both modes tag must carry the same number.
   for (const [id, ref] of Object.entries(snapById)) {
     if (!(id in formById)) continue;
-    assert.equal(formById[id], ref, `element #${id} changed ref between modes (${ref} → ${formById[id]})`);
+    assert.equal(
+      bare(formById[id]),
+      bare(ref),
+      `element #${id} changed ref between modes (${ref} → ${formById[id]})`,
+    );
   }
 
   // And specifically the case that broke: the first form field must not
   // collide with a nav control that precedes it in document order.
   assert.ok(snapById.first, "first-name input should be tagged by snapshot");
-  assert.equal(formById.first, snapById.first);
-  assert.notEqual(formById.first, snapById.nav);
+  assert.equal(bare(formById.first), bare(snapById.first));
+  assert.notEqual(bare(formById.first), bare(snapById.nav));
 
   // Reported sets still differ — form-inspect describes controls, snapshot
-  // describes everything interactive — even though the refs agree.
-  const formRefs = form.controls.map((c) => c.ref);
-  assert.ok(formRefs.includes(formById.country), "combobox should be reported by form-inspect");
+  // describes everything interactive — even though the numbering agrees.
+  const formRefs = form.controls.map((c) => bare(c.ref));
+  assert.ok(formRefs.includes(bare(formById.country)), "combobox should be reported by form-inspect");
   assert.ok(
-    snap.elements.some((e) => e.ref === snapById.nav),
+    snap.elements.some((e) => bare(e.ref) === bare(snapById.nav)),
     "nav button should be reported by snapshot",
   );
 });
 
+test("refs carry the observation that minted them", { skip }, async () => {
+  const first = await page.evaluate(snapshotInPage, { prefix: "", generation: 1 });
+  const second = await page.evaluate(snapshotInPage, { prefix: "", generation: 2 });
+
+  // The version prefix is what makes staleness checkable without touching the
+  // DOM — a ref held across an observation is refused by name.
+  assert.ok(first.elements[0].ref.startsWith("1:"), `expected a 1: prefix, got ${first.elements[0].ref}`);
+  assert.ok(second.elements[0].ref.startsWith("2:"), `expected a 2: prefix, got ${second.elements[0].ref}`);
+  assert.equal(refGenerationOf(first.elements[0].ref), 1);
+  assert.equal(refGenerationOf(second.elements[0].ref), 2);
+  assert.equal(refGenerationOf("e7"), null, "unversioned refs stay recognisable");
+
+  // The frame id must survive the version prefix, or child-frame refs break.
+  assert.equal(frameRefId("3:f1e2"), "f1");
+  assert.equal(frameRefId("3:e2"), null);
+  assert.equal(frameRefId("f1e2"), "f1");
+});
+
 test("form-inspect reports the combobox as a combobox", { skip }, async () => {
-  const form = await page.evaluate(formSnapshotInPage, "");
+  const form = await page.evaluate(formSnapshotInPage, { prefix: "", generation: 1 });
   const country = form.controls.find((c) => c.label === "Country");
   assert.ok(country, "country control should be reported");
   // form-fill dispatches on this: role=combobox must not be driven with

--- a/tests/test-browser-secret-readback.mjs
+++ b/tests/test-browser-secret-readback.mjs
@@ -72,7 +72,7 @@ after(async () => {
 const skip = patchrightAvailable ? false : "patchright/Chrome not installed";
 
 test("snapshot never surfaces a text field's value, but keeps a submit's label", { skip }, async () => {
-  const snap = await page.evaluate(snapshotInPage, "");
+  const snap = await page.evaluate(snapshotInPage, { prefix: "", generation: 1 });
   const names = snap.elements.map((e) => e.name);
 
   // Leak path 1 is closed: neither the OTP value nor the benign text value
@@ -89,7 +89,7 @@ test("snapshot never surfaces a text field's value, but keeps a submit's label",
 });
 
 test("form snapshot is compact, labelled, and includes hidden native controls", { skip }, async () => {
-  const snap = await page.evaluate(formSnapshotInPage, "");
+  const snap = await page.evaluate(formSnapshotInPage, { prefix: "", generation: 1 });
   assert.ok(Array.isArray(snap.controls));
   assert.ok(!JSON.stringify(snap).includes("hunter2"), "password value must never appear");
   assert.ok(!JSON.stringify(snap).includes("alice@example.com"), "text value must never appear");
@@ -114,7 +114,7 @@ test("form snapshot is compact, labelled, and includes hidden native controls", 
 });
 
 test("atomic form fill handles text, hidden checks, selects, and verifies each", { skip }, async () => {
-  const snap = await page.evaluate(formSnapshotInPage, "");
+  const snap = await page.evaluate(formSnapshotInPage, { prefix: "", generation: 1 });
   const text = snap.controls.find((control) => control.name === "full_name");
   const checkbox = snap.controls.find((control) => control.type === "checkbox");
   const degree = snap.controls.find((control) => control.name === "degree");
@@ -144,7 +144,7 @@ test("atomic form fill handles text, hidden checks, selects, and verifies each",
 });
 
 test("ordinary form fill refuses password fields without echoing the value", { skip }, async () => {
-  const snap = await page.evaluate(formSnapshotInPage, "");
+  const snap = await page.evaluate(formSnapshotInPage, { prefix: "", generation: 1 });
   const password = snap.controls.find((control) => control.type === "password");
   const result = await fillForm(
     { current: page, frames: new Map(), refsValid: true, refsInvalidReason: null },
@@ -178,7 +178,7 @@ test("taint survives a re-snapshot and keeps suppressing the value", { skip }, a
   // vault filled stays protected across the re-snapshots the agent does between
   // steps of a login flow.
   await markSecretField(page, "#otp");
-  const snap = await page.evaluate(snapshotInPage, "");
+  const snap = await page.evaluate(snapshotInPage, { prefix: "", generation: 1 });
   const stillTainted = await page.$eval("#otp", (el, attr) => el.hasAttribute(attr), SECRET_TAINT_ATTR);
   assert.equal(stillTainted, true, "re-snapshot must not strip the taint attribute");
   assert.ok(

--- a/tests/test-browser-session-helpers.mjs
+++ b/tests/test-browser-session-helpers.mjs
@@ -10,7 +10,33 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { frameRefId, safeFilename } from "../plugins/agent-id-browser/lib/session-server.mjs";
+import {
+  frameRefId,
+  refuseRef,
+  safeFilename,
+} from "../plugins/agent-id-browser/lib/session-server.mjs";
+
+test("refuseRef: a ref on a focus-typing action is refused, not dropped", () => {
+  // The failure this guards: `type-text --ref e27 --text Switzerland` typed
+  // into whatever held focus and reported success, so the country combobox
+  // never saw the text and answered "There were no results".
+  assert.throws(
+    () => refuseRef("type-text", { ref: "e27", text: "Switzerland" }, "type --ref eN --text T"),
+    (err) => {
+      assert.match(err.message, /takes no --ref/);
+      assert.match(err.message, /e27/); // names the ref it was handed
+      assert.match(err.message, /type --ref eN/); // and the tool that accepts one
+      return true;
+    },
+  );
+});
+
+test("refuseRef: absent/empty refs pass through untouched", () => {
+  assert.doesNotThrow(() => refuseRef("type-text", { text: "hi" }, "type"));
+  assert.doesNotThrow(() => refuseRef("type-text", { ref: undefined }, "type"));
+  assert.doesNotThrow(() => refuseRef("type-text", { ref: null }, "type"));
+  assert.doesNotThrow(() => refuseRef("type-text", { ref: "" }, "type"));
+});
 
 test("frameRefId: main-frame refs have no frame id", () => {
   assert.equal(frameRefId("e1"), null);


### PR DESCRIPTION
## Summary

Three defects that together made an SAP/Taleo-shaped careers form unfillable. Found by tracing a live agent session that could not select "Switzerland" in a country dropdown: the widget reported "There were no results" while its full list was intact.

- **Refs meant different things in different tools.** `snapshot` and `form-inspect` each renumbered from `e1` over *different* element sets, so `e7` was the First Name input after a form-inspect and a toolbar button after a snapshot — proven in the live session's own log. Both modes now number over the UNION of their selectors in document order.
- **Refs are versioned by the observation that minted them** (`3:e7`), so a ref held across a re-observation is refused by name instead of resolving against whatever now holds that number.
- **Comboboxes were driven with `selectOption`**, which only works on a native `<select>` and fails every time against the `<input role=combobox>` that Oracle/Taleo/Workday/SAP use for country pickers. `form-fill` and `select` now dispatch on what the element actually is, using real key events for a combobox and verifying the pick against the control's own value.
- **NEW in this PR — `type-text`/`fill-text` silently discarded `--ref`.** The CLI mapper dropped the flag before the session server saw it, so `type-text --ref e27 --text Switzerland` typed into whatever held focus and returned `ok:true`. That is the proximate cause of the "no results": the filter never received the text. A ref is now refused by name, pointing at `type`/`fill`.

The first three commits are the work from `fix/browser-refs-and-comboboxes`, which never got a PR and so missed the 7.6.1 release; only the EPIPE guard shipped from that branch.

## Verification

- `tests/test-browser-ref-space.mjs` (real browser) passes, including "a ref denotes the same element in both observation modes", "refs carry the observation that minted them", and "form-inspect reports the combobox as a combobox"; 33 tests green across the browser suites.
- New unit tests pin the ref-refusal contract.
- E2E through the real CLI: `type-text --name main --ref e27 --text Switzerland` now returns the actionable error instead of typing into the void; the ref-less form still types normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)