### PR TITLE
feat(browser): give the owner a browser to sign into, and prune dead sessions

### DIFF
--- a/.changeset/owner-driven-signin.md
+++ b/.changeset/owner-driven-signin.md
@@ -1,0 +1,28 @@
+---
+"@alien-id/agent-id-browser": minor
+---
+
+An owner can be handed a browser to sign into, and dead sessions stop haunting the viewer
+
+**A named profile can be created for the owner to sign into.** When a sign-in
+cannot be automated — a bot challenge, an IdP that refuses agents, no display for
+a headed `login` — the answer is to hand the browser to the owner. That was
+impossible for any site not already set up: `login` needs a GUI, `auto-login` had
+just failed, and `open` refuses to auto-create a named profile, so there was
+nowhere to sign in. `open --bootstrap-profile` mints an empty jar for a named
+profile; the owner signs in, and `close` seals it like any other. Without the
+flag a named profile still never auto-creates — the account boundary is
+unchanged, the opt-in is explicit.
+
+**Orphaned sessions are pruned.** A clean `close` reseals and removes its own
+session file, but an abrupt death (a recreated container, a killed daemon) leaves
+it behind, and the state dir usually outlives the process. Those orphans still
+advertise a `streamPort`, so a viewer picking "the newest session with a stream"
+can dial a dead port and show nothing, and `status` lists sessions that do not
+exist. `open` and `status` now drop session files whose pid is gone.
+
+**Stale plaintext profile copies are removed too.** `<name>.work` is the
+UNSEALED profile — cookies on disk, outside the vault. A clean close wipes it;
+an abrupt death left it there indefinitely (weeks-old copies were found for
+sessions long gone). Orphaned work dirs are now removed once they are old enough
+that they cannot belong to a launch still in flight.

--- a/plugins/agent-id-browser/bin/cli.mjs
+++ b/plugins/agent-id-browser/bin/cli.mjs
@@ -55,7 +55,7 @@ import { sessionReplyError } from "../lib/session-route.mjs";
 import { escalationFor } from "../lib/escalation.mjs";
 import { autoLogin } from "../lib/auto-login.mjs";
 import { looksLoggedOut } from "../lib/session.mjs";
-import { runSession, callSession } from "../lib/session-server.mjs";
+import { runSession, callSession, pruneDeadSessions } from "../lib/session-server.mjs";
 import { hasOwnerApproval, unlockViaOwnerApproval } from "../lib/unlock.mjs";
 import {
   ACCESS_LEVELS,
@@ -665,6 +665,9 @@ async function cmdFetch(flags) {
 async function cmdStatus(flags) {
   const stateDir = resolveStateDir(flags);
   const only = flags.name ? profileName(flags.name) : null;
+  // Report on sessions that exist: an orphaned file otherwise shows as an open
+  // session nobody can talk to.
+  await pruneDeadSessions(stateDir).catch(() => []);
   let vault;
   try {
     // Don't drive an Alien-app prompt just to report status — agent-key/passphrase only.
@@ -709,6 +712,10 @@ async function cmdStatus(flags) {
 async function cmdOpen(flags) {
   const name = profileName(flags.name);
   const stateDir = resolveStateDir(flags);
+  // Orphaned session files (killed container, crashed daemon) still advertise a
+  // streamPort, so a viewer picking "the newest session" can dial a dead port.
+  // Clear them before we add ours.
+  await pruneDeadSessions(stateDir).catch(() => []);
   let vault;
   try {
     vault = await openVaultUnlocked(flags);
@@ -720,7 +727,15 @@ async function cmdOpen(flags) {
   let headlessDefault;
   let policy = null;
   try {
-    const cred = await ensureAnonymousDefaultProfile({ vault, stateDir, name });
+    const cred = await ensureAnonymousDefaultProfile({
+      vault,
+      stateDir,
+      name,
+      // Opt-in minting of an empty jar for a named profile: the owner-driven
+      // sign-in path needs somewhere to sign in. Without the flag, a named
+      // profile still refuses to auto-create.
+      allowCreate: flags["bootstrap-profile"] === true,
+    });
     if (!cred || cred.type !== "browser-profile") {
       const e = new Error(`no browser-profile named '${name}' — ${noProfileHint(name)}`);
       e.code = "NO_PROFILE";
@@ -918,9 +933,12 @@ runCli({
         "          one-shot authenticated HTTP GET via the session (API / feed)\n" +
         "  status  [--name N]      list sealed sessions\n\n" +
         "Interactive session (--name optional; defaults to 'main'):\n" +
-        "  open    --name N [--headed] [--url START]   start a persistent session (run in\n" +
-        "          background); navigates to START before reporting ready;\n" +
-        "          missing default 'main' auto-creates as an anonymous L0 profile\n" +
+        "  open    --name N [--headed] [--url START] [--bootstrap-profile]\n" +
+        "          start a persistent session (run in background); navigates to START\n" +
+        "          before reporting ready; missing default 'main' auto-creates as an\n" +
+        "          anonymous L0 profile. --bootstrap-profile mints an EMPTY jar for a\n" +
+        "          named profile so the owner can sign in themselves (then `close`\n" +
+        "          seals it); without it a named profile never auto-creates\n" +
         "  snapshot --name N             accessibility tree with element refs; iframe\n" +
         "          elements get frame-prefixed refs (f1e3); reports open tabs when >1\n" +
         "  form-inspect --name N           compact form controls + labels/types/requirements\n" +

--- a/plugins/agent-id-browser/lib/profile-store.mjs
+++ b/plugins/agent-id-browser/lib/profile-store.mjs
@@ -75,16 +75,29 @@ export async function sealedProfileExists(stateDir, file) {
 // Bootstrap the shared default cookie jar for an L0 identity. Public browsing
 // must not require a fake login credential, while explicitly named profiles
 // remain opt-in account boundaries and therefore never auto-create.
-export async function ensureAnonymousDefaultProfile({ vault, stateDir, name, defaultName = "main" }) {
+//
+// `allowCreate` is that opt-in, and the ONLY way a named profile is minted
+// without a login: an owner-driven sign-in (headed login impossible, auto-login
+// refused by the site) needs an empty jar to sign into and seal, and there was
+// no way to make one — so "open the browser view and sign in yourself" pointed
+// at a profile that could never exist. Callers pass it deliberately; the
+// default stays refuse-by-name.
+export async function ensureAnonymousDefaultProfile({
+  vault,
+  stateDir,
+  name,
+  defaultName = "main",
+  allowCreate = false,
+}) {
   const existing = vault.get(name);
   if (existing) return existing;
-  if (name !== defaultName) {
+  if (name !== defaultName && !allowCreate) {
     const error = new Error(`no browser-profile named '${name}'`);
     error.code = "NO_PROFILE";
     throw error;
   }
 
-  const file = `${defaultName}.tar.enc`;
+  const file = `${name}.tar.enc`;
   const dek = newDek();
   const empty = await fs.mkdtemp(path.join(os.tmpdir(), "agentid-banon-"));
   try {
@@ -93,10 +106,13 @@ export async function ensureAnonymousDefaultProfile({ vault, stateDir, name, def
     await fs.rm(empty, { recursive: true, force: true });
   }
   const record = vault.add({
-    name: defaultName,
+    name,
     type: "browser-profile",
     domains: ["*"],
-    description: "Anonymous L0 browser profile (agent-id-browser)",
+    description:
+      name === defaultName
+        ? "Anonymous L0 browser profile (agent-id-browser)"
+        : `Empty browser profile for owner-driven sign-in (${name})`,
     dek,
     profileFile: file,
     headless: true,

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -56,6 +56,78 @@ export function sessionFilePath(stateDir, name) {
   return path.join(sessionsDir(stateDir), `${name}.json`);
 }
 
+// Is the daemon that wrote a session file still running? Signal 0 delivers
+// nothing and only asks the question, and it answers it on every platform we
+// run on (a /proc probe does not — desktop is macOS). EPERM means the pid
+// exists and belongs to someone else, which still counts as alive.
+export function sessionAlive(info) {
+  const pid = Number(info?.pid);
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return err?.code === "EPERM";
+  }
+}
+
+// Drop session files whose daemon is gone. A clean `close` reseals and removes
+// its own file (see finalize), but a killed container — or any abrupt death —
+// leaves the file behind while /home/lethe persists. Those orphans still
+// advertise a streamPort, so a viewer that picks "the newest session" can dial
+// a dead port and show nothing, and `status` reports sessions that do not
+// exist. Best effort by design: a file we cannot read or unlink is skipped
+// rather than failing the caller's real work. Returns the pruned names.
+export async function pruneDeadSessions(stateDir) {
+  const pruned = [];
+  const live = new Set();
+  let entries;
+  try {
+    entries = await fs.readdir(sessionsDir(stateDir));
+  } catch {
+    return pruned; // no sessions dir yet
+  }
+  for (const entry of entries) {
+    if (!entry.endsWith(".json")) continue;
+    const name = entry.replace(/\.json$/, "");
+    const file = path.join(sessionsDir(stateDir), entry);
+    try {
+      const info = JSON.parse(await fs.readFile(file, "utf8"));
+      if (sessionAlive(info)) {
+        live.add(name);
+        continue;
+      }
+      await fs.rm(file, { force: true });
+      pruned.push(name);
+    } catch {
+      /* unreadable or already gone — leave it alone */
+    }
+  }
+  // `<name>.work` is the UNSEALED profile — cookies in plaintext, outside the
+  // vault. A clean close wipes it; an abrupt death leaves it on disk
+  // indefinitely (found weeks-old copies for sessions long gone). Remove the
+  // ones whose session is gone, but only once they are old enough that they
+  // cannot belong to an open still unsealing into them: the session file is
+  // written after the unseal, so a young dir with no session file may be a
+  // live launch, not an orphan.
+  const STALE_WORK_MS = 60 * 60 * 1000;
+  for (const entry of entries) {
+    if (!entry.endsWith(".work")) continue;
+    const name = entry.replace(/\.work$/, "");
+    if (live.has(name)) continue;
+    const dir = path.join(sessionsDir(stateDir), entry);
+    try {
+      const st = await fs.stat(dir);
+      if (Date.now() - st.mtimeMs < STALE_WORK_MS) continue;
+      await fs.rm(dir, { recursive: true, force: true });
+      pruned.push(entry);
+    } catch {
+      /* gone or unreadable — nothing to do */
+    }
+  }
+  return pruned;
+}
+
 // THE SHARED REF SPACE — keep this selector, and the numbering loop that walks
 // it, byte-identical in snapshotInPage and formSnapshotInPage.
 //

--- a/tests/test-browser-session-helpers.mjs
+++ b/tests/test-browser-session-helpers.mjs
@@ -9,11 +9,16 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 
 import {
   frameRefId,
+  pruneDeadSessions,
   refuseRef,
   safeFilename,
+  sessionAlive,
 } from "../plugins/agent-id-browser/lib/session-server.mjs";
 
 test("refuseRef: a ref on a focus-typing action is refused, not dropped", () => {
@@ -72,4 +77,44 @@ test("safeFilename: empty / dot-only names fall back, long names are bounded", (
   assert.equal(safeFilename(null), "file");
   assert.equal(safeFilename("..."), "file");
   assert.ok(safeFilename("x".repeat(500)).length <= 80);
+});
+
+// --- session liveness + orphan pruning ---------------------------------------
+
+test("sessionAlive: this process is alive, an absurd pid is not", () => {
+  assert.equal(sessionAlive({ pid: process.pid }), true);
+  assert.equal(sessionAlive({ pid: 0x7ffffff }), false);
+  assert.equal(sessionAlive({ pid: 0 }), false);
+  assert.equal(sessionAlive({}), false);
+  assert.equal(sessionAlive(null), false);
+});
+
+test("pruneDeadSessions: drops orphans, keeps live sessions and young work dirs", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "aid-prune-"));
+  const sessions = path.join(dir, "browser-sessions");
+  await fs.mkdir(sessions, { recursive: true });
+
+  const write = (name, info) =>
+    fs.writeFile(path.join(sessions, `${name}.json`), JSON.stringify(info));
+  // A dead daemon with the NEWEST startedAt — the shape that hijacks a viewer
+  // picking "the newest session advertising a stream".
+  await write("dead", { pid: 0x7ffffff, startedAt: Date.now() + 1e6, streamPort: 1 });
+  await write("live", { pid: process.pid, startedAt: 1, streamPort: 2 });
+  await fs.writeFile(path.join(sessions, "junk.json"), "not json");
+  // Work dirs: one orphaned and old, one orphaned but fresh (a launch in
+  // flight), one belonging to the live session.
+  const old = path.join(sessions, "dead.work");
+  await fs.mkdir(old, { recursive: true });
+  const past = new Date(Date.now() - 3 * 60 * 60 * 1000);
+  await fs.utimes(old, past, past);
+  await fs.mkdir(path.join(sessions, "fresh.work"), { recursive: true });
+  await fs.mkdir(path.join(sessions, "live.work"), { recursive: true });
+
+  const pruned = await pruneDeadSessions(dir);
+
+  const left = (await fs.readdir(sessions)).sort();
+  assert.deepEqual(left, ["fresh.work", "junk.json", "live.json", "live.work"]);
+  assert.ok(pruned.includes("dead"));
+  assert.ok(pruned.includes("dead.work"));
+  await fs.rm(dir, { recursive: true, force: true });
 });


### PR DESCRIPTION
## Summary

Found while investigating a report that the browser drawer showed an old, unrelated session when Lethe asked the owner to sign in. The handover was broken end to end; this PR fixes the plugin half.

- **A named profile can be created for the owner to sign into.** When a sign-in cannot be automated (bot challenge, IdP refusing agents, no display for headed `login`), the escalation is to hand over the browser — but that was impossible for any site not already set up: `login` needs a GUI, `auto-login` had just failed, and `open` refuses to auto-create a named profile. `open --bootstrap-profile` mints an empty jar; the owner signs in and `close` seals it. Without the flag a named profile still never auto-creates.
- **Orphaned session files are pruned.** A clean `close` removes its own file; an abrupt death (recreated container) does not, and the state dir outlives the process. Those orphans still advertise a `streamPort`, so a viewer picking "newest session with a stream" can dial a dead port. Observed live: 7 session files, 5 of them dead.
- **Stale plaintext profile copies are removed.** `<name>.work` is the UNSEALED profile — cookies outside the vault. Found copies from five weeks earlier for sessions long gone. Pruned once old enough not to be a launch in flight.

## Verification

- 52 browser tests pass, including new unit tests for the liveness probe and prune (orphan with the newest `startedAt` — the shape that hijacks the viewer — plus "live session kept", "young work dir kept", "unreadable file left alone").
- E2E against a real browser: `open --name X` without the flag still returns `NO_PROFILE`; with `--bootstrap-profile` it mints, opens, navigates, advertises a stream port, and `close` seals the profile and removes the session file. Pruning removed two real five-week-old `.work` dirs.

Runtime + UI halves ship in lethe and lethe-backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)