### PR TITLE
fix(browser): AGENT_ID_FFMPEG counts as codec provisioning (strict 4002 on immutable images)

### DIFF
--- a/.changeset/env-provisioned-h264.md
+++ b/.changeset/env-provisioned-h264.md
@@ -1,0 +1,5 @@
+---
+"@alien-id/agent-id-browser": minor
+---
+
+`AGENT_ID_FFMPEG` now counts as codec provisioning: `loadCodecConfig` falls back to probing the env override when no `browser-codecs.json` record exists, so an immutable container image (which cannot pre-write per-tenant state) provisions H.264 by baking ffmpeg and setting the env var. `codec=auto` resolves to h264 and `strict=1` handshakes succeed on such hosts; a broken override degrades to unprovisioned exactly like a stale record, and nothing is probed on a host that set neither.

--- a/docs/BROWSER-STREAM.md
+++ b/docs/BROWSER-STREAM.md
@@ -163,10 +163,16 @@ probes for a usable ffmpeg (`AGENT_ID_FFMPEG` → `PATH` → a previously
 downloaded copy), on Linux falls back to downloading a static build (BtbN's
 gpl build, into `<stateDir>/tools/ffmpeg`), verifies an H.264 encoder exists,
 and records `<stateDir>/browser-codecs.json`. Sessions load that record at
-startup; only then does `codec=auto` resolve to h264 (`h264Available: true`
-in status). An unprovisioned host never spawns ffmpeg implicitly — explicit
-`?codec=h264` still probes `PATH`, and a failed probe falls back to jpeg with
-a status notice.
+startup — **or, when no record exists, the `AGENT_ID_FFMPEG` env override,
+probed live**: setting the env var is the same explicit host-level opt-in the
+record represents, and it is the only provisioning channel an immutable
+container image has (`install-codecs` writes per-tenant state an image cannot
+pre-write). Either form makes `codec=auto` resolve to h264
+(`h264Available: true` in status) and lets a `strict=1` handshake succeed. A
+host with neither never spawns ffmpeg implicitly; a broken override is
+re-verified like a stale record and degrades to unprovisioned — non-strict
+h264 viewers then fall back to jpeg with a status notice, strict ones are
+refused with close 4002.
 
 Encoder selection: `libx264` when the ffmpeg build has it (typical container
 images; `-preset ultrafast -tune zerolatency`), else `libopenh264` (Cisco's

--- a/plugins/agent-id-browser/lib/stream-encoder.mjs
+++ b/plugins/agent-id-browser/lib/stream-encoder.mjs
@@ -36,12 +36,33 @@ const GOP = 30;
 
 export const codecConfigPath = (stateDir) => path.join(stateDir, "browser-codecs.json");
 
-/** The provisioned codec record, re-verified against the binary, or null. */
+/**
+ * The codec provisioning for this host: the `install-codecs` record from
+ * stateDir, re-verified against the binary — or, when no record exists, the
+ * host-level `AGENT_ID_FFMPEG` override, probed live. Null only when neither
+ * provisions the host.
+ *
+ * The env fallback is what makes an immutable-image host provisionable at
+ * all: `install-codecs` writes into a per-tenant stateDir, but a container
+ * image is shared across every tenant and cannot pre-write per-tenant files —
+ * the one host-level channel an image has is an env var. Setting
+ * AGENT_ID_FFMPEG is the same explicit operator opt-in the record represents
+ * (nothing is probed on a host that set neither), and the probe re-verifies
+ * the binary the same way a record is re-verified, so a stale override
+ * degrades to unprovisioned rather than to a broken encoder. Deliberately
+ * NOT persisted back into stateDir: the env is authoritative per-process,
+ * and a written record would outlive an image whose ffmpeg moved.
+ */
 export async function loadCodecConfig(stateDir) {
   try {
     const cfg = JSON.parse(await fsp.readFile(codecConfigPath(stateDir), "utf8"));
     if (cfg?.ffmpegPath && (await detectH264Encoder(cfg.ffmpegPath))) return cfg;
   } catch { /* absent or stale */ }
+  const envPath = process.env.AGENT_ID_FFMPEG;
+  if (envPath) {
+    const encoder = await detectH264Encoder(envPath);
+    if (encoder) return { ffmpegPath: envPath, encoder, source: "env" };
+  }
   return null;
 }
 

--- a/tests/test-browser-stream.mjs
+++ b/tests/test-browser-stream.mjs
@@ -403,6 +403,53 @@ test("install-codecs records a probed system ffmpeg", async (t) => {
   fsSync.rmSync(stateDir, { recursive: true, force: true });
 });
 
+test("loadCodecConfig falls back to AGENT_ID_FFMPEG when no record exists", async (t) => {
+  const { detectH264Encoder, loadCodecConfig } =
+    await import("../plugins/agent-id-browser/lib/stream-encoder.mjs");
+  if (!(await detectH264Encoder())) return t.skip("no ffmpeg h264 encoder on this machine");
+  const os = await import("node:os");
+  const path = await import("node:path");
+  const fsSync = await import("node:fs");
+  const stateDir = fsSync.mkdtempSync(path.join(os.tmpdir(), "codecs-env-"));
+  const prevEnv = process.env.AGENT_ID_FFMPEG;
+  process.env.AGENT_ID_FFMPEG = prevEnv || "ffmpeg";
+  try {
+    const cfg = await loadCodecConfig(stateDir);
+    assert.ok(cfg, "an env-provisioned host must load a codec config");
+    assert.equal(cfg.source, "env");
+    assert.ok(cfg.encoder);
+    // The env override is per-process truth — it must NOT be written back as
+    // a per-tenant record that would outlive an image whose ffmpeg moved.
+    assert.equal(fsSync.existsSync(path.join(stateDir, "browser-codecs.json")), false);
+  } finally {
+    if (prevEnv === undefined) delete process.env.AGENT_ID_FFMPEG;
+    else process.env.AGENT_ID_FFMPEG = prevEnv;
+    fsSync.rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("loadCodecConfig stays null when neither record nor env provisions", async () => {
+  const { loadCodecConfig } =
+    await import("../plugins/agent-id-browser/lib/stream-encoder.mjs");
+  const os = await import("node:os");
+  const path = await import("node:path");
+  const fsSync = await import("node:fs");
+  const stateDir = fsSync.mkdtempSync(path.join(os.tmpdir(), "codecs-none-"));
+  const prevEnv = process.env.AGENT_ID_FFMPEG;
+  try {
+    delete process.env.AGENT_ID_FFMPEG;
+    assert.equal(await loadCodecConfig(stateDir), null);
+    // A broken override is not provisioning: the probe re-verifies the
+    // binary exactly like a stale record, and degrades to unprovisioned.
+    process.env.AGENT_ID_FFMPEG = path.join(stateDir, "no-such-ffmpeg");
+    assert.equal(await loadCodecConfig(stateDir), null);
+  } finally {
+    if (prevEnv === undefined) delete process.env.AGENT_ID_FFMPEG;
+    else process.env.AGENT_ID_FFMPEG = prevEnv;
+    fsSync.rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
 test("codec=h264 end-to-end: Annex-B chunks with AUD/SPS/IDR arrive", async (t) => {
   const { detectH264Encoder } = await import("../plugins/agent-id-browser/lib/stream-encoder.mjs");
   if (!(await detectH264Encoder())) return t.skip("no ffmpeg h264 encoder on this machine");


### PR DESCRIPTION
Approved by @atemerev.

## The incident

First e2e of a strict H.264 viewer against a hosted multi-tenant deployment: every `codec=h264&strict=1` handshake was refused with close **4002** and the client showed its terminal "provisioning is broken" state. The host had a working ffmpeg (libx264) and `AGENT_ID_FFMPEG` set in its immutable image — yet the daemon called it unprovisioned.

## Root cause

#94's strict gate keys **only** on the `install-codecs` record: `stream-server.mjs` refuses when `!h264Config`, and `h264Config` comes from `loadCodecConfig(stateDir)` = `browser-codecs.json` in the **per-state-dir** record. On a multi-tenant host that file existed for zero tenants — nothing in a hosted flow runs `install-codecs`, and nothing sensibly can: the stateDir is per-tenant mutable state, while the encoder is a host property of a **shared, immutable image**. The env var was honored only as an `installCodecs` probe candidate — i.e. only if something ran `install-codecs`. (The pre-#94 doc sentence "explicit `?codec=h264` still probes `PATH`" described handshake-less behavior that #94 deliberately replaced — the doc is updated here too.)

## The fix

`loadCodecConfig` falls back to probing `AGENT_ID_FFMPEG` when no record exists:

- **The env var is provisioning.** It is the same explicit, host-level operator opt-in the record represents — and the only channel an immutable image has (`install-codecs` cannot pre-write per-tenant files at build time). Nothing is probed on a host that set neither — the "never spawn ffmpeg implicitly" property is intact.
- **Record wins over env** when both exist: an owner-machine install (possibly the downloaded static build in `<stateDir>/tools`) stays authoritative.
- **A broken override degrades to unprovisioned**, exactly like a stale record: the probe re-verifies the binary (`ffmpeg -encoders`, cached per path), so strict clients get the honest 4002 and non-strict fall back to jpeg — never a spawn-and-die encoder.
- **Deliberately not persisted** into stateDir: the env is per-process truth; a written record would outlive an image whose ffmpeg path changed and turn one stale deploy into per-tenant stale state.
- Side effect that's a feature: `codec=auto` (the bundled web viewer) now also resolves to h264 on env-provisioned hosts (`h264Available: true`).

## Verification

- New: `loadCodecConfig falls back to AGENT_ID_FFMPEG when no record exists` (asserts `source: "env"` and that nothing is written to stateDir) and `stays null when neither record nor env provisions` (unset env AND broken-path env).
- Pre-existing guards still green: record-wins/stale-record self-heal, and `codec=h264 without a usable ffmpeg falls back to jpeg with a status` (broken env → null, unchanged behavior).
- Full suite: **657/657**.

Changeset included (`agent-id-browser` minor). Downstream images that already bake ffmpeg + `AGENT_ID_FFMPEG` need only a ref bump.
