### PR TITLE
fix(browser): viewport stream stops looking over-compressed

### DIFF
--- a/.changeset/stream-quality-tuning.md
+++ b/.changeset/stream-quality-tuning.md
@@ -1,0 +1,12 @@
+---
+"@alien-id/agent-id-browser": patch
+---
+
+Viewport stream quality: screencast motion frames go out at JPEG quality 80
+(was 55 — visible ringing around text that the H.264 stage then spent bits
+reproducing), and the libx264 path encodes at veryfast/CRF 20 with a 4M/8M
+rate cap instead of ultrafast with defaults (~2x quality per bit, latency
+unchanged). The openh264 fallback's bitrate rises to 4000k/6000k for parity.
+Profile stays constrained-baseline — the WebCodecs viewer and the WebRTC path
+pin avc1.42E01F. Traffic is roughly unchanged: the pipeline is change-driven,
+and CRF only spends bits while the picture moves.

--- a/plugins/agent-id-browser/lib/stream-encoder.mjs
+++ b/plugins/agent-id-browser/lib/stream-encoder.mjs
@@ -145,12 +145,22 @@ function codecArgs(encoder) {
   // yuv420p needs even dimensions; screencast frames can be odd-sized.
   const scale = ["-vf", "scale=trunc(iw/2)*2:trunc(ih/2)*2"];
   if (encoder === "libx264") {
+    // veryfast/CRF over ultrafast/defaults: roughly 2x the quality per bit,
+    // still comfortably realtime for a viewport-sized feed. zerolatency keeps
+    // lookahead off so latency is unchanged; CRF spends bits only when the
+    // picture moves and the maxrate cap bounds worst-case bursts. The profile
+    // stays constrained-baseline on purpose — the WebCodecs viewer and the
+    // WebRTC path both pin avc1.42E01F, and that contract is what guarantees
+    // every consumer decodes the feed.
     return [
       ...scale,
       "-c:v", "libx264",
-      "-preset", "ultrafast",
+      "-preset", "veryfast",
       "-tune", "zerolatency",
       "-profile:v", "baseline",
+      "-crf", "20",
+      "-maxrate", "4M",
+      "-bufsize", "8M",
       "-pix_fmt", "yuv420p",
       "-g", String(GOP),
       "-bf", "0",
@@ -164,8 +174,8 @@ function codecArgs(encoder) {
     "-profile:v", "constrained_baseline",
     "-pix_fmt", "yuv420p",
     "-g", String(GOP),
-    "-b:v", "1500k",
-    "-maxrate", "2500k",
+    "-b:v", "4000k",
+    "-maxrate", "6000k",
   ];
 }
 

--- a/plugins/agent-id-browser/lib/stream-server.mjs
+++ b/plugins/agent-id-browser/lib/stream-server.mjs
@@ -73,9 +73,12 @@ function envInt(name, fallback, min, max) {
   return Math.min(max, Math.max(min, Math.floor(n)));
 }
 
-// Motion frames run lean; the idle refinement frame carries the visual quality
-// (0 disables refinement). Bind is overridable ONLY for LAN viewer testing.
-const STREAM_QUALITY = envInt("AGENT_ID_STREAM_QUALITY", 55, 1, 100);
+// Motion frames at 80: at >=80 the JPEG artifacts sit below what the H.264
+// stage preserves anyway, so the double compression stops being visible — 55
+// produced ringing around text that the encoder then spent bits reproducing.
+// The idle refinement frame still carries the top visual quality (0 disables
+// refinement). Bind is overridable ONLY for LAN viewer testing.
+const STREAM_QUALITY = envInt("AGENT_ID_STREAM_QUALITY", 80, 1, 100);
 const REFINE_QUALITY = envInt("AGENT_ID_STREAM_REFINE_QUALITY", 90, 0, 100);
 // Watchdog: with a viewer attached and nothing arriving for this long, restart
 // the screencast (0 disables). Refinement is NOT a substitute — it is armed by


### PR DESCRIPTION
Two compounding lossy stages made the live viewport look badly over-compressed:

1. **Screencast JPEG at quality 55** — visible ringing/blocking around text, which the H.264 stage then faithfully re-encoded, wasting bits on artifacts. Motion frames now go out at **80** (env `AGENT_ID_STREAM_QUALITY` still overrides); at ≥80 the JPEG artifacts sit below what the H.264 stage preserves, so the double compression stops being visible. The idle refinement frame (quality 90) is unchanged.
2. **libx264 at `ultrafast` with implicit defaults** — the worst quality-per-bit preset. Now **`veryfast` + CRF 20 + `-maxrate 4M -bufsize 8M`**: ~2× quality per bit, `zerolatency` untouched so latency is unchanged, and the cap bounds worst-case bursts. The **openh264 fallback** rises 1500k/2500k → **4000k/6000k** for parity.

**Deliberately NOT changed:** the profile stays constrained-baseline — `stream-viewer.html` (WebCodecs) and the WebRTC path both pin `avc1.42E01F`, and that contract is what guarantees every consumer decodes the feed.

**Traffic:** roughly unchanged. The pipeline is change-driven — a static page streams next to nothing — and CRF spends bits only while the picture moves; the JPEG stage is process-internal and never crosses the network.

Tests: full suite 658/658 green locally; both files `node --check` clean.