### PR TITLE
fix(browser): authenticate session liveness with a token handshake

### DIFF
--- a/.changeset/env-provisioned-h264.md
+++ b/.changeset/env-provisioned-h264.md
@@ -1,0 +1,5 @@
+---
+"@alien-id/agent-id-browser": minor
+---
+
+`AGENT_ID_FFMPEG` now counts as codec provisioning: `loadCodecConfig` falls back to probing the env override when no `browser-codecs.json` record exists, so an immutable container image (which cannot pre-write per-tenant state) provisions H.264 by baking ffmpeg and setting the env var. `codec=auto` resolves to h264 and `strict=1` handshakes succeed on such hosts; a broken override degrades to unprovisioned exactly like a stale record, and nothing is probed on a host that set neither.

--- a/.changeset/session-probe-auth.md
+++ b/.changeset/session-probe-auth.md
@@ -1,0 +1,12 @@
+---
+"@alien-id/agent-id-browser": patch
+---
+
+Session liveness is now authenticated: `pruneDeadSessions` follows the pid
+check with a one-line token handshake against the session's control port
+(new `probeSession` helper). On hosts where the state dir outlives the
+container, a leftover session file's pid and port are routinely recycled to
+unrelated processes — the pid answer alone then calls a dead session alive,
+while a listener that rejects the token proves the daemon is gone. No reply
+within the budget keeps the file (a busy daemon answers late); files without
+control coordinates keep the pid-only behavior.

--- a/docs/BROWSER-STREAM.md
+++ b/docs/BROWSER-STREAM.md
@@ -163,10 +163,16 @@ probes for a usable ffmpeg (`AGENT_ID_FFMPEG` → `PATH` → a previously
 downloaded copy), on Linux falls back to downloading a static build (BtbN's
 gpl build, into `<stateDir>/tools/ffmpeg`), verifies an H.264 encoder exists,
 and records `<stateDir>/browser-codecs.json`. Sessions load that record at
-startup; only then does `codec=auto` resolve to h264 (`h264Available: true`
-in status). An unprovisioned host never spawns ffmpeg implicitly — explicit
-`?codec=h264` still probes `PATH`, and a failed probe falls back to jpeg with
-a status notice.
+startup — **or, when no record exists, the `AGENT_ID_FFMPEG` env override,
+probed live**: setting the env var is the same explicit host-level opt-in the
+record represents, and it is the only provisioning channel an immutable
+container image has (`install-codecs` writes per-tenant state an image cannot
+pre-write). Either form makes `codec=auto` resolve to h264
+(`h264Available: true` in status) and lets a `strict=1` handshake succeed. A
+host with neither never spawns ffmpeg implicitly; a broken override is
+re-verified like a stale record and degrades to unprovisioned — non-strict
+h264 viewers then fall back to jpeg with a status notice, strict ones are
+refused with close 4002.
 
 Encoder selection: `libx264` when the ffmpeg build has it (typical container
 images; `-preset ultrafast -tune zerolatency`), else `libopenh264` (Cisco's

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -61,6 +61,11 @@ export function sessionFilePath(stateDir, name) {
 // nothing and only asks the question, and it answers it on every platform we
 // run on (a /proc probe does not — desktop is macOS). EPERM means the pid
 // exists and belongs to someone else, which still counts as alive.
+//
+// This is only the cheap first gate. On hosts where the state dir outlives the
+// container, a leftover file's pid routinely collides with some unrelated live
+// process in the fresh PID namespace — the pid answer alone then calls a dead
+// session alive. Callers that must be sure follow up with probeSession().
 export function sessionAlive(info) {
   const pid = Number(info?.pid);
   if (!Number.isInteger(pid) || pid <= 0) return false;
@@ -70,6 +75,53 @@ export function sessionAlive(info) {
   } catch (err) {
     return err?.code === "EPERM";
   }
+}
+
+// Does the daemon that wrote this session file ANSWER for it? Speaks one line
+// of the control protocol — `{token, action: "info"}` — and classifies the
+// outcome. Only the daemon that wrote the file holds this token, so `ok: true`
+// proves identity where a pid or a connectable port cannot: both are recycled
+// by the OS and can belong to a stranger.
+//
+//   "ours"   — replied ok:true: the session's own daemon.
+//   "gone"   — nothing listening, connection dropped, or the token was
+//              rejected (a stranger on a recycled port).
+//   "unsure" — could not disprove: connected but no reply line in time (a
+//              daemon mid-action answers late), or the file predates the
+//              control server and carries nothing to speak to.
+export function probeSession(info, timeoutMs = 450) {
+  return new Promise((resolve) => {
+    const port = Number(info?.port);
+    if (!Number.isInteger(port) || port <= 0 || !info?.token) return resolve("unsure");
+    const sock = net.connect(port, "127.0.0.1");
+    let buf = "";
+    let settled = false;
+    const finish = (verdict) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      sock.destroy();
+      resolve(verdict);
+    };
+    const timer = setTimeout(() => finish("unsure"), timeoutMs);
+    sock.on("connect", () => {
+      sock.write(JSON.stringify({ token: info.token, action: "info" }) + "\n");
+    });
+    sock.on("data", (d) => {
+      buf += d.toString("utf8");
+      const nl = buf.indexOf("\n");
+      if (nl < 0) return;
+      let reply;
+      try {
+        reply = JSON.parse(buf.slice(0, nl));
+      } catch {
+        return finish("gone");
+      }
+      finish(reply?.ok === true ? "ours" : "gone");
+    });
+    sock.on("error", () => finish("gone"));
+    sock.on("close", () => finish("gone"));
+  });
 }
 
 // Drop session files whose daemon is gone. A clean `close` reseals and removes
@@ -94,7 +146,11 @@ export async function pruneDeadSessions(stateDir) {
     const file = path.join(sessionsDir(stateDir), entry);
     try {
       const info = JSON.parse(await fs.readFile(file, "utf8"));
-      if (sessionAlive(info)) {
+      // The pid gate alone false-positives on recycled pids (see
+      // sessionAlive); only a token handshake proves the daemon behind the
+      // file is the one answering. "unsure" keeps the file: pruning a LIVE
+      // session's registration would orphan its unsealed profile.
+      if (sessionAlive(info) && (await probeSession(info)) !== "gone") {
         live.add(name);
         continue;
       }

--- a/plugins/agent-id-browser/lib/stream-encoder.mjs
+++ b/plugins/agent-id-browser/lib/stream-encoder.mjs
@@ -36,12 +36,33 @@ const GOP = 30;
 
 export const codecConfigPath = (stateDir) => path.join(stateDir, "browser-codecs.json");
 
-/** The provisioned codec record, re-verified against the binary, or null. */
+/**
+ * The codec provisioning for this host: the `install-codecs` record from
+ * stateDir, re-verified against the binary — or, when no record exists, the
+ * host-level `AGENT_ID_FFMPEG` override, probed live. Null only when neither
+ * provisions the host.
+ *
+ * The env fallback is what makes an immutable-image host provisionable at
+ * all: `install-codecs` writes into a per-tenant stateDir, but a container
+ * image is shared across every tenant and cannot pre-write per-tenant files —
+ * the one host-level channel an image has is an env var. Setting
+ * AGENT_ID_FFMPEG is the same explicit operator opt-in the record represents
+ * (nothing is probed on a host that set neither), and the probe re-verifies
+ * the binary the same way a record is re-verified, so a stale override
+ * degrades to unprovisioned rather than to a broken encoder. Deliberately
+ * NOT persisted back into stateDir: the env is authoritative per-process,
+ * and a written record would outlive an image whose ffmpeg moved.
+ */
 export async function loadCodecConfig(stateDir) {
   try {
     const cfg = JSON.parse(await fsp.readFile(codecConfigPath(stateDir), "utf8"));
     if (cfg?.ffmpegPath && (await detectH264Encoder(cfg.ffmpegPath))) return cfg;
   } catch { /* absent or stale */ }
+  const envPath = process.env.AGENT_ID_FFMPEG;
+  if (envPath) {
+    const encoder = await detectH264Encoder(envPath);
+    if (encoder) return { ffmpegPath: envPath, encoder, source: "env" };
+  }
   return null;
 }
 

--- a/tests/test-browser-session-helpers.mjs
+++ b/tests/test-browser-session-helpers.mjs
@@ -14,11 +14,13 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import os from "node:os";
+import net from "node:net";
 import path from "node:path";
 
 import {
   chromeCompensatedBounds,
   frameRefId,
+  probeSession,
   pruneDeadSessions,
   refuseRef,
   safeFilename,
@@ -141,17 +143,80 @@ test("sessionAlive: this process is alive, an absurd pid is not", () => {
   assert.equal(sessionAlive(null), false);
 });
 
-test("pruneDeadSessions: drops orphans, keeps live sessions and young work dirs", async () => {
+// A stand-in for the daemon's control server: reads one line per connection
+// and answers with the daemon's own token rule — ok:true for a match, "bad
+// token" otherwise. Returns { port, close }.
+function daemonStub(expectedToken) {
+  const server = net.createServer((sock) => {
+    let buf = "";
+    sock.on("data", (d) => {
+      buf += d.toString("utf8");
+      const nl = buf.indexOf("\n");
+      if (nl < 0) return;
+      let msg;
+      try {
+        msg = JSON.parse(buf.slice(0, nl));
+      } catch {
+        sock.end(JSON.stringify({ ok: false, error: "bad json" }) + "\n");
+        return;
+      }
+      const reply =
+        msg.token === expectedToken
+          ? { ok: true, url: "about:blank", title: "", tabs: 1 }
+          : { ok: false, error: "bad token" };
+      sock.end(JSON.stringify(reply) + "\n");
+    });
+    sock.on("error", () => {});
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      resolve({ port: server.address().port, close: () => server.close() });
+    });
+  });
+}
+
+test("probeSession: token identity, not connectability, decides the verdict", async (t) => {
+  const stub = await daemonStub("right-token");
+  t.after(() => stub.close());
+  assert.equal(await probeSession({ port: stub.port, token: "right-token" }), "ours");
+  // The incident shape: the port answers, but it is not this session's
+  // daemon — a recycled port after a container restart.
+  assert.equal(await probeSession({ port: stub.port, token: "stale-token" }), "gone");
+  // Nothing listening at all.
+  const vacated = await daemonStub("x");
+  vacated.close();
+  assert.equal(await probeSession({ port: vacated.port, token: "x" }), "gone");
+  // No control coordinates: nothing to disprove with.
+  assert.equal(await probeSession({ pid: process.pid }), "unsure");
+  // A listener that never answers is not proof of death.
+  const silent = net.createServer(() => {});
+  await new Promise((r) => silent.listen(0, "127.0.0.1", r));
+  t.after(() => silent.close());
+  assert.equal(
+    await probeSession({ port: silent.address().port, token: "x" }, 200),
+    "unsure",
+  );
+});
+
+test("pruneDeadSessions: drops orphans, keeps live sessions and young work dirs", async (t) => {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "aid-prune-"));
   const sessions = path.join(dir, "browser-sessions");
   await fs.mkdir(sessions, { recursive: true });
+  const stub = await daemonStub("live-token");
+  t.after(() => stub.close());
+  t.after(() => fs.rm(dir, { recursive: true, force: true }));
 
   const write = (name, info) =>
     fs.writeFile(path.join(sessions, `${name}.json`), JSON.stringify(info));
   // A dead daemon with the NEWEST startedAt — the shape that hijacks a viewer
   // picking "the newest session advertising a stream".
   await write("dead", { pid: 0x7ffffff, startedAt: Date.now() + 1e6, streamPort: 1 });
-  await write("live", { pid: process.pid, startedAt: 1, streamPort: 2 });
+  await write("live", { pid: process.pid, startedAt: 1, streamPort: 2, port: stub.port, token: "live-token" });
+  // A live pid whose port is answered by a STRANGER (recycled port after a
+  // container restart): the token handshake is what unmasks it.
+  await write("impostor", { pid: process.pid, startedAt: 2, streamPort: 3, port: stub.port, token: "someone-elses-token" });
+  // No control coordinates at all: the pid answer is all there is — kept.
+  await write("legacy", { pid: process.pid, startedAt: 3, streamPort: 4 });
   await fs.writeFile(path.join(sessions, "junk.json"), "not json");
   // Work dirs: one orphaned and old, one orphaned but fresh (a launch in
   // flight), one belonging to the live session.
@@ -165,8 +230,8 @@ test("pruneDeadSessions: drops orphans, keeps live sessions and young work dirs"
   const pruned = await pruneDeadSessions(dir);
 
   const left = (await fs.readdir(sessions)).sort();
-  assert.deepEqual(left, ["fresh.work", "junk.json", "live.json", "live.work"]);
+  assert.deepEqual(left, ["fresh.work", "junk.json", "legacy.json", "live.json", "live.work"]);
   assert.ok(pruned.includes("dead"));
+  assert.ok(pruned.includes("impostor"));
   assert.ok(pruned.includes("dead.work"));
-  await fs.rm(dir, { recursive: true, force: true });
 });

--- a/tests/test-browser-stream.mjs
+++ b/tests/test-browser-stream.mjs
@@ -403,6 +403,53 @@ test("install-codecs records a probed system ffmpeg", async (t) => {
   fsSync.rmSync(stateDir, { recursive: true, force: true });
 });
 
+test("loadCodecConfig falls back to AGENT_ID_FFMPEG when no record exists", async (t) => {
+  const { detectH264Encoder, loadCodecConfig } =
+    await import("../plugins/agent-id-browser/lib/stream-encoder.mjs");
+  if (!(await detectH264Encoder())) return t.skip("no ffmpeg h264 encoder on this machine");
+  const os = await import("node:os");
+  const path = await import("node:path");
+  const fsSync = await import("node:fs");
+  const stateDir = fsSync.mkdtempSync(path.join(os.tmpdir(), "codecs-env-"));
+  const prevEnv = process.env.AGENT_ID_FFMPEG;
+  process.env.AGENT_ID_FFMPEG = prevEnv || "ffmpeg";
+  try {
+    const cfg = await loadCodecConfig(stateDir);
+    assert.ok(cfg, "an env-provisioned host must load a codec config");
+    assert.equal(cfg.source, "env");
+    assert.ok(cfg.encoder);
+    // The env override is per-process truth — it must NOT be written back as
+    // a per-tenant record that would outlive an image whose ffmpeg moved.
+    assert.equal(fsSync.existsSync(path.join(stateDir, "browser-codecs.json")), false);
+  } finally {
+    if (prevEnv === undefined) delete process.env.AGENT_ID_FFMPEG;
+    else process.env.AGENT_ID_FFMPEG = prevEnv;
+    fsSync.rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("loadCodecConfig stays null when neither record nor env provisions", async () => {
+  const { loadCodecConfig } =
+    await import("../plugins/agent-id-browser/lib/stream-encoder.mjs");
+  const os = await import("node:os");
+  const path = await import("node:path");
+  const fsSync = await import("node:fs");
+  const stateDir = fsSync.mkdtempSync(path.join(os.tmpdir(), "codecs-none-"));
+  const prevEnv = process.env.AGENT_ID_FFMPEG;
+  try {
+    delete process.env.AGENT_ID_FFMPEG;
+    assert.equal(await loadCodecConfig(stateDir), null);
+    // A broken override is not provisioning: the probe re-verifies the
+    // binary exactly like a stale record, and degrades to unprovisioned.
+    process.env.AGENT_ID_FFMPEG = path.join(stateDir, "no-such-ffmpeg");
+    assert.equal(await loadCodecConfig(stateDir), null);
+  } finally {
+    if (prevEnv === undefined) delete process.env.AGENT_ID_FFMPEG;
+    else process.env.AGENT_ID_FFMPEG = prevEnv;
+    fsSync.rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
 test("codec=h264 end-to-end: Annex-B chunks with AUD/SPS/IDR arrive", async (t) => {
   const { detectH264Encoder } = await import("../plugins/agent-id-browser/lib/stream-encoder.mjs");
   if (!(await detectH264Encoder())) return t.skip("no ffmpeg h264 encoder on this machine");


### PR DESCRIPTION
## Problem

`pruneDeadSessions` decides a session daemon is alive from `kill(pid, 0)` alone. On hosts where the state dir outlives the container (state on a persistent volume), a leftover session file's pid is routinely recycled to some unrelated live process in the fresh PID namespace — and its port to some other listener. The pid answer then keeps a dead session's file: `status` reports a session nobody is behind, viewers discover and dial it, and the stale `.work` dir (unsealed profile) is never cleaned up.

## Fix

New `probeSession(info)` speaks one line of the daemon's own control protocol — `{token, action: "info"}` — and classifies the reply:

- `"ours"` — replied `ok: true`: only the daemon that wrote the file holds this token.
- `"gone"` — nothing listening, connection dropped, or the token was rejected (a stranger on a recycled port). Pruned.
- `"unsure"` — no reply within the budget (a daemon mid-action answers late) or the file predates the control server. Kept: pruning a live-but-busy session's registration would orphan its unsealed profile.

`pruneDeadSessions` keeps the cheap pid gate as the first check and prunes only on a definitive `"gone"` — the change can only remove false-positives, never newly kill a live session.

## Verification

- New tests: token identity decides the verdict (right token → ours, wrong token on the same live port → gone, vacated port → gone, silent listener → unsure, no coordinates → unsure); prune drops the impostor shape (live pid + foreign listener) while keeping the real session and legacy files. 14/14 green.
- Mutation-checked: reverting the handshake (pid-only prune) while keeping the tests turns the impostor test red.
- Conformance against a real daemon: `probeSession` run against a live `open --bootstrap-profile` session returns `ours`, and `gone` for a forged token; `pruneDeadSessions` keeps the live session. Probe latency on the real daemon: idle max 1.2 ms, max 37.4 ms during an in-flight navigate — well inside the 450 ms default budget.