### PR TITLE
feat(browser): close sessions nobody is using

### DIFF
--- a/.changeset/idle-sessions-close.md
+++ b/.changeset/idle-sessions-close.md
@@ -1,0 +1,21 @@
+---
+"@alien-id/agent-id-browser": minor
+---
+
+Unused sessions close themselves
+
+A session holds a Chrome and a node process for as long as it lives, and nothing
+ended one: an agent that opened a browser and moved on — or failed a login and
+gave up — left it running until the container stopped. Sessions accumulated,
+holding memory and making "which browser is this?" genuinely ambiguous, since
+every host-side pick that falls back to "whichever started last" was choosing
+between browsers nobody was using.
+
+A session now closes itself after 20 minutes with no agent action, no viewer
+input, and nobody watching. Closing is the safe direction: the existing shutdown
+path reseals the profile into the vault first, so a signed-in session that times
+out keeps its cookies and simply reopens next time.
+
+A session with a viewer attached is never idle, however quiet it is — the owner
+may be reading a page or part-way through a sign-in they were handed. Set
+`AGENT_ID_BROWSER_IDLE_MS` to change the window, or `0` to disable it.

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -329,6 +329,14 @@ export function formSnapshotInPage(arg) {
 
 const sel = (ref) => `[data-aibref="${String(ref).replace(/["\\]/g, "")}"]`;
 const ACTION_TIMEOUT = 15000;
+
+// How long a session may sit unused (no agent action, no viewer input, nobody
+// watching) before it closes itself. Long enough that an owner reading a page
+// or stepping away mid-task is not cut off, short enough that a forgotten
+// session does not hold a browser for the life of the container. Override with
+// AGENT_ID_BROWSER_IDLE_MS; 0 disables.
+const DEFAULT_IDLE_MS = 20 * 60_000;
+const IDLE_POLL_MS = 30_000;
 const MAX_FRAMES = 12; // iframes snapshotted per page (ad-heavy pages have dozens)
 const CONSOLE_CAP = 300; // ring-buffer size for captured console/pageerror entries
 
@@ -1651,9 +1659,21 @@ export async function runSession({
   // token ride in the session file so the host runtime can relay it to the
   // owner's client; the feed and viewer input are suspended while fill-secret
   // / fill-otp inject credential values (see those dispatch cases).
+  // Idle shutdown. A session holds a Chrome and a node process for as long as
+  // it lives, and nothing used to end one: an agent that opened a browser and
+  // moved on (or failed a login and gave up) left it running until the
+  // container did, so profiles piled up holding memory and muddying "which
+  // browser is this?". Any agent action or viewer input counts as use, and a
+  // session with someone watching is never idle however quiet it is — the
+  // owner may be reading a page or part-way through a sign-in.
+  let lastActivityAt = Date.now();
+  const touch = () => {
+    lastActivityAt = Date.now();
+  };
   const stream = await startStreamServer(state, {
     log: (m) => process.stderr.write(`${m}\n`),
     resize: (width, height) => resizeToViewport(state, width, height),
+    onActivity: touch,
   });
   state.stream = stream;
 
@@ -1674,6 +1694,33 @@ export async function runSession({
     process.exit(0);
   }
 
+  // Closing on idle is the SAFE direction: finalize reseals the profile into
+  // the vault first, so a signed-in session that times out keeps its cookies
+  // and simply reopens next time. Set AGENT_ID_BROWSER_IDLE_MS=0 to disable.
+  const idleMs = (() => {
+    const raw = Number(process.env.AGENT_ID_BROWSER_IDLE_MS);
+    if (Number.isFinite(raw)) return Math.max(0, raw);
+    return DEFAULT_IDLE_MS;
+  })();
+  if (idleMs > 0) {
+    const reaper = setInterval(() => {
+      if (finalizing) return;
+      if (stream.viewers() > 0) {
+        touch(); // being watched is being used
+        return;
+      }
+      if (Date.now() - lastActivityAt < idleMs) return;
+      const forHuman =
+        idleMs >= 60_000 ? `${Math.round(idleMs / 60_000)} min` : `${Math.round(idleMs / 1000)}s`;
+      process.stderr.write(
+        `Session '${name}' idle for ${forHuman} with no viewer — closing ` +
+          `(profile is resealed; reopen with \`open --name ${name}\`).\n`,
+      );
+      void finalize();
+    }, IDLE_POLL_MS);
+    reaper.unref?.();
+  }
+
   const token = crypto.randomBytes(24).toString("hex");
   const server = net.createServer((sock) => {
     let buf = "";
@@ -1691,6 +1738,7 @@ export async function runSession({
         return;
       }
       msg._stateDir = stateDir;
+      touch();
       try {
         const result = await dispatch(state, msg, policy);
         sock.end(JSON.stringify({ ok: true, ...result }) + "\n");

--- a/plugins/agent-id-browser/lib/stream-server.mjs
+++ b/plugins/agent-id-browser/lib/stream-server.mjs
@@ -171,7 +171,10 @@ function mutatesPage(msg) {
 const RESIZE_MIN = 200;
 const RESIZE_MAX = 4096;
 
-export async function startStreamServer(state, { log = () => {}, resize = null } = {}) {
+export async function startStreamServer(
+  state,
+  { log = () => {}, resize = null, onActivity = () => {} } = {},
+) {
   const token = crypto.randomBytes(24).toString("hex");
   const clients = new Set();
   let cdp = null; // active CDPSession for the screencast
@@ -286,6 +289,7 @@ export async function startStreamServer(state, { log = () => {}, resize = null }
       // Input is disabled while a credential fill is in flight — the viewer
       // must not be able to interact with a form mid-injection.
       if (suspended > 0) return;
+      onActivity();
       if (msg.type === "resize") {
         // Reshape the page viewport to the viewer's screen (mobile-sized
         // viewports for phone watchers). Serialized behind pending input and
@@ -345,6 +349,8 @@ export async function startStreamServer(state, { log = () => {}, resize = null }
   return {
     port: server.address().port,
     token,
+    /** How many viewers are attached — a watched session is never idle. */
+    viewers: () => clients.size,
     /** Hide the feed while a secret is typed into the page. Depth-counted. */
     suspend() {
       suspended++;


### PR DESCRIPTION
## Summary

Sessions were immortal. A session holds a Chrome and a node process for as long as it lives, and nothing ended one — an agent that opened a browser and moved on, or failed a login and gave up, left it running until the container stopped. On one live workspace that meant `main`, `goodreads-main` and five stale `epfl_*` profiles, none in use.

That is also why "which browser am I looking at?" was ambiguous: every host-side fallback picks "whichever session started last", and it was choosing between browsers nobody was using.

A session now closes itself after **20 minutes** with no agent action, no viewer input, and nobody watching. Closing is the safe direction — the existing shutdown path reseals the profile into the vault first, so a signed-in session that times out keeps its cookies and simply reopens next time. `AGENT_ID_BROWSER_IDLE_MS` overrides the window; `0` disables it.

**A watched session is never idle**, however quiet it is: the owner may be reading a page or part-way through a sign-in they were handed. Viewer attachment and viewer input both count as use, alongside agent actions.

## Verification

Live, with `AGENT_ID_BROWSER_IDLE_MS=8000`:

- **Idle session closes**: after 45s untouched the daemon exited, the session file was removed, and the profile was resealed — log line `Session 'main' idle for 8s with no viewer — closing (profile is resealed…)`.
- **Watched session survives**: with a viewer holding the stream open and sending nothing, the same session was still alive and serving 46s later — well past the window.

54 browser tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)