### PR TITLE
fix(browser): always lift the viewport blackout, and give a joining viewer a frame

### DIFF
--- a/.changeset/blackout-never-lifted.md
+++ b/.changeset/blackout-never-lifted.md
@@ -1,0 +1,29 @@
+---
+"@alien-id/agent-id-browser": patch
+---
+
+The viewport blackout is always lifted, and a joining viewer always gets a frame
+
+Three faults that together made the live browser view look dead. An owner asked
+to finish a sign-in opened the view and watched a blank canvas — the relay said
+it was streaming, and not one frame ever arrived.
+
+**A failed credential fill blacked out the feed forever.** `fill-secret`
+suspends the stream, then unlocks the vault — but the unlock ran *outside* the
+`try` whose `finally` resumes. Any failure there (locked vault, no agent-key
+slot, timeout) left the suspend depth stuck above zero for the rest of the
+session: frames were acked and dropped, so every later viewer saw
+`screencasting` and nothing else. That is exactly what a failed auto-login leaves
+behind, minutes before the owner is asked to take over. `fill-otp` already had
+the right shape; `fill-secret` now matches it.
+
+**A viewer joining an already-running screencast got no frame.** Frames are
+change-driven, and Chrome emits its first one when the cast starts — so a client
+that arrives afterwards has nothing to draw until the page happens to move. On a
+sign-in form that is never. A joining client now restarts the cast to force a
+fresh keyframe, the same trick `resume` uses.
+
+**A blacked-out feed was indistinguishable from a broken one.** The status sent
+on connect claimed `screencasting: true` and said nothing about the blackout, so
+a suspended feed and a dead one looked identical from the outside. The connect
+status now reports `suspended`.

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -858,7 +858,9 @@ export async function fillForm(state, p) {
   };
 }
 
-async function dispatch(state, msg, policy = null) {
+// Exported for tests: the suspend/resume contract around credential fills is
+// only observable here.
+export async function dispatch(state, msg, policy = null) {
   const p = msg.params || {};
   const page = state.current;
   // Read-only sessions refuse the un-auditable/secret-bearing actions here;
@@ -1040,35 +1042,45 @@ async function dispatch(state, msg, policy = null) {
       // Viewport-stream blackout while the value is on its way into the page —
       // watchers see nothing and viewer input is ignored until resume.
       state.stream?.suspend();
-      const vault = await openVaultAgentKey(msg._stateDir);
+      // Everything after the suspend must be inside this try: unlocking the
+      // vault can fail (locked, no agent-key slot, timeout), and when that
+      // throw escaped the blackout was never lifted — the feed stayed
+      // suspended for the rest of the session, so every later viewer got
+      // "screencasting" and not one frame. Seen in the wild after a failed
+      // auto-login: the owner opened the browser view to sign in and watched a
+      // blank canvas. `fill-otp` below already had this shape.
       try {
-        const rec = vault.get(credName);
-        if (!rec) throw new Error(`no credential "${credName}"`);
-        // Refuse a sealed field, and refuse a page whose host isn't on the
-        // credential's allowlist — BEFORE reading the value into memory. When
-        // the field lives in an iframe, the frame's origin is where the value
-        // actually goes, so BOTH the top page and the frame must pass.
-        assertFillAllowed(rec, hostOfUrl(page.url()), field);
-        if (target !== page) assertFillAllowed(rec, hostOfUrl(target.url()), field);
-        const value = rec[field];
-        if (typeof value !== "string" || !value) {
-          throw new Error(`"${credName}.${field}" is not a usable string field`);
-        }
-        // CRITICAL: a fill/keyboard error can echo the value being typed, so
-        // never let the raw error escape — it would leak the secret to the agent.
+        const vault = await openVaultAgentKey(msg._stateDir);
         try {
-          await humanType(page, sel(p.ref), value, {
-            timeout: ACTION_TIMEOUT,
-            submit: !!p.submit,
-            root: target,
-          });
-        } catch {
-          throw new Error(`fill-secret: could not fill "${p.ref}" — element not visible/editable (re-snapshot and retry)`);
+          const rec = vault.get(credName);
+          if (!rec) throw new Error(`no credential "${credName}"`);
+          // Refuse a sealed field, and refuse a page whose host isn't on the
+          // credential's allowlist — BEFORE reading the value into memory. When
+          // the field lives in an iframe, the frame's origin is where the value
+          // actually goes, so BOTH the top page and the frame must pass.
+          assertFillAllowed(rec, hostOfUrl(page.url()), field);
+          if (target !== page) assertFillAllowed(rec, hostOfUrl(target.url()), field);
+          const value = rec[field];
+          if (typeof value !== "string" || !value) {
+            throw new Error(`"${credName}.${field}" is not a usable string field`);
+          }
+          // CRITICAL: a fill/keyboard error can echo the value being typed, so
+          // never let the raw error escape — it would leak the secret to the agent.
+          try {
+            await humanType(page, sel(p.ref), value, {
+              timeout: ACTION_TIMEOUT,
+              submit: !!p.submit,
+              root: target,
+            });
+          } catch {
+            throw new Error(`fill-secret: could not fill "${p.ref}" — element not visible/editable (re-snapshot and retry)`);
+          }
+          // Tag the field so a later read-back is refused whatever its input type.
+          await markSecretField(target, sel(p.ref));
+        } finally {
+          vault.lock();
         }
-        // Tag the field so a later read-back is refused whatever its input type.
-        await markSecretField(target, sel(p.ref));
       } finally {
-        vault.lock();
         state.stream?.resume();
       }
       return { filled: p.ref, cred: p.cred };

--- a/plugins/agent-id-browser/lib/stream-server.mjs
+++ b/plugins/agent-id-browser/lib/stream-server.mjs
@@ -244,7 +244,19 @@ export async function startStreamServer(state, { log = () => {} } = {}) {
         `Sec-WebSocket-Accept: ${accept}\r\n\r\n`,
     );
     clients.add(socket);
-    socket.write(encodeTextFrame(JSON.stringify({ type: "status", source: "alien", screencasting: true })));
+    // Tell a joining client the CURRENT state, not just "screencasting". A
+    // blacked-out feed (credential fill in flight) looks exactly like a broken
+    // one from the outside — the viewer needs to know which it is.
+    socket.write(
+      encodeTextFrame(
+        JSON.stringify({
+          type: "status",
+          source: "alien",
+          screencasting: true,
+          suspended: suspended > 0,
+        }),
+      ),
+    );
 
     const parse = makeFrameParser(({ opcode, payload }) => {
       if (opcode === 0x8) {
@@ -283,7 +295,14 @@ export async function startStreamServer(state, { log = () => {} } = {}) {
     socket.on("close", drop);
     socket.on("error", drop);
 
-    void startScreencast(); // first watcher starts the feed
+    // Frames are CHANGE-driven, so a client that joins an already-running cast
+    // gets nothing at all until the page happens to move — on a sign-in form
+    // that is forever, and a blank canvas reads as "the browser view is
+    // broken". Restart the cast so Chrome emits a fresh first frame for it
+    // (the same trick `resume` uses); otherwise this is the first watcher and
+    // starting the feed produces that frame anyway.
+    if (cdp) void stopScreencast().then(() => startScreencast());
+    else void startScreencast();
   });
 
   await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));

--- a/tests/test-browser-stream-blackout.mjs
+++ b/tests/test-browser-stream-blackout.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+
+// The viewport blackout that protects a credential fill must ALWAYS be lifted.
+//
+// `fill-secret` suspends the stream, then unlocks the vault. That unlock can
+// fail — locked vault, no agent-key slot, timeout — and the suspend used to sit
+// outside the try that resumes, so the throw left the feed suspended for the
+// rest of the session: frames were acked and dropped, every later viewer saw
+// "screencasting" and not one frame. In the wild that looked like a dead
+// browser view — an owner asked to sign in stared at a blank canvas — and
+// nothing pointed at a failed fill an hour earlier.
+//
+// Pure: no browser, no vault. The fill never gets past the vault unlock, which
+// is the point.
+//
+// Run: node --test tests/test-browser-stream-blackout.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { dispatch } from "../plugins/agent-id-browser/lib/session-server.mjs";
+
+/** Counts suspend/resume the way the real stream server does (depth-counted). */
+function fakeStream() {
+  let depth = 0;
+  return {
+    suspends: 0,
+    resumes: 0,
+    get depth() {
+      return depth;
+    },
+    suspend() {
+      this.suspends++;
+      depth++;
+    },
+    resume() {
+      this.resumes++;
+      depth = Math.max(0, depth - 1);
+    },
+  };
+}
+
+function fakeState(stream) {
+  const page = {
+    url: () => "https://example.com/login",
+    isClosed: () => false,
+    frames: () => [],
+  };
+  return {
+    stream,
+    current: page,
+    ctx: {},
+    // frameForRef runs before the suspend and refuses stale refs; a valid ref
+    // space is what lets the test reach the blackout at all.
+    refsValid: true,
+    refGeneration: 1,
+    frames: new Map(),
+    invalidateRefs() {},
+  };
+}
+
+for (const action of ["fill-secret", "fill-otp"]) {
+  test(`${action}: a failed vault unlock still lifts the blackout`, async () => {
+    // A state dir with no vault at all — openVaultAgentKey cannot succeed.
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "aid-blackout-"));
+    const stream = fakeStream();
+    const state = fakeState(stream);
+
+    await assert.rejects(
+      () =>
+        dispatch(state, {
+          action,
+          params: { ref: "1:e1", cred: "example.password" },
+          _stateDir: dir,
+        }),
+      "the fill must fail — there is no vault to unlock",
+    );
+
+    assert.equal(stream.suspends, 1, "the feed is blacked out for the fill");
+    assert.equal(
+      stream.resumes,
+      1,
+      "and the blackout is lifted even though the fill threw",
+    );
+    assert.equal(stream.depth, 0, "no leaked suspend depth");
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+}


### PR DESCRIPTION
## Summary

Reported as "the open-the-browser-view button does not work at all." The button, the drawer, the session targeting and both relay hops were all fine — verified hop by hop on prod. What failed was further in: the canvas stayed blank forever.

Three faults, found by attaching a probe to the owner's real session:

1. **A failed credential fill blacks out the feed permanently.** `fill-secret` suspends the stream, then unlocks the vault — but the unlock ran *outside* the `try` whose `finally` resumes. Any failure there (locked vault, no agent-key slot, timeout) leaves the depth stuck above zero for the session's life: frames acked, never broadcast. A failed auto-login leaves precisely that behind, minutes before the owner is asked to take over. `fill-otp` already had the right shape.
2. **A viewer joining an already-running screencast gets no frame.** Frames are change-driven and Chrome emits the first one at cast start, so a later client has nothing to draw until the page moves — on a sign-in form, never.
3. **A blacked-out feed was indistinguishable from a dead one:** the connect status claimed `screencasting: true` and never mentioned the blackout.

## Verification

- Attached to the owner's live session on prod: `relaying` + `screencasting: true`, then **no frame in 20s — and none even after scrolling the page**. Closing and reopening that session produced a frame instantly (84KB JPEG), pinning it to leaked session state rather than the code path being dead.
- New `tests/test-browser-stream-blackout.mjs` drives `dispatch` with a vault-less state dir and asserts suspend/resume balance for both fill actions. Confirmed it *catches* the bug: reintroducing the original ordering fails the `fill-secret` case and leaves `fill-otp` passing.
- 54 browser tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)