### PR TITLE
chore: remove internal codenames from public docs and comments

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,7 +13,7 @@ Three packages go to npm:
 | --- | --- | --- |
 | `@alien-id/agent-id-core` | public | shared crypto / bundle / verifier / OIDC / state |
 | `@alien-id/agent-id-vault` | public | encrypted credential vault (depends on core) |
-| `@alien-id/agent-id-browser` | public | vault-sealed browser automation; also consumed as a library (the Lethe desktop bundles it as an npm dependency) |
+| `@alien-id/agent-id-browser` | public | vault-sealed browser automation; also consumed as a library (a downstream desktop agent bundles it as an npm dependency) |
 
 `agent-id-browser` is dual-channel: it ships as a marketplace plugin **and** is
 published to npm, so external apps can depend on it instead of vendoring a

--- a/docs/COWORK-MCP.md
+++ b/docs/COWORK-MCP.md
@@ -31,7 +31,7 @@ locked VM."
 MCP connectors are exactly how Cowork wires in tools. Instead of shipping bash-CLI
 plugins, ship an **MCP server** that Cowork adds as a **remote connector** over
 HTTPS. The server is a **thin adapter over the existing `agent-id-*` CLIs** — the
-same pattern Lethe already uses (shell out, return JSON) — so there is no
+same pattern the desktop agent runtime already uses (shell out, return JSON) — so there is no
 re-implementation of command logic.
 
 ```
@@ -45,7 +45,7 @@ Cowork VM ── HTTPS (Streamable-HTTP MCP, per-user bearer) ──▶  agent-i
 Running the server **hosted** (not in the VM) sidesteps every VM limitation — no
 hooks, no plugin env vars, no npm-in-VM, no Chrome-in-VM. The VM just opens one
 allowed HTTPS connection. The **vault-sealed browser runs server-side**, exactly
-as `lethe-hosted` already does, so the "agent never sees the credential" seal is
+as the hosted agent runtime already does, so the "agent never sees the credential" seal is
 preserved (a host-Chrome path would break it — secrets would flow through Cowork's
 own browser). Vault + identity state persist on the service, not the ephemeral VM.
 
@@ -54,14 +54,14 @@ own browser). Vault + identity state persist on the service, not the ephemeral V
 1. **`plugins/agent-id-mcp/`** (new, private) — an MCP server (`@modelcontextprotocol/sdk`).
    - Maps MCP tools → the existing CLIs via subprocess, returning their JSON.
    - Resolves each CLI by `AGENT_ID_{CORE,VAULT,BROWSER}_BIN` env or PATH (mirrors
-     lethe's `find_bin`).
+     the host runtime's binary lookup).
    - Two transports from one tool registry: **stdio** (local dev / in-VM option)
      and **Streamable HTTP** (hosted connector).
-   - Tool surface = the current lethe surface: `agent_id_status/sign/bind`,
+   - Tool surface = the host runtime's current surface: `agent_id_status/sign/bind`,
      `vault_list/add/remove/set_totp`, `browser_open/act/close/login/auto_login/fill_secret/fill_otp`.
-2. **Hosting** — reuse the `lethe-hosted` runtime image (Chrome + CLIs baked, the
+2. **Hosting** — reuse the hosted runtime image (Chrome + CLIs baked, the
    `AGENT_ID_BROWSER_NO_SANDBOX`/`--shm-size` work already done). Expose the MCP
-   server on an HTTPS route with per-user auth (lethe-hosted already issues
+   server on an HTTPS route with per-user auth (the hosted runtime already issues
    per-user tokens). Per-user state dir → per-user vault/identity.
 3. **Cowork plugin** — a thin bundle (a `.claude-plugin` + a connector manifest
    declaring the MCP server + optional `/`-skills that call it) so it appears in
@@ -77,16 +77,16 @@ own browser). Vault + identity state persist on the service, not the ephemeral V
   already runs server-side; the MCP server just relays `open/act/close/fill_*`).
 - [ ] **3. HTTP transport + auth** — Streamable-HTTP with a per-user bearer; map
   the bearer → per-user `AGENT_ID_STATE_DIR`.
-- [ ] **4. Hosting** — add the MCP route to lethe-hosted (or a sibling service);
+- [ ] **4. Hosting** — add the MCP route to the hosted runtime (or a sibling service);
   bake `agent-id-mcp` into the runtime image; nginx route + TLS.
 - [ ] **5. Cowork plugin** — connector manifest + skills; validate install via the
   Cowork setup flow.
 
 ### Open decisions
 
-- **Where hosted**: fold into the lethe-hosted control plane vs a standalone
+- **Where hosted**: fold into the hosted runtime's control plane vs a standalone
   `agent-id-mcp` service. Leaning fold-in (reuses per-user containers + Chrome).
-- **Auth**: reuse lethe-hosted per-user tokens vs a dedicated OAuth for the
+- **Auth**: reuse the hosted runtime's per-user tokens vs a dedicated OAuth for the
   connector. Cowork connectors support both bearer and OAuth.
 - **Multi-tenant browser**: one sealed-browser daemon per user (as today) keyed by
   the per-user state dir.

--- a/plugins/agent-id-browser/lib/launch.mjs
+++ b/plugins/agent-id-browser/lib/launch.mjs
@@ -82,7 +82,7 @@ export async function loadChromium() {
 
 // Chrome hard-refuses to start as root with the sandbox on ("Running as root
 // without --no-sandbox is not supported"), which is exactly the situation in a
-// containerized deployment (e.g. lethe-hosted per-user containers run as root;
+// containerized deployment (e.g. hosted per-user agent containers run as root;
 // the container itself is the isolation boundary there). This explicit opt-in
 // KEEPS patchright's injected --no-sandbox instead of stripping it. Default
 // (unset) preserves the stealth-validated sandbox-on launch. Not fingerprintable

--- a/plugins/agent-id-mcp/cowork/README.md
+++ b/plugins/agent-id-mcp/cowork/README.md
@@ -45,7 +45,7 @@ the `SessionStart` hook the CLI plugins rely on.
   bundled alongside.
 - **`runtime: cowork-vm`** (or chrome missing / localhost blocked) → the local
   browser can't run there; use the **hosted** transport (Streamable-HTTP connector
-  backed by the lethe-hosted service, browser server-side). Identity + vault may
+  backed by the hosted runtime service, browser server-side). Identity + vault may
   still work locally if the CLIs are bundled.
 
 ## Rebuilding the bundle

--- a/plugins/agent-id-mcp/lib/cli-adapter.mjs
+++ b/plugins/agent-id-mcp/lib/cli-adapter.mjs
@@ -1,8 +1,8 @@
 // Resolve and run the agent-id-* CLIs as subprocesses, returning their JSON.
 //
 // The MCP server is a THIN adapter: every tool maps to a CLI subcommand (the same
-// battle-tested surface Lethe shells out to), so there is no re-implementation of
-// command logic. Resolution mirrors lethe's `find_bin`: an explicit
+// battle-tested surface the host runtime shells out to), so there is no
+// re-implementation of command logic. Resolution is an explicit
 // AGENT_ID_{CORE,VAULT,BROWSER}_BIN override, else the CLI on PATH, else the dev
 // workspace sibling. A `.mjs`/`.js` target is run with the current node.
 

--- a/plugins/agent-id-mcp/lib/tools.mjs
+++ b/plugins/agent-id-mcp/lib/tools.mjs
@@ -1,5 +1,5 @@
 // The MCP tool surface, each mapped to an agent-id-* CLI subcommand. Mirrors the
-// surface Lethe exposes (src/tools/agent_id.rs). Increment 1: identity + vault.
+// surface the host runtime exposes. Increment 1: identity + vault.
 // Browser tools (browser_open/act/close/…) are added in increment 2 once the
 // server-side sealed-browser daemon relay is wired (see docs/COWORK-MCP.md).
 //

--- a/tests/test-browser-sandbox-toggle.mjs
+++ b/tests/test-browser-sandbox-toggle.mjs
@@ -4,7 +4,7 @@
 // launcher strips patchright's injected --no-sandbox to keep the renderer
 // sandbox ON (the stealth-validated config). Chrome refuses to start as root
 // with the sandbox on, so containerized deployments that run as root (e.g.
-// lethe-hosted per-user containers) set the env var to keep the injected flag.
+// hosted per-user agent containers) set the env var to keep the injected flag.
 // Pure — no browser.
 //
 // Run: node --test tests/test-browser-sandbox-toggle.mjs


### PR DESCRIPTION
agent-id is a public project — this replaces references to the internal host-runtime project name with generic wording ("the host runtime", "the hosted agent runtime", "a downstream desktop agent") across RELEASING.md, docs/COWORK-MCP.md, the MCP plugin's comments/README, the browser launcher comment, and a test header.

Docs and comments only; no behavior change (suite green). The two stream-file comments carrying the same phrasing are already reworded in #84 and are deliberately not touched here, so the branches don't conflict.