### PR TITLE
feat(browser): stream viewer resize + profile name in the session file

### DIFF
--- a/.changeset/stream-resize-session-profile.md
+++ b/.changeset/stream-resize-session-profile.md
@@ -1,0 +1,16 @@
+---
+"@alien-id/agent-id-browser": minor
+---
+
+Viewer `resize` in the stream protocol + profile name in the session file.
+
+- The viewport stream now accepts `{"type":"resize","width":W,"height":H}`
+  from viewers: the session reshapes the page viewport to the viewer's own
+  dimensions (window-chrome-compensated, lands the exact size), so a phone
+  watching the stream gets the page's mobile layout instead of a shrunken
+  desktop one. The achieved viewport is broadcast to every watcher as a
+  `status` message; requests are clamped to 200–4096 per axis and ignored
+  while a credential fill has the stream suspended.
+- Session files now name their `profile` in the body, so viewers scanning the
+  sessions directory can attach to the right profile's stream instead of
+  guessing by newest `startedAt`.

--- a/docs/BROWSER-STREAM.md
+++ b/docs/BROWSER-STREAM.md
@@ -1,0 +1,111 @@
+# Browser viewport stream
+
+Every open `agent-id-browser` session runs a live viewport stream — the
+"watch the agent browse" / pair-browsing feed. A viewer (the host runtime's
+relay to the owner's client, or any agent-browser-compatible client) connects
+over WebSocket, sees what the sealed browser sees, and can optionally drive it
+with mouse/keyboard input or reshape its viewport.
+
+Implementation: `plugins/agent-id-browser/lib/stream-server.mjs`. No runtime
+dependencies — the WebSocket server is hand-rolled, and frames come from a CDP
+screencast over the existing patchright pipe (the seal is preserved: no CDP
+debug port is ever opened).
+
+## Discovery and authentication
+
+The session process writes its session file to
+`<stateDir>/browser-sessions/<name>.json`:
+
+```json
+{
+  "profile": "work",
+  "port": 41720,
+  "token": "<48-hex>",
+  "pid": 12345,
+  "headless": true,
+  "startedAt": 1754300000000,
+  "streamPort": 41723,
+  "streamToken": "<48-hex>"
+}
+```
+
+- `profile` names the profile this session serves. Viewers scanning the
+  sessions directory MUST select by `profile`, not by newest `startedAt` —
+  with several sessions open, newest-wins attaches the feed to the wrong
+  profile.
+- `port`/`token` are the session's own line-JSON action socket;
+  `streamPort`/`streamToken` are the stream's.
+- WebSocket upgrade: `ws://127.0.0.1:<streamPort>/?token=<streamToken>`.
+  Anything else on that port answers `426`; a bad token is refused before the
+  upgrade completes. The server binds `127.0.0.1` — the intended remote path
+  is the host runtime relaying the token-gated socket.
+
+## Wire protocol
+
+The message shapes match agent-browser's streaming protocol, so one viewer
+client works against both browser stacks. `resize` is our one extension
+beyond those shapes (agent-browser servers ignore unknown types, so a shared
+client stays compatible).
+
+Server → client (JSON text):
+
+```jsonc
+{ "type": "status", "source": "alien", "screencasting": true }  // on join
+{ "type": "status", "source": "alien", "suspended": true }      // fill blackout
+{ "type": "status", "source": "alien",                          // after resize
+  "resized": { "width": 390, "height": 844 },                   //   request
+  "viewport": { "width": 390, "height": 844 } }                 //   achieved
+{ "type": "frame", "data": "<base64 jpeg>",
+  "metadata": { "deviceWidth": 1440, "deviceHeight": 813, /* … */ } }
+```
+
+Client → server (JSON text):
+
+```jsonc
+{ "type": "input_mouse", "eventType": "mousePressed",
+  "x": 100, "y": 200, "button": "left", "clickCount": 1 }
+{ "type": "input_mouse", "eventType": "mouseMoved" | "mouseReleased" | "mouseWheel",
+  "deltaX": 0, "deltaY": 120 }
+{ "type": "input_keyboard", "eventType": "keyDown" | "keyUp" | "char",
+  "key": "Enter", "text": "a" }
+{ "type": "resize", "width": 390, "height": 844 }
+```
+
+Input coordinates are in `metadata.deviceWidth/Height` space (CSS viewport
+pixels). Mutating input (click, wheel, keydown, char) invalidates the agent's
+element refs, exactly like any page mutation.
+
+## The `resize` message
+
+`width`/`height` are the **viewer's** dimensions — the desired page
+**viewport**, not the outer window size the session-protocol `resize` action
+takes. This is how a phone-sized viewer gets the page's mobile layout instead
+of a shrunken desktop one: send your own screen size and the page reflows.
+
+The session converts viewport → outer window with one chrome-compensation
+pass: resize the window to the requested size, measure how much the window
+chrome ate, grow the window by that delta. The result lands on the exact
+requested viewport (verified against headless Chrome: requesting 390×844
+yields a 390×844 viewport).
+
+Rules:
+
+- Dimensions clamp to **200–4096** per axis. Non-numeric dimensions are
+  ignored entirely (not resized-to-minimum).
+- Requests are serialized behind pending viewer input, so a resize lands in
+  arrival order relative to queued clicks and keys.
+- The achieved viewport is broadcast to **every** watcher as the `status`
+  message above — the request mirror in `resized`, the authoritative result
+  in `viewport`. Do coordinate math against `viewport`.
+- A resize does not invalidate element refs (the DOM is untouched; refs are
+  sparse and stable) — but screenshot coordinates taken before the resize are
+  stale, as after any reflow.
+
+## Suspend (credential blackout)
+
+While `fill-secret` / `fill-otp` inject a credential value, the session
+suspends the feed: frames stop, and **all** viewer messages — input and
+`resize` alike — are dropped at apply time, so a watcher can neither see nor
+touch a form mid-injection. Suspension is depth-counted and announced with
+`{"type":"status","suspended":true|false}`; on resume the screencast restarts
+to force a fresh keyframe.

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -128,6 +128,14 @@ export async function pruneDeadSessions(stateDir) {
   return pruned;
 }
 
+// Body of <name>.json. The profile name must ride IN the body, not just the
+// filename: viewers discover a session by scanning these files for stream
+// coordinates, and a body without `profile` left them picking blind (newest
+// startedAt wins) — attaching the watch feed to the wrong profile.
+export function sessionRecord(name, fields) {
+  return { profile: name, ...fields };
+}
+
 // THE SHARED REF SPACE — keep this selector, and the numbering loop that walks
 // it, byte-identical in snapshotInPage and formSnapshotInPage.
 //
@@ -858,6 +866,68 @@ export async function fillForm(state, p) {
   };
 }
 
+// One CDP window-bounds resize; returns the achieved INNER viewport (null on a
+// JS-hostile page). Shared by the `resize` action (outer-size semantics) and
+// the stream's viewer resize (viewport semantics, via resizeToViewport).
+async function resizeWindow(state, page, width, height) {
+  const before = await page
+    .evaluate(() => [window.innerWidth, window.innerHeight])
+    .catch(() => null);
+  const cdp = await state.ctx.newCDPSession(page);
+  try {
+    const { windowId } = await cdp.send("Browser.getWindowForTarget");
+    // Two steps: exit maximized/fullscreen FIRST, else Chrome applies the
+    // state change and ignores the bounds in the same call.
+    await cdp.send("Browser.setWindowBounds", { windowId, bounds: { windowState: "normal" } }).catch(() => {});
+    await cdp.send("Browser.setWindowBounds", { windowId, bounds: { width, height } });
+  } catch (err) {
+    throw new Error(`resize failed (CDP window bounds unavailable — needs a headed/cloud Chrome): ${err.message || err}`);
+  } finally {
+    await cdp.detach().catch(() => {});
+  }
+  // setWindowBounds acks before the renderer re-lays-out — wait for the inner
+  // size to actually change (best-effort) so the returned viewport isn't stale.
+  if (before) {
+    await page
+      .waitForFunction(
+        (b) => window.innerWidth !== b[0] || window.innerHeight !== b[1],
+        before,
+        { timeout: 3000 },
+      )
+      .catch(() => {});
+  }
+  return page
+    .evaluate(() => ({ width: window.innerWidth, height: window.innerHeight }))
+    .catch(() => null);
+}
+
+// Second-pass OUTER size that should land the INNER viewport on `want`, given
+// what a straight outer resize to `want` actually yielded (`got`) — the delta
+// between the two is the window chrome. null when the first pass already
+// landed, or when the page could not be measured. Exported for tests.
+export function chromeCompensatedBounds(want, got) {
+  if (!got) return null;
+  const width = want.width + Math.max(0, want.width - got.width);
+  const height = want.height + Math.max(0, want.height - got.height);
+  if (width === want.width && height === want.height) return null;
+  return { width, height };
+}
+
+// Viewer-driven resize (stream protocol `resize` message): width/height are
+// the viewer's SCREEN — i.e. the desired page VIEWPORT, not the outer window
+// size the `resize` action takes. A phone watching the stream sends its own
+// dimensions and the page reflows into its mobile layout instead of staying a
+// shrunken desktop. One compensation pass converts viewport → outer: resize to
+// the requested size, measure the chrome the window ate, grow by that delta.
+async function resizeToViewport(state, width, height) {
+  const page = state.current;
+  if (!page || page.isClosed?.()) return null;
+  const first = await resizeWindow(state, page, width, height);
+  const second = chromeCompensatedBounds({ width, height }, first);
+  if (!second) return first;
+  return (await resizeWindow(state, page, second.width, second.height)) ?? first;
+}
+
 // Exported for tests: the suspend/resume contract around credential fills is
 // only observable here.
 export async function dispatch(state, msg, policy = null) {
@@ -1281,35 +1351,7 @@ export async function dispatch(state, msg, policy = null) {
       if (![width, height].every(Number.isFinite) || width < 200 || height < 200) {
         throw new Error("resize needs numeric --width and --height (min 200 each)");
       }
-      const before = await page
-        .evaluate(() => [window.innerWidth, window.innerHeight])
-        .catch(() => null);
-      const cdp = await state.ctx.newCDPSession(page);
-      try {
-        const { windowId } = await cdp.send("Browser.getWindowForTarget");
-        // Two steps: exit maximized/fullscreen FIRST, else Chrome applies the
-        // state change and ignores the bounds in the same call.
-        await cdp.send("Browser.setWindowBounds", { windowId, bounds: { windowState: "normal" } }).catch(() => {});
-        await cdp.send("Browser.setWindowBounds", { windowId, bounds: { width, height } });
-      } catch (err) {
-        throw new Error(`resize failed (CDP window bounds unavailable — needs a headed/cloud Chrome): ${err.message || err}`);
-      } finally {
-        await cdp.detach().catch(() => {});
-      }
-      // setWindowBounds acks before the renderer re-lays-out — wait for the inner
-      // size to actually change (best-effort) so the returned viewport isn't stale.
-      if (before) {
-        await page
-          .waitForFunction(
-            (b) => window.innerWidth !== b[0] || window.innerHeight !== b[1],
-            before,
-            { timeout: 3000 },
-          )
-          .catch(() => {});
-      }
-      const viewport = await page
-        .evaluate(() => ({ width: window.innerWidth, height: window.innerHeight }))
-        .catch(() => null);
+      const viewport = await resizeWindow(state, page, width, height);
       return { resized: { width, height }, ...(viewport ? { viewport } : {}) };
     }
     case "zoom":
@@ -1611,6 +1653,7 @@ export async function runSession({
   // / fill-otp inject credential values (see those dispatch cases).
   const stream = await startStreamServer(state, {
     log: (m) => process.stderr.write(`${m}\n`),
+    resize: (width, height) => resizeToViewport(state, width, height),
   });
   state.stream = stream;
 
@@ -1663,7 +1706,7 @@ export async function runSession({
   await fs.mkdir(sessionsDir(stateDir), { recursive: true, mode: 0o700 });
   await fs.writeFile(
     sessionFilePath(stateDir, name),
-    JSON.stringify({
+    JSON.stringify(sessionRecord(name, {
       port,
       token,
       pid: process.pid,
@@ -1671,7 +1714,7 @@ export async function runSession({
       startedAt: Date.now(),
       streamPort: stream.port,
       streamToken: stream.token,
-    }),
+    })),
     { mode: 0o600 },
   );
   // Optional start page: navigate BEFORE the ready line so "ready" means "up

--- a/plugins/agent-id-browser/lib/stream-server.mjs
+++ b/plugins/agent-id-browser/lib/stream-server.mjs
@@ -11,6 +11,13 @@
 //                     {"type":"status", ...}
 //   client → server   {"type":"input_mouse","eventType":"mousePressed",...}
 //                     {"type":"input_keyboard","eventType":"keyDown",...}
+//                     {"type":"resize","width":W,"height":H}
+//
+// `resize` is our one extension beyond agent-browser's shapes (harmless there —
+// unknown types are ignored). width/height are the VIEWER's dimensions — the
+// desired page viewport — so a phone-sized viewer gets the page's mobile
+// layout, not a shrunken desktop one. The resulting viewport is broadcast to
+// every watcher as {"type":"status","resized":{...},"viewport":{...}}.
 //
 // SEAL PRESERVED: this never opens a CDP debug port — frames come from a
 // patchright CDPSession over the existing pipe, input goes through
@@ -53,8 +60,8 @@ function encodeControlFrame(opcode, payload = Buffer.alloc(0)) {
 
 // Incremental parser for client frames. Client→server frames are always
 // masked (RFC 6455 §5.1). Yields {opcode, payload} per complete frame;
-// fragmented text is reassembled.
-function makeFrameParser(onFrame) {
+// fragmented text is reassembled. Exported for tests.
+export function makeFrameParser(onFrame) {
   let buf = Buffer.alloc(0);
   let fragments = null;
   return (chunk) => {
@@ -159,7 +166,12 @@ function mutatesPage(msg) {
  * so tab-new / tab-switch / tab-close all retarget without hooks).
  * Returns { port, token, suspend, resume, close }.
  */
-export async function startStreamServer(state, { log = () => {} } = {}) {
+// Viewer resize requests are clamped to sane page dimensions: below 200 the
+// page is unusable, above 4096 a typo'd request could balloon the framebuffer.
+const RESIZE_MIN = 200;
+const RESIZE_MAX = 4096;
+
+export async function startStreamServer(state, { log = () => {}, resize = null } = {}) {
   const token = crypto.randomBytes(24).toString("hex");
   const clients = new Set();
   let cdp = null; // active CDPSession for the screencast
@@ -274,6 +286,29 @@ export async function startStreamServer(state, { log = () => {} } = {}) {
       // Input is disabled while a credential fill is in flight — the viewer
       // must not be able to interact with a form mid-injection.
       if (suspended > 0) return;
+      if (msg.type === "resize") {
+        // Reshape the page viewport to the viewer's screen (mobile-sized
+        // viewports for phone watchers). Serialized behind pending input and
+        // suspend-checked at apply time like every other viewer event; the
+        // achieved viewport is broadcast so ALL watchers learn the new shape.
+        const width = Math.round(Number(msg.width));
+        const height = Math.round(Number(msg.height));
+        if (!resize || ![width, height].every(Number.isFinite)) return;
+        const clamp = (n) => Math.min(Math.max(n, RESIZE_MIN), RESIZE_MAX);
+        inputChain = inputChain
+          .then(async () => {
+            if (suspended > 0) return;
+            const viewport = await resize(clamp(width), clamp(height));
+            broadcast({
+              type: "status",
+              source: "alien",
+              resized: { width: clamp(width), height: clamp(height) },
+              ...(viewport ? { viewport } : {}),
+            });
+          })
+          .catch(() => {});
+        return;
+      }
       if (mutatesPage(msg)) state.invalidateRefs?.("owner used live browser control");
       // Queue, don't fire-and-forget: the suspend/page checks re-run at apply
       // time so a fill starting mid-queue still blacks out the queued tail.

--- a/tests/test-browser-session-helpers.mjs
+++ b/tests/test-browser-session-helpers.mjs
@@ -2,8 +2,11 @@
 
 // Tests for the pure session-server helpers behind the iframe/tab/download
 // additions: frameRefId (ref → frame prefix parsing, the contract every
-// ref-based action resolves through) and safeFilename (download names must be
-// joinable under the sessions dir without traversal). Pure — no browser.
+// ref-based action resolves through), safeFilename (download names must be
+// joinable under the sessions dir without traversal), sessionRecord (the
+// session file body a viewer discovers a stream by), and
+// chromeCompensatedBounds (the viewport→outer-window conversion behind the
+// stream's viewer resize). Pure — no browser.
 //
 // Run: node --test tests/test-browser-session-helpers.mjs
 
@@ -14,11 +17,13 @@ import os from "node:os";
 import path from "node:path";
 
 import {
+  chromeCompensatedBounds,
   frameRefId,
   pruneDeadSessions,
   refuseRef,
   safeFilename,
   sessionAlive,
+  sessionRecord,
 } from "../plugins/agent-id-browser/lib/session-server.mjs";
 
 test("refuseRef: a ref on a focus-typing action is refused, not dropped", () => {
@@ -70,6 +75,53 @@ test("safeFilename: separators and traversal are neutralized", () => {
   assert.ok(!safeFilename("..\\..\\x").includes("\\"));
   assert.notEqual(safeFilename("..")[0], ".");
   assert.equal(safeFilename("a b:c*d.png"), "a_b_c_d.png");
+});
+
+test("sessionRecord: the body names its profile — discovery must not guess", () => {
+  // The failure this guards: the session file carried streamPort/streamToken/
+  // startedAt but not the profile, so a viewer scanning the sessions dir could
+  // only take the newest file and could attach to the wrong profile.
+  const rec = sessionRecord("work", {
+    port: 4001,
+    token: "t0k",
+    pid: 123,
+    headless: true,
+    startedAt: 1754300000000,
+    streamPort: 4002,
+    streamToken: "s3cret",
+  });
+  assert.equal(rec.profile, "work");
+  // The coordinates the viewer connects with ride along untouched.
+  assert.equal(rec.streamPort, 4002);
+  assert.equal(rec.streamToken, "s3cret");
+  assert.equal(rec.startedAt, 1754300000000);
+});
+
+test("chromeCompensatedBounds: grows the outer size by the chrome the window ate", () => {
+  // A viewer asked for a 390×844 viewport; the straight outer resize yielded
+  // 390×757 — the window chrome ate 87px of height. The second pass must ask
+  // for exactly that much more.
+  assert.deepEqual(
+    chromeCompensatedBounds({ width: 390, height: 844 }, { width: 390, height: 757 }),
+    { width: 390, height: 931 },
+  );
+});
+
+test("chromeCompensatedBounds: no second pass when the first one landed", () => {
+  assert.equal(chromeCompensatedBounds({ width: 390, height: 844 }, { width: 390, height: 844 }), null);
+  // Unmeasurable page (JS-hostile): nothing to compensate against.
+  assert.equal(chromeCompensatedBounds({ width: 390, height: 844 }, null), null);
+});
+
+test("chromeCompensatedBounds: an OVERSHOOT never shrinks the request", () => {
+  // A window-manager minimum can hand back MORE than asked (got > want).
+  // Compensating downward would fight the WM forever — the delta clamps at 0,
+  // and if both axes overshot there is no second pass at all.
+  assert.deepEqual(
+    chromeCompensatedBounds({ width: 200, height: 844 }, { width: 500, height: 757 }),
+    { width: 200, height: 931 },
+  );
+  assert.equal(chromeCompensatedBounds({ width: 200, height: 200 }, { width: 500, height: 400 }), null);
 });
 
 test("safeFilename: empty / dot-only names fall back, long names are bounded", () => {

--- a/tests/test-browser-stream-resize.mjs
+++ b/tests/test-browser-stream-resize.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+
+// Tests for the stream protocol's `resize` message — the one extension beyond
+// agent-browser's message shapes. A viewer (typically a phone) sends its own
+// dimensions and the session reshapes the page viewport to match; without it
+// there is no way to get a mobile-sized viewport through the stream. Driven
+// end-to-end over real sockets against a FAKE CDP session (no browser): the
+// resize itself is the injected callback, so what's under test is the wire
+// contract — parse, clamp, suspend gating, and the status broadcast.
+//
+// Run: node --test tests/test-browser-stream-resize.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import net from "node:net";
+import { once } from "node:events";
+
+import {
+  startStreamServer,
+  makeFrameParser,
+} from "../plugins/agent-id-browser/lib/stream-server.mjs";
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ── fakes ────────────────────────────────────────────────────────────────────
+
+function makeFakeSession() {
+  const handlers = new Map();
+  return {
+    on: (event, fn) => handlers.set(event, fn),
+    async send() { return {}; },
+    async detach() {},
+  };
+}
+
+function makeFakeState() {
+  const page = {
+    isClosed: () => false,
+    mouse: { move: async () => {}, down: async () => {}, up: async () => {}, wheel: async () => {} },
+    keyboard: { down: async () => {}, up: async () => {}, insertText: async () => {} },
+  };
+  return {
+    current: page,
+    invalidateRefs() {},
+    ctx: { newCDPSession: async () => makeFakeSession() },
+  };
+}
+
+// ── minimal WS client (client → server frames are masked, RFC 6455) ──────────
+
+function maskedTextFrame(payload) {
+  const data = Buffer.from(payload, "utf8");
+  const mask = crypto.randomBytes(4);
+  const masked = Buffer.from(data);
+  for (let i = 0; i < masked.length; i++) masked[i] ^= mask[i & 3];
+  let header;
+  if (data.length < 126) header = Buffer.from([0x81, 0x80 | data.length]);
+  else {
+    header = Buffer.alloc(4);
+    header[0] = 0x81;
+    header[1] = 0x80 | 126;
+    header.writeUInt16BE(data.length, 2);
+  }
+  return Buffer.concat([header, mask, masked]);
+}
+
+async function connectStream(port, token) {
+  const sock = net.connect(port, "127.0.0.1");
+  await once(sock, "connect");
+  const key = crypto.randomBytes(16).toString("base64");
+  sock.write(
+    `GET /?token=${token} HTTP/1.1\r\nHost: t\r\nUpgrade: websocket\r\n` +
+      `Connection: Upgrade\r\nSec-WebSocket-Key: ${key}\r\nSec-WebSocket-Version: 13\r\n\r\n`,
+  );
+  const queue = [];
+  const waiters = [];
+  const parse = makeFrameParser((m) => {
+    const w = waiters.shift();
+    if (w) w(m);
+    else queue.push(m);
+  });
+  let head = Buffer.alloc(0);
+  let upgraded = false;
+  await new Promise((resolve, reject) => {
+    sock.on("data", (d) => {
+      if (upgraded) return parse(d);
+      head = Buffer.concat([head, d]);
+      const end = head.indexOf("\r\n\r\n");
+      if (end < 0) return;
+      upgraded = true;
+      resolve();
+      parse(head.subarray(end + 4));
+    });
+    sock.on("error", reject);
+  });
+  return {
+    sock,
+    send: (obj) => sock.write(maskedTextFrame(JSON.stringify(obj))),
+    async next(timeoutMs = 2000) {
+      if (queue.length) return JSON.parse(queue.shift().payload.toString("utf8"));
+      const frame = await new Promise((resolve, reject) => {
+        const t = setTimeout(() => reject(new Error("timed out waiting for a frame")), timeoutMs);
+        waiters.push((m) => { clearTimeout(t); resolve(m); });
+      });
+      return JSON.parse(frame.payload.toString("utf8"));
+    },
+    close: () => sock.destroy(),
+  };
+}
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+test("resize: viewer dimensions reach the callback; the viewport is broadcast", async () => {
+  const resizes = [];
+  const stream = await startStreamServer(makeFakeState(), {
+    // Fake session-side resize: the "window chrome" eats 87px of height.
+    resize: async (w, h) => { resizes.push([w, h]); return { width: w, height: h - 87 }; },
+  });
+  const client = await connectStream(stream.port, stream.token);
+  try {
+    const hello = await client.next();
+    assert.equal(hello.type, "status");
+    client.send({ type: "resize", width: 390, height: 844 });
+    const status = await client.next();
+    assert.deepEqual(resizes, [[390, 844]]);
+    assert.equal(status.type, "status");
+    assert.deepEqual(status.resized, { width: 390, height: 844 });
+    assert.deepEqual(status.viewport, { width: 390, height: 757 });
+  } finally {
+    client.close();
+    stream.close();
+  }
+});
+
+test("resize: out-of-range dimensions clamp instead of failing the viewer", async () => {
+  const resizes = [];
+  const stream = await startStreamServer(makeFakeState(), {
+    resize: async (w, h) => { resizes.push([w, h]); return { width: w, height: h }; },
+  });
+  const client = await connectStream(stream.port, stream.token);
+  try {
+    await client.next(); // greeting
+    client.send({ type: "resize", width: 50, height: 99999 });
+    await client.next();
+    assert.deepEqual(resizes, [[200, 4096]]);
+  } finally {
+    client.close();
+    stream.close();
+  }
+});
+
+test("resize: garbage dimensions are ignored, not resized-to-minimum", async () => {
+  const resizes = [];
+  const stream = await startStreamServer(makeFakeState(), {
+    resize: async (w, h) => { resizes.push([w, h]); return null; },
+  });
+  const client = await connectStream(stream.port, stream.token);
+  try {
+    await client.next(); // greeting
+    client.send({ type: "resize" });
+    client.send({ type: "resize", width: "wide", height: 700 });
+    await sleep(150);
+    assert.deepEqual(resizes, []);
+  } finally {
+    client.close();
+    stream.close();
+  }
+});
+
+test("resize: dropped while a credential fill has the stream suspended", async () => {
+  const resizes = [];
+  const stream = await startStreamServer(makeFakeState(), {
+    resize: async (w, h) => { resizes.push([w, h]); return null; },
+  });
+  const client = await connectStream(stream.port, stream.token);
+  try {
+    await client.next(); // greeting
+    stream.suspend();
+    await client.next(); // suspended:true broadcast
+    client.send({ type: "resize", width: 390, height: 844 });
+    await sleep(150);
+    assert.deepEqual(resizes, []);
+    stream.resume();
+  } finally {
+    client.close();
+    stream.close();
+  }
+});


### PR DESCRIPTION
## Two review findings on the viewport stream

### No mobile-sized viewports
The stream protocol had no `resize` message, so a phone-sized viewer watched a desktop-shaped feed with no way to reshape it — while the session-protocol `resize` action existed, nothing exposed it to stream viewers.

The stream now accepts `{"type":"resize","width":W,"height":H}` (our one extension beyond agent-browser's message shapes — harmless to its viewers, which ignore unknown types). Width/height are the **viewer's** dimensions, i.e. the desired page **viewport**: the session converts viewport → outer window with one chrome-compensation pass (`chromeCompensatedBounds`: measure what the window chrome ate, grow by the delta), landing the exact requested size — verified live at 390×844 against headless Chrome. The achieved viewport is broadcast to every watcher as a `status` message.

Guard rails: dimensions clamp to 200–4096 per axis (garbage is ignored, not resized-to-minimum), requests serialize behind pending viewer input, and they drop while a credential fill has the feed suspended — same policy as every other viewer event. The session `resize` action's CDP logic is extracted into a shared `resizeWindow()` helper; its documented outer-size semantics are unchanged.

### Viewers picked a profile blind
The session file carried `streamPort`/`streamToken`/`startedAt` but not the profile name, so discovery scanning `browser-sessions/*.json` (e.g. lethe's relay) could only take the newest file — attaching the watch feed to the wrong profile. `sessionRecord()` now stamps `profile` into the body.

## Tests
- `test-browser-stream-resize.mjs`: wire contract over real sockets against a fake CDP session — parse, clamp, garbage rejection, suspend gating, status broadcast.
- `test-browser-session-helpers.mjs`: `chromeCompensatedBounds` (incl. WM-overshoot never shrinking the request) and `sessionRecord`.
- Full suite: 616 pass.

Note for #84: the stream-v2 branch rewrites `stream-server.mjs`; the `resize` handler and the v2 protocol doc's client→server table will need the same message ported when it rebases.