### PR TITLE
build: standalone linux binaries for core, vault, proxy

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,9 +1,5 @@
 name: Release binaries
 
-# Standalone linux/amd64 binaries for the microVM rootfs, which has no Node and
-# no node_modules. Consumers pin a tag and verify the .sha256 next to each file,
-# so asset names must stay exactly as they are here.
-
 on:
   push:
     tags: ['v*']
@@ -19,8 +15,6 @@ jobs:
 
     steps:
       - name: Harden runner
-        # audit, not block: this job holds no id-token, and `bun build --compile`
-        # fetches the target runtime from bun.sh on a version mismatch.
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
@@ -44,8 +38,6 @@ jobs:
           done
 
       - name: Smoke test
-        # Catches a bundler regression that only shows up in the binary, e.g. a
-        # module resolved at runtime instead of at bundle time.
         run: |
           for plugin in agent-id-core agent-id-vault agent-id-proxy; do
             "./$plugin" --help > /dev/null

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,66 @@
+name: Release binaries
+
+# Standalone linux/amd64 binaries for the microVM rootfs, which has no Node and
+# no node_modules. Consumers pin a tag and verify the .sha256 next to each file,
+# so asset names must stay exactly as they are here.
+
+on:
+  push:
+    tags: ['v*']
+
+permissions: {}
+
+jobs:
+  release:
+    name: Build and publish binaries
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Harden runner
+        # audit, not block: this job holds no id-token, and `bun build --compile`
+        # fetches the target runtime from bun.sh on a version mismatch.
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun project
+        uses: ./.github/actions/setup-bun-project
+
+      - name: Test
+        run: bun run test
+
+      - name: Build
+        run: |
+          for plugin in agent-id-core agent-id-vault agent-id-proxy; do
+            bun build --compile --target=bun-linux-x64 \
+              "plugins/$plugin/bin/cli.mjs" --outfile "$plugin"
+          done
+
+      - name: Smoke test
+        # Catches a bundler regression that only shows up in the binary, e.g. a
+        # module resolved at runtime instead of at bundle time.
+        run: |
+          for plugin in agent-id-core agent-id-vault agent-id-proxy; do
+            "./$plugin" --help > /dev/null
+          done
+
+      - name: Publish
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          for plugin in agent-id-core agent-id-vault agent-id-proxy; do
+            sha256sum "$plugin" > "$plugin.sha256"
+          done
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "agent-id ${GITHUB_REF_NAME}" \
+            --generate-notes \
+            agent-id-core agent-id-core.sha256 \
+            agent-id-vault agent-id-vault.sha256 \
+            agent-id-proxy agent-id-proxy.sha256

--- a/plugins/agent-id-proxy/bin/cli.mjs
+++ b/plugins/agent-id-proxy/bin/cli.mjs
@@ -47,10 +47,7 @@ import {
   promptSecret,
 } from "@alien-id/agent-id-vault/lib/trusted-input.mjs";
 import { collectViaForm } from "@alien-id/agent-id-core/lib/secure-form.mjs";
-// The QR renderer is a CommonJS module vendored in agent-id-core. Imported
-// statically, not via createRequire: `bun build --compile` resolves imports at
-// bundle time, but leaves createRequire to a runtime node_modules lookup that
-// does not exist inside the single-file binary.
+// Static, not createRequire: the compiled binary has no node_modules to resolve against.
 import qrcode from "@alien-id/agent-id-core/bin/qrcode.cjs";
 
 import { createProxy, DEFAULT_IDLE_TIMEOUT_MS } from "../lib/proxy.mjs";

--- a/plugins/agent-id-proxy/bin/cli.mjs
+++ b/plugins/agent-id-proxy/bin/cli.mjs
@@ -18,7 +18,6 @@ import fs from "node:fs/promises";
 import http from "node:http";
 import https from "node:https";
 import path from "node:path";
-import { createRequire } from "node:module";
 
 import {
   outputError,
@@ -48,14 +47,16 @@ import {
   promptSecret,
 } from "@alien-id/agent-id-vault/lib/trusted-input.mjs";
 import { collectViaForm } from "@alien-id/agent-id-core/lib/secure-form.mjs";
+// The QR renderer is a CommonJS module vendored in agent-id-core. Imported
+// statically, not via createRequire: `bun build --compile` resolves imports at
+// bundle time, but leaves createRequire to a runtime node_modules lookup that
+// does not exist inside the single-file binary.
+import qrcode from "@alien-id/agent-id-core/bin/qrcode.cjs";
 
 import { createProxy, DEFAULT_IDLE_TIMEOUT_MS } from "../lib/proxy.mjs";
 import { loadOauthSecretsFile } from "../lib/oauth.mjs";
 import { buildPairingPayload, pickReachableHost } from "../lib/pairing.mjs";
 import { normalizeFingerprint } from "../lib/control-tls.mjs";
-
-// The QR renderer is a CommonJS module vendored in agent-id-core.
-const qrcode = createRequire(import.meta.url)("@alien-id/agent-id-core/bin/qrcode.cjs");
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 


### PR DESCRIPTION
Prepares the three Node-free plugins for the microVM rootfs: one static
linux/amd64 binary each, published on a `v*` tag.

## `bun build --compile`

`agent-id-core`, `agent-id-vault` and `agent-id-proxy` are pure `.mjs` with no
external npm deps, so they compile as-is. `agent-id-browser` is untouched — its
`patchright` dependency is a real runtime install.

## qrcode fix

`createRequire(import.meta.url)("@alien-id/agent-id-core/bin/qrcode.cjs")` is
**not** resolved by the bundler. The compiled proxy died at startup on every
subcommand:

```
error: Cannot find module '@alien-id/agent-id-core/bin/qrcode.cjs' from '/$bunfs/root/agent-id-proxy'
```

Replaced with a static `import qrcode from "@alien-id/agent-id-core/bin/qrcode.cjs"`
— which is already how `agent-id-core`'s own CLI imports it. Node keeps working
(CJS `module.exports` becomes the default export).

## Release workflow

`.github/workflows/release-binaries.yml`, on `v*` tags, mirroring alien-id/envd:
build, smoke test, `sha256sum`, `gh release create`. Assets are
`agent-id-{core,vault,proxy}` plus a `.sha256` each — node-agent pins a version
and verifies the digest, so the names must stay stable.

Independent of the changesets pipeline, which tags per package
(`@alien-id/agent-id-core@x.y.z`) and never pushes `v*`.

## Verified

Everything below ran in a bare `ubuntu:24.04` container with no Node and no
node_modules, against the compiled linux/amd64 binaries:

- `--help` on all three
- `agent-id-core init`, `agent-id-vault init --dev` / `add` / `list`
- `agent-id-proxy start` / `status` / `stop`
- `agent-id-proxy pair` — renders the QR, i.e. the fixed path actually executes

`bun run test` passes (655/655), and `node plugins/agent-id-proxy/bin/cli.mjs`
still runs.