### PR TITLE
fix(browser): strict codec negotiation, text-only char, screencast watchdog

### DIFF
--- a/.changeset/stream-strict-char-watchdog.md
+++ b/.changeset/stream-strict-char-watchdog.md
@@ -1,0 +1,30 @@
+---
+"@alien-id/agent-id-browser": minor
+---
+
+Strict codec negotiation, text-only `char`, and a screencast watchdog
+
+**`codec=h264&strict=1` refuses instead of falling back.** An explicit h264
+request that landed on an unprovisioned host was quietly served JPEG, so broken
+provisioning stayed invisible while costing roughly 10× the traffic. With
+`strict=1` the handshake is refused immediately with close code **4002** — before
+a single frame — and an encoder that fails later closes the same way rather than
+downgrading a client that never agreed to it. `codec=auto` deliberately ignores
+`strict`: it asks for the best available, and JPEG is a valid answer.
+
+**`char` no longer needs a `key`.** The payload of a text-insertion event is
+`text`; `key` is only a fallback for it. Requiring `key` dropped well-formed
+`{eventType:"char", text:"…"}` on the floor without a word, silently losing the
+character. `keyDown`/`keyUp` still require a key — there is no pressing
+"nothing" — and input the server cannot act on now comes back to the sender as
+`{"type":"status","error":"…","for":"input_keyboard"}` instead of disappearing
+into a swallowed rejection.
+
+**A watchdog restarts a stalled screencast.** With viewers attached and no frame
+for `AGENT_ID_STREAM_WATCHDOG_MS` (default 15s, 0 disables), the screencast is
+restarted. The idle refinement pass is not a substitute: it is *armed* by a
+screencast frame, so a cast that dies before or between frames never triggers
+it, and the retarget poll only fires when the current page CHANGES — which a
+silently-detached CDP session does not do. A healthy session never trips this
+(Chrome keeps emitting frames even on a blank page); when it does trip, the
+restart delivers a fresh keyframe, which is also how it proves the pipe is back.

--- a/docs/BROWSER-STREAM.md
+++ b/docs/BROWSER-STREAM.md
@@ -44,6 +44,7 @@ both browser stacks.
 | `binary` | `1` | `frame` messages become WS **binary** messages (layout below); everything else stays JSON text |
 | `codec` | `jpeg` \| `h264` \| `auto` | `h264`/`auto` imply `binary=1`. `auto` resolves at join time: h264 on a provisioned host (see *Provisioning*), else jpeg. Omitting the param means `jpeg` — that is a compatibility floor, not a recommendation: a client that never asked can't be assumed to decode video. **New clients should always send `codec=auto`** (the bundled viewer does), which is how h264 becomes the effective default wherever the owner ran `install-codecs` |
 | `pacing` | `push` (default) \| `ack` | `ack`: at most one frame in flight; the client releases the next with an `ack` message |
+| `strict` | `1` | Only with an explicit `codec=h264`: make it a **requirement**. An unprovisioned host (or an encoder that fails to start) refuses with close code **4002** instead of quietly serving jpeg — broken provisioning is otherwise invisible and jpeg costs roughly 10× the traffic. `codec=auto` ignores it: `auto` asks for the best available, and jpeg is a valid answer |
 | `maxFps` | 0–120 | per-client delivery cap (0 = uncapped) |
 
 ### Messages
@@ -79,6 +80,10 @@ Client → server (always JSON text):
   "deltaX": 0, "deltaY": 120 }
 { "type": "input_keyboard", "eventType": "keyDown" | "keyUp" | "char",
   "key": "Enter", "text": "a" }
+// `char` carries its payload in `text`; `key` is only a fallback for it, so a
+// text-only char is valid. `keyDown`/`keyUp` require `key`. Input the server
+// cannot act on comes back to the SENDER as
+// {"type":"status","error":"…","for":"input_keyboard"} rather than vanishing.
 { "type": "resize", "width": 390, "height": 844 }  // viewport, see below
 { "type": "webrtc_offer", "sdp": "…" }             // experimental, see below
 { "type": "webrtc_ice", "candidate": { … } }
@@ -88,6 +93,12 @@ Input coordinates are in `metadata.deviceWidth/Height` space (CSS viewport
 pixels — capture is clamped to the CSS viewport, so the mapping is 1:1).
 Mutating input (click, wheel, keydown, char) invalidates the agent's element
 refs, exactly like any page mutation.
+
+### Close codes
+
+| Code | Meaning |
+|---|---|
+| `4002` | The requested codec cannot be served and the client sent `strict=1`. Typed on purpose: a strict client can tell this from a network drop and stop reconnecting. A `status` frame carrying `error` and `code` precedes the close, so a text-logging viewer sees the reason in words |
 
 ### Binary frame layout
 

--- a/plugins/agent-id-browser/lib/stream-server.mjs
+++ b/plugins/agent-id-browser/lib/stream-server.mjs
@@ -77,6 +77,15 @@ function envInt(name, fallback, min, max) {
 // (0 disables refinement). Bind is overridable ONLY for LAN viewer testing.
 const STREAM_QUALITY = envInt("AGENT_ID_STREAM_QUALITY", 55, 1, 100);
 const REFINE_QUALITY = envInt("AGENT_ID_STREAM_REFINE_QUALITY", 90, 0, 100);
+// Watchdog: with a viewer attached and nothing arriving for this long, restart
+// the screencast (0 disables). Refinement is NOT a substitute — it is armed by
+// a screencast frame (`refined` starts true and `lastMetadata` starts null), so
+// a cast that dies before or between frames never triggers it, and the retarget
+// poll only fires when `state.current` CHANGES, which a silently-detached CDP
+// session does not do. On a genuinely static page this restarts every interval:
+// two CDP calls and one keyframe, which also proves the pipe is alive and is
+// far cheaper than a viewer staring at a frozen picture.
+const WATCHDOG_MS = envInt("AGENT_ID_STREAM_WATCHDOG_MS", 15000, 0, 600000);
 const BIND_HOST = process.env.AGENT_ID_STREAM_BIND || "127.0.0.1";
 
 // ── WS wire helpers (server side: outgoing unmasked, incoming masked) ────────
@@ -104,6 +113,11 @@ const encodeTextFrame = (payload) => wsFrame(0x1, Buffer.from(payload, "utf8"));
 function encodeControlFrame(opcode, payload = Buffer.alloc(0)) {
   return Buffer.concat([Buffer.from([0x80 | opcode, payload.length]), payload]);
 }
+
+// Application close code (4000-4999 is the private-use range) for "you asked
+// for a codec I cannot serve". Typed so a strict client can distinguish it
+// from a network drop and stop retrying, instead of reconnecting forever.
+export const CLOSE_CODEC_UNAVAILABLE = 4002;
 
 /** Binary frame-message body: [u32 LE header length][JSON header][payload]. */
 export function encodeFrameBinary(header, payload) {
@@ -180,6 +194,13 @@ export function parseStreamParams(url) {
   const codec = raw === "h264" || raw === "auto" ? raw : "jpeg";
   const rawFps = Number(url.searchParams.get("maxFps"));
   return {
+    // `strict=1` turns the codec request into a requirement. A silent fall
+    // back to jpeg hides broken provisioning and quietly costs ~10x the
+    // traffic, so a client that cannot use jpeg wants the refusal instead —
+    // immediately, and typed, rather than as a surprise in the bandwidth bill.
+    // Only meaningful with an explicit codec: `auto` ASKS for the best
+    // available and jpeg is a valid answer.
+    strict: url.searchParams.get("strict") === "1" && raw === "h264",
     // h264/auto payloads are raw bytes — the codec choice implies binary framing.
     binary: url.searchParams.get("binary") === "1" || codec !== "jpeg",
     codec,
@@ -192,7 +213,8 @@ export function parseStreamParams(url) {
 
 const KEY_ALIASES = { " ": "Space" };
 
-async function applyInput(page, msg) {
+// Exported for tests: the input contract is only observable here.
+export async function applyInput(page, msg) {
   if (msg.type === "input_mouse") {
     const x = Number(msg.x) || 0;
     const y = Number(msg.y) || 0;
@@ -214,14 +236,26 @@ async function applyInput(page, msg) {
   }
   if (msg.type === "input_keyboard") {
     const key = KEY_ALIASES[msg.key] ?? msg.key;
-    if (!key || typeof key !== "string") return;
+    // `char` is the text-insertion event: what it needs is `text`, and `key`
+    // is only ever a fallback for it. Requiring `key` here dropped a
+    // perfectly well-formed {eventType:"char", text:"…"} on the floor without
+    // a word — silently losing the character. keyDown/keyUp genuinely need a
+    // key, since there is no such thing as pressing "nothing".
+    if (msg.eventType === "char") {
+      const text = typeof msg.text === "string" && msg.text !== "" ? msg.text : key;
+      if (typeof text !== "string" || text === "") {
+        throw new Error("input_keyboard char needs `text` (or a `key` to fall back to)");
+      }
+      return page.keyboard.insertText(text);
+    }
+    if (!key || typeof key !== "string") {
+      throw new Error(`input_keyboard ${msg.eventType || "?"} needs \`key\``);
+    }
     switch (msg.eventType) {
       case "keyDown":
         return page.keyboard.down(key);
       case "keyUp":
         return page.keyboard.up(key);
-      case "char":
-        return page.keyboard.insertText(String(msg.text ?? key));
       default:
         return;
     }
@@ -279,6 +313,22 @@ export async function startStreamServer(
 
   function sendText(client, obj) {
     client.sock.write(encodeTextFrame(JSON.stringify(obj)));
+  }
+
+  // Refuse a client with a close code it can act on. The status frame goes
+  // first so a viewer that logs text has the reason in words, not just a
+  // number; then a proper WS close (2-byte big-endian code + UTF-8 reason).
+  function closeClient(client, code, reason) {
+    try {
+      sendText(client, { type: "status", source: "alien", error: reason, code });
+      const body = Buffer.from(reason, "utf8").subarray(0, 123);
+      const payload = Buffer.alloc(2 + body.length);
+      payload.writeUInt16BE(code, 0);
+      body.copy(payload, 2);
+      client.sock.write(encodeControlFrame(0x8, payload));
+    } catch { /* socket already gone */ }
+    clients.delete(client);
+    try { client.sock.end(); } catch { /* already closed */ }
   }
 
   function broadcastStatus(obj) {
@@ -437,9 +487,16 @@ export async function startStreamServer(
         lastFrameAt = 0;
       }
     } catch (err) {
-      log(`stream: h264 unavailable (${err.message || err}) — falling back to jpeg`);
+      const why = err.message || String(err);
+      log(`stream: h264 unavailable (${why})`);
       for (const client of clients) {
         if (client.codec !== "h264") continue;
+        if (client.strict) {
+          // Asked for h264 and nothing else: say so and close, rather than
+          // serve a format the client did not agree to.
+          closeClient(client, CLOSE_CODEC_UNAVAILABLE, `h264 unavailable: ${why}`);
+          continue;
+        }
         client.codec = "jpeg";
         sendText(client, statusFor(client));
       }
@@ -547,6 +604,23 @@ export async function startStreamServer(
   }, REFINE_POLL_MS);
   refine.unref?.();
 
+  // "A viewer is watching and no frames are coming" — the one condition that
+  // always means the picture is wrong, whatever the cause (dead CDP session,
+  // a screencast Chrome stopped feeding, an encoder that never started).
+  const watchdog = setInterval(() => {
+    if (closed || WATCHDOG_MS <= 0 || suspended > 0 || clients.size === 0) return;
+    const page = state.current;
+    if (!page || page.isClosed?.()) return;
+    if (cdp && Date.now() - lastFrameAt < WATCHDOG_MS) return;
+    if (!cdp) {
+      void startScreencast();
+      return;
+    }
+    log(`stream: no frames for ${WATCHDOG_MS}ms with ${clients.size} viewer(s) — restarting screencast`);
+    void stopScreencast().then(() => startScreencast());
+  }, Math.max(1000, Math.floor(WATCHDOG_MS / 3)));
+  watchdog.unref?.();
+
   async function handleWebRtcSignal(client, msg) {
     try {
       if (!webrtc) {
@@ -610,6 +684,18 @@ export async function startStreamServer(
     // auto resolves against provisioning: h264 only on an install-codecs'd
     // host. The join status tells the viewer which one it got.
     if (client.codec === "auto") client.codec = h264Config ? "h264" : "jpeg";
+    // Strict + unprovisioned host: refuse now. Waiting for the encoder to
+    // fail would answer a handshake question minutes later, and only after
+    // the viewer had already been served jpeg it never agreed to.
+    if (client.strict && !h264Config) {
+      clients.add(client);
+      closeClient(
+        client,
+        CLOSE_CODEC_UNAVAILABLE,
+        "h264 requested with strict=1 but this host has no encoder — run `agent-id-browser install-codecs`",
+      );
+      return;
+    }
     clients.add(client);
     sendText(client, statusFor(client));
     if (client.codec === "h264") void ensureAnnexBEncoder();
@@ -693,7 +779,18 @@ export async function startStreamServer(
           if (!page || page.isClosed?.()) return;
           return applyInput(page, msg);
         })
-        .catch(() => {});
+        // Malformed input used to disappear here: the viewer sent something
+        // the server could not act on and heard nothing back, so a client bug
+        // looked like a dead feed. Report it to the sender (only — it is their
+        // message) and keep the queue running.
+        .catch((err) => {
+          sendText(client, {
+            type: "status",
+            source: "alien",
+            error: err?.message || String(err),
+            for: msg.type,
+          });
+        });
     });
     socket.on("data", parse);
     socket.on("drain", () => {
@@ -748,6 +845,7 @@ export async function startStreamServer(
     close() {
       closed = true;
       clearInterval(retarget);
+      clearInterval(watchdog);
       clearInterval(refine);
       void stopScreencast();
       if (annexB) {

--- a/tests/test-browser-stream-negotiation.mjs
+++ b/tests/test-browser-stream-negotiation.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+
+// Handshake and input contracts that must not fail silently.
+//
+// 1. `codec=h264&strict=1` is a REQUIREMENT. Falling back to jpeg hides broken
+//    provisioning and quietly costs ~10x the traffic, so an unprovisioned host
+//    must refuse at the handshake with a typed close code, not serve a format
+//    the client never agreed to.
+// 2. `char` carries its payload in `text`; `key` is only a fallback. Requiring
+//    `key` dropped well-formed text-only chars on the floor without a word.
+//
+// Pure: parseStreamParams and applyInput against a stub page. No browser.
+//
+// Run: node --test tests/test-browser-stream-negotiation.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  parseStreamParams,
+  applyInput,
+  CLOSE_CODEC_UNAVAILABLE,
+} from "../plugins/agent-id-browser/lib/stream-server.mjs";
+
+const params = (qs) => parseStreamParams(new URL(`ws://x/?${qs}`));
+
+test("strict only binds an explicit codec request", () => {
+  assert.equal(params("codec=h264&strict=1").strict, true);
+  // `auto` asks for the best available — jpeg is a valid answer to it, so
+  // strict would be a contradiction.
+  assert.equal(params("codec=auto&strict=1").strict, false);
+  assert.equal(params("codec=h264").strict, false);
+  assert.equal(params("strict=1").strict, false);
+});
+
+test("h264 implies binary framing; jpeg stays v1 by default", () => {
+  assert.equal(params("codec=h264").binary, true);
+  assert.equal(params("").binary, false);
+  assert.equal(params("").codec, "jpeg");
+});
+
+test("the codec-refusal close code is in the application range", () => {
+  assert.ok(CLOSE_CODEC_UNAVAILABLE >= 4000 && CLOSE_CODEC_UNAVAILABLE <= 4999);
+});
+
+function stubPage() {
+  const calls = [];
+  return {
+    calls,
+    keyboard: {
+      down: (k) => (calls.push(["down", k]), Promise.resolve()),
+      up: (k) => (calls.push(["up", k]), Promise.resolve()),
+      insertText: (t) => (calls.push(["insertText", t]), Promise.resolve()),
+    },
+    mouse: {},
+  };
+}
+
+test("char with only `text` inserts it (no `key` required)", async () => {
+  const page = stubPage();
+  await applyInput(page, { type: "input_keyboard", eventType: "char", text: "é" });
+  assert.deepEqual(page.calls, [["insertText", "é"]]);
+});
+
+test("char still falls back to `key` when that is all there is", async () => {
+  const page = stubPage();
+  await applyInput(page, { type: "input_keyboard", eventType: "char", key: "a" });
+  assert.deepEqual(page.calls, [["insertText", "a"]]);
+});
+
+test("a char with neither text nor key is reported, not swallowed", async () => {
+  const page = stubPage();
+  await assert.rejects(
+    () => applyInput(page, { type: "input_keyboard", eventType: "char" }),
+    /needs `text`/,
+  );
+  assert.deepEqual(page.calls, [], "nothing was typed");
+});
+
+test("keyDown without a key is reported — there is no pressing 'nothing'", async () => {
+  const page = stubPage();
+  await assert.rejects(
+    () => applyInput(page, { type: "input_keyboard", eventType: "keyDown" }),
+    /needs `key`/,
+  );
+});
+
+test("keyDown/keyUp still work normally", async () => {
+  const page = stubPage();
+  await applyInput(page, { type: "input_keyboard", eventType: "keyDown", key: "Enter" });
+  await applyInput(page, { type: "input_keyboard", eventType: "keyUp", key: "Enter" });
+  assert.deepEqual(page.calls, [["down", "Enter"], ["up", "Enter"]]);
+});

--- a/tests/test-browser-stream.mjs
+++ b/tests/test-browser-stream.mjs
@@ -166,12 +166,12 @@ async function startServer(opts = {}, stateOpts = {}) {
 
 test("parseStreamParams: defaults match the v1 wire protocol", () => {
   const p = parseStreamParams(new URL("http://x/?token=t"));
-  assert.deepEqual(p, { binary: false, codec: "jpeg", pacing: "push", maxFps: 0 });
+  assert.deepEqual(p, { strict: false, binary: false, codec: "jpeg", pacing: "push", maxFps: 0 });
 });
 
 test("parseStreamParams: clamps and coerces", () => {
   const p = parseStreamParams(new URL("http://x/?binary=1&pacing=ack&maxFps=500"));
-  assert.deepEqual(p, { binary: true, codec: "jpeg", pacing: "ack", maxFps: 120 });
+  assert.deepEqual(p, { strict: false, binary: true, codec: "jpeg", pacing: "ack", maxFps: 120 });
   assert.equal(parseStreamParams(new URL("http://x/?maxFps=junk")).maxFps, 0);
 });
 


### PR DESCRIPTION
Three items from the review, all cases where the stream failed quietly rather than saying so.

## 1. `codec=h264&strict=1` refuses instead of falling back

An explicit `codec=h264` on an unprovisioned host was silently served JPEG. Broken provisioning stayed invisible while costing roughly 10× the traffic — the worst shape of failure, since nothing looks wrong.

`strict=1` makes the codec a requirement: refused at the **handshake** with close code **4002**, before a frame is sent, and an encoder that dies later closes the same way rather than downgrading a client that never agreed to JPEG. `codec=auto` deliberately ignores `strict` — it asks for the best available, and JPEG is a valid answer to that question.

Verified live against a real session: `codec=h264` still degrades (`h264Available=false`), `codec=h264&strict=1` returns `CLOSE code: 4002` with the reason in words.

## 2. `char` accepts text-only

`if (!key) return` dropped a well-formed `{eventType:"char", text:"…"}` on the floor. `text` is the payload of a text-insertion event; `key` is only a fallback for it. `keyDown`/`keyUp` still require a key — there is no pressing "nothing".

Both halves of the suggestion are in: text-only is accepted, and input the server genuinely cannot act on now answers the **sender** with `{"type":"status","error":"…","for":"input_keyboard"}` instead of vanishing into a swallowed rejection.

## 3. Screencast watchdog — refinement is not a substitute

Answering the open question: **no**, and here is why. The refinement pass is *armed by* a screencast frame — `refined` starts `true` and `lastMetadata` starts `null` — so a cast that dies before or between frames never triggers it. The retarget poll only fires when the current page **changes**, which a silently-detached CDP session does not do. So a dead-but-attached screencast had nothing to recover it.

Now: viewers attached, not suspended, no frame for `AGENT_ID_STREAM_WATCHDOG_MS` (default 15s, 0 disables) ⇒ restart. A healthy session never trips it — Chrome keeps emitting frames even on `about:blank`, which I checked before choosing the threshold — and when it does trip, the restart delivers a keyframe, which is also how it proves the pipe is back. Forced to fire at 200ms against a live session: 8 restarts logged, frames flowing throughout (11–14 per 5s window).

## Verification

91 browser tests pass. New `tests/test-browser-stream-negotiation.mjs` pins the strict/char contracts; the v2 `parseStreamParams` shape assertions are updated for the new field. `docs/BROWSER-STREAM.md` documents `strict`, a close-code table, and the `char` contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)