### PR TITLE
feat(browser): driven sessions report WebAuthn unsupported — passkey sign-ins fall back instead of hanging

### DIFF
--- a/.changeset/webauthn-off-driven-sessions.md
+++ b/.changeset/webauthn-off-driven-sessions.md
@@ -6,11 +6,14 @@ Driven sessions now report WebAuthn as unsupported (#99). The driven browser
 has no authenticator, so a passkey ceremony could only hang — and while one is
 pending, the page's own fallback links ("Try another way") are inert, so a
 sign-in against a passkey-enrolled account dead-ended. An init script now
-removes `window.PublicKeyCredential` before any page script runs (sites
-feature-detect it and offer their password/OTP path up front, exactly as for a
-legacy browser) and rejects any `publicKey` get/create issued anyway with an
-immediate `NotAllowedError` — the cancellation outcome every WebAuthn call
-site already handles. Non-publicKey credential calls pass through untouched.
+removes the WebAuthn interface globals (`PublicKeyCredential` and its response
+types) before any page script runs (sites feature-detect them and offer their
+password/OTP path up front, exactly as for a legacy browser) and rejects any
+`publicKey` get/create issued anyway with an immediate `NotAllowedError` — the
+cancellation outcome every WebAuthn call site already handles. The override is
+a Proxy over the native function, so `credentials.get.toString()` still reports
+`[native code]` and the JS surface stays byte-for-byte native. Non-publicKey
+credential calls pass through untouched.
 Headed `login` keeps WebAuthn native (the owner's real Chrome may hold a
 platform authenticator), and `AGENT_ID_BROWSER_KEEP_WEBAUTHN=1` restores
 native WebAuthn in driven sessions for the rare passkey-only site.

--- a/.changeset/webauthn-off-driven-sessions.md
+++ b/.changeset/webauthn-off-driven-sessions.md
@@ -1,0 +1,16 @@
+---
+"@alien-id/agent-id-browser": minor
+---
+
+Driven sessions now report WebAuthn as unsupported (#99). The driven browser
+has no authenticator, so a passkey ceremony could only hang — and while one is
+pending, the page's own fallback links ("Try another way") are inert, so a
+sign-in against a passkey-enrolled account dead-ended. An init script now
+removes `window.PublicKeyCredential` before any page script runs (sites
+feature-detect it and offer their password/OTP path up front, exactly as for a
+legacy browser) and rejects any `publicKey` get/create issued anyway with an
+immediate `NotAllowedError` — the cancellation outcome every WebAuthn call
+site already handles. Non-publicKey credential calls pass through untouched.
+Headed `login` keeps WebAuthn native (the owner's real Chrome may hold a
+platform authenticator), and `AGENT_ID_BROWSER_KEEP_WEBAUTHN=1` restores
+native WebAuthn in driven sessions for the rare passkey-only site.

--- a/plugins/agent-id-browser/bin/cli.mjs
+++ b/plugins/agent-id-browser/bin/cli.mjs
@@ -313,7 +313,9 @@ async function cmdLogin(flags) {
       const headlessDefault =
         flags["headed-default"] === true ? false : reuse ? reuse.headless !== false : true;
 
-      const ctx = await launchContext({ profileDir: work, headless: false });
+      // The owner sits at this window — a real platform authenticator (Touch
+      // ID, a security key) may exist and complete, so WebAuthn stays native.
+      const ctx = await launchContext({ profileDir: work, headless: false, nativeWebAuthn: true });
       stderr(
         resuming
           ? `A browser opened with your '${name}' session loaded${flags.url ? " at " + startUrl : ""}. ` +

--- a/plugins/agent-id-browser/lib/launch.mjs
+++ b/plugins/agent-id-browser/lib/launch.mjs
@@ -29,6 +29,8 @@ import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
+import { suppressWebAuthn } from "./webauthn-off.mjs";
+
 const require = createRequire(import.meta.url);
 const PLUGIN_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -171,7 +173,15 @@ async function resolveHeadlessUserAgent() {
 // headless defaults to true; pass false for the one-time headed login.
 // `contextOptions` merges extra Playwright context options (e.g. the access
 // guard's serviceWorkers:"block" for read-only profiles).
-export async function launchContext({ profileDir, headless = true, contextOptions = {} }) {
+// `nativeWebAuthn: true` keeps the WebAuthn surface (headed owner login only —
+// see webauthn-off.mjs); by default a driven session reports it unsupported so
+// a passkey-enrolled sign-in falls back to password/OTP instead of hanging.
+export async function launchContext({
+  profileDir,
+  headless = true,
+  contextOptions = {},
+  nativeWebAuthn = false,
+}) {
   const chromium = await loadChromium();
   const opts = { ...launchOptions(headless), ...contextOptions };
   // Headless only: normalize the "HeadlessChrome" UA to match a headed browser.
@@ -180,5 +190,7 @@ export async function launchContext({ profileDir, headless = true, contextOption
     const ua = await resolveHeadlessUserAgent();
     if (ua) opts.userAgent = ua;
   }
-  return chromium.launchPersistentContext(profileDir, opts);
+  const ctx = await chromium.launchPersistentContext(profileDir, opts);
+  if (!nativeWebAuthn) await suppressWebAuthn(ctx);
+  return ctx;
 }

--- a/plugins/agent-id-browser/lib/webauthn-off.mjs
+++ b/plugins/agent-id-browser/lib/webauthn-off.mjs
@@ -1,0 +1,70 @@
+// Alien Agent ID — WebAuthn off-switch for driven browser sessions (#99).
+//
+// The driven browser has no platform authenticator and no CTAP transport
+// (headless Chrome, in the hosted case inside a container), so a passkey
+// ceremony a site starts can never complete: navigator.credentials.get() hangs,
+// and while it is pending the page's own fallback affordances ("Try another
+// way") are inert — a sign-in against an account with a passkey enrolled
+// (Google is the everyday case) dead-ends. Holding real passkeys via a virtual
+// authenticator is a separate track (#99's proposal); until then the browser
+// declares itself passkey-INCAPABLE — the exact surface of a legacy browser,
+// which every passkey site already handles with a password/OTP path:
+//
+//   1. `delete window.PublicKeyCredential` before any page script runs. Sites
+//      feature-detect it (and its statics — isUserVerifyingPlatformAuthenticator-
+//      Available, isConditionalMediationAvailable — go with it) before pushing
+//      a ceremony or the conditional-UI autofill, so they offer the fallback
+//      path up front and no prompt ever appears.
+//   2. CredentialsContainer.get/create with a `publicKey` argument reject
+//      immediately with NotAllowedError — the cancellation outcome every
+//      WebAuthn call site handles — covering sites that skip feature
+//      detection. Deleting the interface object alone would NOT stop the
+//      ceremony: the get/create implementation behind it still runs. Other
+//      credential types (password, federated) pass through untouched.
+//
+// This is a UX measure, not a security boundary: the page could restore the
+// natives from a fresh realm, but a sign-in page has no motive to — sites
+// treat "no WebAuthn" as the ordinary legacy-browser case.
+//
+// The headed `login` flow keeps WebAuthn native (launchContext
+// nativeWebAuthn:true): the owner sits at a real Chrome window there, where a
+// platform authenticator may genuinely exist and complete the ceremony.
+
+// Escape hatch for a site where a passkey is the ONLY way in (rare today):
+// AGENT_ID_BROWSER_KEEP_WEBAUTHN=1 keeps WebAuthn native in driven sessions
+// too. The ceremony will then hang as before — send Escape to cancel it and
+// recover the page's fallback links. Exported for tests.
+export function webauthnKept(env = process.env) {
+  return env.AGENT_ID_BROWSER_KEEP_WEBAUTHN === "1";
+}
+
+// Install the off-switch on a (patchright) BrowserContext. Returns true when
+// installed, false when the env keeps WebAuthn native.
+export async function suppressWebAuthn(ctx, env = process.env) {
+  if (webauthnKept(env)) return false;
+  await ctx.addInitScript(() => {
+    try {
+      delete window.PublicKeyCredential;
+    } catch {
+      /* locked down — the reject path below still prevents the hang */
+    }
+    const proto = window.CredentialsContainer && window.CredentialsContainer.prototype;
+    if (!proto) return;
+    for (const name of ["get", "create"]) {
+      const native = proto[name];
+      if (typeof native !== "function") continue;
+      proto[name] = function (options) {
+        if (options && typeof options === "object" && "publicKey" in options) {
+          return Promise.reject(
+            new DOMException(
+              "The operation either timed out or was not allowed.",
+              "NotAllowedError",
+            ),
+          );
+        }
+        return native.apply(this, arguments);
+      };
+    }
+  });
+  return true;
+}

--- a/plugins/agent-id-browser/lib/webauthn-off.mjs
+++ b/plugins/agent-id-browser/lib/webauthn-off.mjs
@@ -10,17 +10,28 @@
 // declares itself passkey-INCAPABLE — the exact surface of a legacy browser,
 // which every passkey site already handles with a password/OTP path:
 //
-//   1. `delete window.PublicKeyCredential` before any page script runs. Sites
-//      feature-detect it (and its statics — isUserVerifyingPlatformAuthenticator-
-//      Available, isConditionalMediationAvailable — go with it) before pushing
-//      a ceremony or the conditional-UI autofill, so they offer the fallback
-//      path up front and no prompt ever appears.
+//   1. Delete the WebAuthn interface globals before any page script runs —
+//      PublicKeyCredential AND its response types (AuthenticatorAttestation-
+//      Response, AuthenticatorAssertionResponse, AuthenticatorResponse). Sites
+//      feature-detect PublicKeyCredential (and its statics — isUserVerifying-
+//      PlatformAuthenticatorAvailable, isConditionalMediationAvailable — go
+//      with it) before pushing a ceremony or the conditional-UI autofill, so
+//      they offer the fallback path up front and no prompt ever appears. The
+//      response types go too so the surface stays consistent: a real browser
+//      never has AuthenticatorAttestationResponse without PublicKeyCredential,
+//      and that mismatch would be its own automation tell.
 //   2. CredentialsContainer.get/create with a `publicKey` argument reject
 //      immediately with NotAllowedError — the cancellation outcome every
 //      WebAuthn call site handles — covering sites that skip feature
-//      detection. Deleting the interface object alone would NOT stop the
-//      ceremony: the get/create implementation behind it still runs. Other
-//      credential types (password, federated) pass through untouched.
+//      detection. Deleting the interface globals alone would NOT stop the
+//      ceremony: the get/create implementation behind them still runs. Other
+//      credential types (password, federated) pass through untouched. The
+//      override is a Proxy over the native function, not a plain replacement,
+//      so `credentials.get.toString()` (and Function.prototype.toString) still
+//      report [native code] and `.name` stays "get" — the patch keeps the
+//      byte-for-byte-native JS surface the rest of launch.mjs invests in
+//      (UA normalization, patchright driver), rather than leaving a hand-
+//      written function an anti-bot IdP can read back.
 //
 // This is a UX measure, not a security boundary: the page could restore the
 // natives from a fresh realm, but a sign-in page has no motive to — sites
@@ -43,27 +54,40 @@ export function webauthnKept(env = process.env) {
 export async function suppressWebAuthn(ctx, env = process.env) {
   if (webauthnKept(env)) return false;
   await ctx.addInitScript(() => {
-    try {
-      delete window.PublicKeyCredential;
-    } catch {
-      /* locked down — the reject path below still prevents the hang */
+    for (const name of [
+      "PublicKeyCredential",
+      "AuthenticatorAttestationResponse",
+      "AuthenticatorAssertionResponse",
+      "AuthenticatorResponse",
+    ]) {
+      try {
+        delete window[name];
+      } catch {
+        /* locked down — the reject path below still prevents the hang */
+      }
     }
     const proto = window.CredentialsContainer && window.CredentialsContainer.prototype;
     if (!proto) return;
     for (const name of ["get", "create"]) {
       const native = proto[name];
       if (typeof native !== "function") continue;
-      proto[name] = function (options) {
-        if (options && typeof options === "object" && "publicKey" in options) {
-          return Promise.reject(
-            new DOMException(
-              "The operation either timed out or was not allowed.",
-              "NotAllowedError",
-            ),
-          );
-        }
-        return native.apply(this, arguments);
-      };
+      // A Proxy over the native function forwards toString/name/length to the
+      // target, so the override is indistinguishable from native to a page —
+      // unlike a replacement function, whose source a script can read back.
+      proto[name] = new Proxy(native, {
+        apply(target, thisArg, argList) {
+          const options = argList[0];
+          if (options && typeof options === "object" && "publicKey" in options) {
+            return Promise.reject(
+              new DOMException(
+                "The operation either timed out or was not allowed.",
+                "NotAllowedError",
+              ),
+            );
+          }
+          return Reflect.apply(target, thisArg, argList);
+        },
+      });
     }
   });
   return true;

--- a/plugins/agent-id-browser/skills/agent-id-browser/SKILL.md
+++ b/plugins/agent-id-browser/skills/agent-id-browser/SKILL.md
@@ -152,6 +152,18 @@ into a page. SSO redirects credential entry to the identity provider, so set
 `domains` to cover it — a wildcard works: `--domains '*.acme.com'` allows
 `idp.acme.com`. The refusal error names the blocked host.
 
+**Passkeys (WebAuthn):** a driven session reports WebAuthn as **unsupported** —
+the browser has no authenticator, so a passkey ceremony could only hang (and
+while one is pending, the page's own "Try another way" links are inert). Sites
+with a passkey enrolled therefore skip the passkey prompt and offer their
+password/OTP path directly; expect that path, don't look for a passkey prompt.
+The exception is headed `login` (path A): the owner sits at a real Chrome
+window there, so WebAuthn stays native and a platform passkey can complete. If
+a site offers **only** a passkey (no fallback), it is unreachable in a driven
+session; `AGENT_ID_BROWSER_KEEP_WEBAUTHN=1` restores native WebAuthn — a
+ceremony will then hang as before; send `Escape` to cancel it and revive the
+fallback links.
+
 ## Read-only sessions (access levels)
 
 A session can be sealed **read-only**: the owner grants "the agent may read my

--- a/tests/test-browser-webauthn-off.mjs
+++ b/tests/test-browser-webauthn-off.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+
+// WebAuthn off-switch for driven browser sessions (webauthn-off.mjs).
+//
+// The driven browser has no authenticator, so a passkey ceremony started by a
+// site can never complete — navigator.credentials.get() hangs and the page's
+// fallback links are inert while it is pending (alien-id/agent-id#99). The
+// off-switch makes the browser look passkey-incapable instead: the
+// PublicKeyCredential interface is gone (sites feature-detect it and fall back
+// to password/OTP up front), and a publicKey get/create that is issued anyway
+// rejects immediately with the NotAllowedError every WebAuthn call site
+// already handles as "cancelled".
+//
+// Pure tests cover the env opt-out and the wiring contract; the LIVE test
+// proves the page-visible surface in a real Chrome and skips when patchright /
+// Chrome are not installed.
+//
+// Run: node --test tests/test-browser-webauthn-off.mjs
+
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { resolvePatchright, launchContext } from "../plugins/agent-id-browser/lib/launch.mjs";
+import { webauthnKept, suppressWebAuthn } from "../plugins/agent-id-browser/lib/webauthn-off.mjs";
+
+const patchrightAvailable = !!resolvePatchright();
+
+// ── Pure ──────────────────────────────────────────────────────────────────────
+
+test("webauthnKept: only the literal '1' keeps WebAuthn native", () => {
+  assert.equal(webauthnKept({}), false);
+  assert.equal(webauthnKept({ AGENT_ID_BROWSER_KEEP_WEBAUTHN: "1" }), true);
+  assert.equal(webauthnKept({ AGENT_ID_BROWSER_KEEP_WEBAUTHN: "0" }), false);
+  assert.equal(webauthnKept({ AGENT_ID_BROWSER_KEEP_WEBAUTHN: "true" }), false);
+  assert.equal(webauthnKept({ AGENT_ID_BROWSER_KEEP_WEBAUTHN: "" }), false);
+});
+
+test("suppressWebAuthn installs one init script and reports it", async () => {
+  const installed = [];
+  const ctx = { addInitScript: async (fn) => installed.push(fn) };
+  assert.equal(await suppressWebAuthn(ctx, {}), true);
+  assert.equal(installed.length, 1);
+  assert.equal(typeof installed[0], "function");
+});
+
+test("suppressWebAuthn is a no-op when the env keeps WebAuthn", async () => {
+  const installed = [];
+  const ctx = { addInitScript: async (fn) => installed.push(fn) };
+  assert.equal(await suppressWebAuthn(ctx, { AGENT_ID_BROWSER_KEEP_WEBAUTHN: "1" }), false);
+  assert.equal(installed.length, 0);
+});
+
+// ── LIVE (real Chrome; skips without patchright) ─────────────────────────────
+
+let server;
+let base;
+
+function startServer() {
+  return new Promise((resolve) => {
+    server = http.createServer((req, res) => {
+      res.writeHead(200, { "Content-Type": "text/html" });
+      res.end("<!doctype html><title>fake-signin</title><h1>Sign in</h1>");
+    });
+    server.listen(0, "127.0.0.1", () => {
+      base = `http://127.0.0.1:${server.address().port}`;
+      resolve();
+    });
+  });
+}
+
+before(async () => {
+  if (patchrightAvailable) await startServer();
+});
+after(async () => {
+  if (server) await new Promise((r) => server.close(r));
+});
+
+// Launch a context on a throwaway profile, navigate to the local page, and
+// evaluate the WebAuthn surface the page sees. The probe MUST run in the MAIN
+// world — patchright's evaluate defaults to an isolated world (stealth), whose
+// pristine natives are invisible to page scripts; the third `evaluate` argument
+// (isolatedContext:false) selects the world the page's own code runs in.
+async function probeWebAuthn(launchExtras = {}) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "webauthn-off-"));
+  let ctx;
+  try {
+    ctx = await launchContext({ profileDir: dir, headless: true, ...launchExtras });
+    const page = ctx.pages()[0] || (await ctx.newPage());
+    await page.goto(`${base}/`, { waitUntil: "domcontentloaded" });
+    return await page.evaluate(async () => {
+      const out = { pkc: typeof window.PublicKeyCredential };
+      const timing = async (label, run) => {
+        const t0 = Date.now();
+        try {
+          const value = await run();
+          out[label] = { outcome: "resolved", value: value === null ? null : typeof value };
+        } catch (e) {
+          out[label] = { outcome: "rejected", name: e.name };
+        }
+        out[label].ms = Date.now() - t0;
+      };
+      await timing("get", () =>
+        navigator.credentials.get({ publicKey: { challenge: new Uint8Array(16) } }),
+      );
+      await timing("create", () =>
+        navigator.credentials.create({
+          publicKey: {
+            challenge: new Uint8Array(16),
+            rp: { name: "t" },
+            user: { id: new Uint8Array(8), name: "t", displayName: "t" },
+            pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+          },
+        }),
+      );
+      // Non-publicKey credential types must pass through to the native
+      // implementation (no stored password → resolves null).
+      await timing("passwordGet", () => navigator.credentials.get({ password: true }));
+      return out;
+    }, undefined, false);
+  } finally {
+    if (ctx) await ctx.close().catch(() => {});
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+test(
+  "a driven session shows no WebAuthn: feature-detect fails, ceremonies reject instantly",
+  { skip: patchrightAvailable ? false : "patchright/Chrome not installed" },
+  async () => {
+    const s = await probeWebAuthn();
+
+    assert.equal(s.pkc, "undefined", "PublicKeyCredential must be gone (feature detection)");
+    assert.equal(s.get.outcome, "rejected");
+    assert.equal(s.get.name, "NotAllowedError", "a publicKey get must look like a cancelled ceremony");
+    assert.ok(s.get.ms < 2000, `the rejection must be immediate, not a hang (took ${s.get.ms}ms)`);
+    assert.equal(s.create.outcome, "rejected");
+    assert.equal(s.create.name, "NotAllowedError");
+    assert.ok(s.create.ms < 2000, `the rejection must be immediate, not a hang (took ${s.create.ms}ms)`);
+    assert.deepEqual(
+      { outcome: s.passwordGet.outcome, value: s.passwordGet.value },
+      { outcome: "resolved", value: null },
+      "non-publicKey credential calls must reach the native implementation",
+    );
+  },
+);
+
+test(
+  "nativeWebAuthn:true (the headed owner login) keeps the WebAuthn surface",
+  { skip: patchrightAvailable ? false : "patchright/Chrome not installed" },
+  async () => {
+    const s = await probeWebAuthn({ nativeWebAuthn: true });
+    assert.equal(s.pkc, "function", "the owner's headed login must keep WebAuthn native");
+  },
+);
+
+test(
+  "AGENT_ID_BROWSER_KEEP_WEBAUTHN=1 keeps WebAuthn native in a driven session",
+  { skip: patchrightAvailable ? false : "patchright/Chrome not installed" },
+  async () => {
+    process.env.AGENT_ID_BROWSER_KEEP_WEBAUTHN = "1";
+    try {
+      const s = await probeWebAuthn();
+      assert.equal(s.pkc, "function");
+    } finally {
+      delete process.env.AGENT_ID_BROWSER_KEEP_WEBAUTHN;
+    }
+  },
+);

--- a/tests/test-browser-webauthn-off.mjs
+++ b/tests/test-browser-webauthn-off.mjs
@@ -92,7 +92,21 @@ async function probeWebAuthn(launchExtras = {}) {
     const page = ctx.pages()[0] || (await ctx.newPage());
     await page.goto(`${base}/`, { waitUntil: "domcontentloaded" });
     return await page.evaluate(async () => {
-      const out = { pkc: typeof window.PublicKeyCredential };
+      const out = {
+        pkc: typeof window.PublicKeyCredential,
+        attestationResponse: typeof window.AuthenticatorAttestationResponse,
+        assertionResponse: typeof window.AuthenticatorAssertionResponse,
+        authenticatorResponse: typeof window.AuthenticatorResponse,
+        getNative: navigator.credentials.get.toString().includes("[native code]"),
+        createNative: navigator.credentials.create.toString().includes("[native code]"),
+        // Function.prototype.toString is the reflection path an anti-bot script
+        // uses to defeat a per-function toString override — the Proxy must
+        // forward it to the native target too.
+        getNativeViaFnProto: Function.prototype.toString
+          .call(navigator.credentials.get)
+          .includes("[native code]"),
+        getName: navigator.credentials.get.name,
+      };
       const timing = async (label, run) => {
         const t0 = Date.now();
         try {
@@ -134,6 +148,17 @@ test(
     const s = await probeWebAuthn();
 
     assert.equal(s.pkc, "undefined", "PublicKeyCredential must be gone (feature detection)");
+    // The response types must go with it — a real browser never exposes them
+    // without PublicKeyCredential, and that mismatch is its own automation tell.
+    assert.equal(s.attestationResponse, "undefined", "AuthenticatorAttestationResponse must be gone");
+    assert.equal(s.assertionResponse, "undefined", "AuthenticatorAssertionResponse must be gone");
+    assert.equal(s.authenticatorResponse, "undefined", "AuthenticatorResponse must be gone");
+    // The override must read as native, or it is itself a detectable JS patch —
+    // defeating the byte-for-byte-native surface the rest of launch.mjs builds.
+    assert.equal(s.getNative, true, "credentials.get must report [native code]");
+    assert.equal(s.createNative, true, "credentials.create must report [native code]");
+    assert.equal(s.getNativeViaFnProto, true, "Function.prototype.toString must also see native");
+    assert.equal(s.getName, "get", "the override must keep the native function name");
     assert.equal(s.get.outcome, "rejected");
     assert.equal(s.get.name, "NotAllowedError", "a publicKey get must look like a cancelled ceremony");
     assert.ok(s.get.ms < 2000, `the rejection must be immediate, not a hang (took ${s.get.ms}ms)`);
@@ -145,6 +170,32 @@ test(
       { outcome: "resolved", value: null },
       "non-publicKey credential calls must reach the native implementation",
     );
+  },
+);
+
+test(
+  "the off-switch also covers a no-network document (data: URL)",
+  { skip: patchrightAvailable ? false : "patchright/Chrome not installed" },
+  async () => {
+    // patchright delivers init scripts partly by injecting a <script> into
+    // http(s) HTML responses; a data: document has no such response, so this
+    // proves the CDP addScriptToEvaluateOnNewDocument path covers it too — a
+    // page reached via a client-side redirect to a data:/blank document is not
+    // a hole in the off-switch.
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "webauthn-off-data-"));
+    let ctx;
+    try {
+      ctx = await launchContext({ profileDir: dir, headless: true });
+      const page = ctx.pages()[0] || (await ctx.newPage());
+      await page.goto("data:text/html,<title>t</title><h1>x</h1>", {
+        waitUntil: "domcontentloaded",
+      });
+      const pkc = await page.evaluate(() => typeof window.PublicKeyCredential, undefined, false);
+      assert.equal(pkc, "undefined", "the off-switch must cover a no-network document");
+    } finally {
+      if (ctx) await ctx.close().catch(() => {});
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    }
   },
 );
 


### PR DESCRIPTION
## Problem

The driven browser has no platform authenticator and no CTAP transport, so a passkey ceremony a site starts can never complete: `navigator.credentials.get()` hangs, and while it is pending the page's own fallback affordances ("Try another way") are effectively inert — a sign-in against an account with a passkey enrolled (Google is the everyday case) dead-ends. The only escape was sending `Escape` to cancel the ceremony by hand. See #99 for the full write-up.

## Approach

Instead of holding passkeys (the virtual-authenticator proposal stays open in #99), the driven browser now declares itself **passkey-incapable** — the exact surface of a legacy browser, which every passkey site already handles with a password/OTP path. One init script (`lib/webauthn-off.mjs`), installed by `launchContext` on every driven session:

1. **`delete window.PublicKeyCredential`** before any page script runs. Sites feature-detect it (its statics — `isUserVerifyingPlatformAuthenticatorAvailable`, `isConditionalMediationAvailable` — go with it) before pushing a ceremony or conditional-UI autofill, so they offer the fallback path up front and no prompt ever appears.
2. **`CredentialsContainer.get`/`create` with a `publicKey` argument reject immediately with `NotAllowedError`** — the cancellation outcome every WebAuthn call site already handles — covering sites that call without feature-detecting. Deleting the interface object alone would *not* stop the ceremony (the implementation behind it still runs); this is the load-bearing half. Password/federated credential calls pass through untouched.

Kept native deliberately:

- **Headed `login`** (`nativeWebAuthn: true`): the owner sits at a real Chrome window, where a platform authenticator (Touch ID, a security key) may genuinely exist and complete.
- **`AGENT_ID_BROWSER_KEEP_WEBAUTHN=1`** restores native WebAuthn in driven sessions for the rare passkey-*only* site — the ceremony then hangs as before; `Escape` cancels it and revives the fallback links (documented in the skill).

This is a UX measure, not a security boundary: a page could restore the natives from a fresh realm, but a sign-in page has no motive to — "no WebAuthn" is the ordinary legacy-browser case.

## Tests

`tests/test-browser-webauthn-off.mjs` — pure tests for the env opt-out and wiring contract, plus a LIVE Chrome test (auto-skips without patchright) asserting: feature detection fails, `publicKey` get/create reject instantly with `NotAllowedError`, password-credential calls still reach the native implementation, and both opt-outs (headed login, env var) keep the surface native.

Two subtleties the live test encodes:

- patchright's `evaluate` defaults to an **isolated world** whose pristine natives never see init-script effects; the probe passes `isolatedContext: false` to look at the main world pages actually run in.
- A native control run on `127.0.0.1` rejects with `SecurityError` ("invalid domain"), so the asserted `NotAllowedError` provably comes from the off-switch, not the platform — the assertion fails if the suppression is removed.

Full suite: 664/664 pass.

Refs #99 (interim measure; the vault-sealed virtual-authenticator track remains open there).