### PR TITLE
feat(browser): input_focus status — viewers learn what the page focused

### DIFF
--- a/.changeset/input-focus-status.md
+++ b/.changeset/input-focus-status.md
@@ -1,0 +1,14 @@
+---
+"@alien-id/agent-id-browser": patch
+---
+
+The viewport stream now reports the page's input-focus state: while a viewer
+is attached, a poller (250 ms, isolated-world evaluate — no Runtime domain,
+no page-visible side effects, CSP-immune) walks the page's frames for a
+focused editable element and broadcasts `input_focus {editable, type?,
+inputmode?}` status messages, deduped, suppressed during credential-fill
+blackouts, and snapshotted into the join status so a late viewer learns an
+already-focused field immediately. Viewers can auto-open their keyboard (and
+pick a layout from type/inputmode) instead of relying on a manual toggle.
+Covered by wire-contract tests and a local-only real-browser e2e
+(tests/integration/browser-focus-e2e.mjs) including an iframe fixture.

--- a/plugins/agent-id-browser/lib/stream-server.mjs
+++ b/plugins/agent-id-browser/lib/stream-server.mjs
@@ -67,6 +67,10 @@ const REFINE_AFTER_MS = 600;
 const REFINE_POLL_MS = 250;
 const H264_MAX_BUFFERED = 4 * 1024 * 1024;
 
+// Keyboard-open latency budget: the viewer's IME pops within a quarter second
+// of the page focusing a field — imperceptible next to the tap round-trip.
+const FOCUS_POLL_MS = 250;
+
 function envInt(name, fallback, min, max) {
   const n = Number(process.env[name]);
   if (!Number.isFinite(n)) return fallback;
@@ -340,6 +344,91 @@ export async function startStreamServer(
     for (const c of clients) c.sock.write(frame);
   }
 
+  // The page's focus truth, pushed by the session's init script. Deduped so a
+  // page that re-reports the same element (focus bouncing inside an editor)
+  // doesn't spam viewers, remembered so statusFor can hand the current state
+  // to a viewer that joins with a field already focused, and suppressed during
+  // a credential fill — the owner's keyboard must not pop over a blackout.
+  let lastInputFocus = null;
+
+  function inputFocus(payload) {
+    if (suspended > 0) return;
+    const next = payload && typeof payload === "object" ? payload : { editable: false };
+    if (lastInputFocus && JSON.stringify(lastInputFocus) === JSON.stringify(next)) return;
+    lastInputFocus = next;
+    broadcastStatus({ type: "status", source: "alien", input_focus: next });
+  }
+
+  // Focus is POLLED, not event-driven: the stealth patching deliberately keeps
+  // the CDP Runtime domain off, which is exactly what exposeBinding/initScript
+  // reporting rides on — and a page-side beacon would die on strict CSPs. An
+  // isolated-world evaluate sees the DOM without touching either. Frames are
+  // walked because a field inside an iframe focuses ITS document, not the
+  // main one; document.hasFocus() is true for the whole ancestor chain, but
+  // only the actually-focused document holds an editable activeElement, so at
+  // most one frame answers. Runs only while someone is watching, like the
+  // screencast itself.
+  let focusPoller = null;
+
+  async function readInputFocus() {
+    const page = state.current;
+    if (!page || page.isClosed?.() || typeof page.frames !== "function") return null;
+    for (const frame of page.frames()) {
+      try {
+        const found = await frame.evaluate(() => {
+          if (!document.hasFocus()) return null;
+          const NON_TEXT = new Set([
+            "button", "submit", "reset", "image", "checkbox", "radio",
+            "range", "color", "file", "hidden",
+          ]);
+          let el = document.activeElement;
+          while (el && el.shadowRoot && el.shadowRoot.activeElement) el = el.shadowRoot.activeElement;
+          if (!el || el === document.body || el === document.documentElement) return null;
+          const tag = (el.tagName || "").toLowerCase();
+          const type = tag === "input" ? (el.getAttribute("type") || "text").toLowerCase() : null;
+          const editable =
+            tag === "textarea" ||
+            el.isContentEditable === true ||
+            (tag === "input" && !NON_TEXT.has(type));
+          if (!editable) return null;
+          const inputmode = (el.getAttribute && el.getAttribute("inputmode")) || null;
+          return {
+            editable: true,
+            ...(type ? { type } : {}),
+            ...(inputmode ? { inputmode } : {}),
+          };
+        });
+        if (found) return found;
+      } catch {
+        /* frame detached mid-poll */
+      }
+    }
+    return { editable: false };
+  }
+
+  function ensureFocusPoller() {
+    if (focusPoller) return;
+    let inFlight = false;
+    focusPoller = setInterval(async () => {
+      if (inFlight || suspended > 0 || clients.size === 0) return;
+      inFlight = true;
+      try {
+        const focus = await readInputFocus();
+        if (focus) inputFocus(focus);
+      } finally {
+        inFlight = false;
+      }
+    }, FOCUS_POLL_MS);
+    if (typeof focusPoller.unref === "function") focusPoller.unref();
+  }
+
+  function stopFocusPoller() {
+    if (!focusPoller) return;
+    clearInterval(focusPoller);
+    focusPoller = null;
+    lastInputFocus = null;
+  }
+
   function statusFor(client) {
     const vp = state.current?.viewportSize?.() ?? null;
     return {
@@ -353,6 +442,7 @@ export async function startStreamServer(
       pacing: client.pacing,
       maxFps: client.maxFps,
       ...(vp ? { viewportWidth: vp.width, viewportHeight: vp.height } : {}),
+      ...(lastInputFocus ? { input_focus: lastInputFocus } : {}),
     };
   }
 
@@ -806,7 +896,10 @@ export async function startStreamServer(
       if (client.timer) clearTimeout(client.timer);
       webrtc?.drop(client);
       void ensureAnnexBEncoder(); // tears down when the last h264 viewer left
-      if (clients.size === 0) void stopScreencast(); // save CPU when unwatched
+      if (clients.size === 0) {
+        void stopScreencast(); // save CPU when unwatched
+        stopFocusPoller();
+      }
     };
     socket.on("close", drop);
     socket.on("error", drop);
@@ -819,6 +912,7 @@ export async function startStreamServer(
     // starting the feed produces that frame anyway.
     if (cdp) void stopScreencast().then(() => startScreencast());
     else void startScreencast();
+    ensureFocusPoller();
   });
 
   await new Promise((resolve) => server.listen(0, BIND_HOST, resolve));
@@ -828,6 +922,8 @@ export async function startStreamServer(
     token,
     /** How many viewers are attached — a watched session is never idle. */
     viewers: () => clients.size,
+    /** Report the page's input-focus state (see the session init script). */
+    inputFocus,
     /** Hide the feed while a secret is typed into the page. Depth-counted. */
     suspend() {
       suspended++;
@@ -846,6 +942,7 @@ export async function startStreamServer(
       }
     },
     close() {
+      stopFocusPoller();
       closed = true;
       clearInterval(retarget);
       clearInterval(watchdog);

--- a/tests/integration/browser-focus-e2e.mjs
+++ b/tests/integration/browser-focus-e2e.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+
+// LOCAL-ONLY end-to-end for the input-focus events: a REAL Chromium (via the
+// plugin's own patchright loader, driving installed Chrome) renders a fixture
+// page with fields at fixed coordinates, viewer taps arrive as real
+// mousePressed/mouseReleased over the stream WebSocket, and the test asserts
+// the `input_focus` status messages the viewer-gated focus poller produces —
+// text, password, inputmode, a non-editable button, and a field INSIDE an
+// iframe (the poller walks frames; document.hasFocus() picks the right one).
+//
+// Deliberately not part of `npm test` (the CI glob only picks tests/test-*.mjs):
+// it needs a local Chrome. Run it by hand when touching the stream or the
+// focus-reporting script:
+//
+//   node --test tests/integration/browser-focus-e2e.mjs
+//
+// Skips cleanly when patchright/Chrome is unavailable.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import net from "node:net";
+import { once } from "node:events";
+
+import {
+  startStreamServer,
+  makeFrameParser,
+} from "../../plugins/agent-id-browser/lib/stream-server.mjs";
+import { loadChromium } from "../../plugins/agent-id-browser/lib/launch.mjs";
+
+const FIXTURE = `data:text/html,${encodeURIComponent(`
+<!doctype html><meta name="viewport" content="width=device-width">
+<style>
+  body { margin: 0; }
+  input, button, iframe { position: absolute; width: 200px; height: 40px; left: 100px; }
+</style>
+<input id="text"    type="text"                        style="top: 50px">
+<input id="pass"    type="password"                    style="top: 150px">
+<input id="num"     type="text" inputmode="numeric"    style="top: 250px">
+<button id="button" style="top: 350px">not editable</button>
+<iframe style="top: 430px; height: 100px" srcdoc="
+  <style>input { position: absolute; left: 20px; top: 20px; width: 150px; height: 30px }</style>
+  <input id='framed' type='email'>"></iframe>
+`)}`;
+
+// Field centers in CSS px (the fixture pins everything absolutely).
+const AT = {
+  text: { x: 200, y: 70 },
+  pass: { x: 200, y: 170 },
+  num: { x: 200, y: 270 },
+  button: { x: 200, y: 370 },
+  framed: { x: 100 + 20 + 75, y: 430 + 20 + 15 },
+};
+
+function maskedTextFrame(payload) {
+  const data = Buffer.from(payload, "utf8");
+  const mask = crypto.randomBytes(4);
+  const masked = Buffer.from(data);
+  for (let i = 0; i < masked.length; i++) masked[i] ^= mask[i & 3];
+  let header;
+  if (data.length < 126) header = Buffer.from([0x81, 0x80 | data.length]);
+  else {
+    header = Buffer.alloc(4);
+    header[0] = 0x81;
+    header[1] = 0x80 | 126;
+    header.writeUInt16BE(data.length, 2);
+  }
+  return Buffer.concat([header, mask, masked]);
+}
+
+async function connectStream(port, token) {
+  const sock = net.connect(port, "127.0.0.1");
+  await once(sock, "connect");
+  const key = crypto.randomBytes(16).toString("base64");
+  sock.write(
+    `GET /?token=${token} HTTP/1.1\r\nHost: t\r\nUpgrade: websocket\r\n` +
+      `Connection: Upgrade\r\nSec-WebSocket-Key: ${key}\r\nSec-WebSocket-Version: 13\r\n\r\n`,
+  );
+  const queue = [];
+  const waiters = [];
+  const parse = makeFrameParser((m) => {
+    const w = waiters.shift();
+    if (w) w(m);
+    else queue.push(m);
+  });
+  let head = Buffer.alloc(0);
+  let upgraded = false;
+  await new Promise((resolve, reject) => {
+    sock.on("data", (d) => {
+      if (upgraded) return parse(d);
+      head = Buffer.concat([head, d]);
+      const end = head.indexOf("\r\n\r\n");
+      if (end < 0) return;
+      upgraded = true;
+      resolve();
+      parse(head.subarray(end + 4));
+    });
+    sock.on("error", reject);
+  });
+  return {
+    send: (obj) => sock.write(maskedTextFrame(JSON.stringify(obj))),
+    async nextInputFocus(timeoutMs = 5000) {
+      const deadline = Date.now() + timeoutMs;
+      for (;;) {
+        let msg;
+        if (queue.length) msg = queue.shift();
+        else {
+          msg = await new Promise((resolve, reject) => {
+            const t = setTimeout(
+              () => reject(new Error("timed out waiting for input_focus")),
+              Math.max(1, deadline - Date.now()),
+            );
+            waiters.push((m) => { clearTimeout(t); resolve(m); });
+          });
+        }
+        let parsed;
+        try {
+          parsed = JSON.parse(msg.payload.toString("utf8"));
+        } catch {
+          continue; // a binary/odd frame — screencast traffic, not ours
+        }
+        // Frames and other statuses flow constantly; only focus reports matter.
+        if (parsed && parsed.type === "status" && parsed.input_focus !== undefined) {
+          return parsed.input_focus;
+        }
+      }
+    },
+    close: () => sock.destroy(),
+  };
+}
+
+async function tap(client, { x, y }) {
+  client.send({ type: "input_mouse", eventType: "mousePressed", x, y, button: "left" });
+  client.send({ type: "input_mouse", eventType: "mouseReleased", x, y, button: "left" });
+}
+
+let chromium = null;
+try {
+  chromium = await loadChromium();
+} catch {
+  chromium = null;
+}
+
+test("taps on the fixture report page-truth focus over the stream", { skip: !chromium && "patchright/Chrome unavailable" }, async () => {
+  const browser = await chromium.launch({ channel: "chrome", headless: true });
+  try {
+    const ctx = await browser.newContext({ viewport: { width: 800, height: 600 } });
+    const state = { current: null, ctx, invalidateRefs() {} };
+    const page = await ctx.newPage();
+    state.current = page;
+    await page.goto(FIXTURE);
+
+    const stream = await startStreamServer(state, { log: () => {} });
+    const client = await connectStream(stream.port, stream.token);
+    try {
+      await tap(client, AT.text);
+      assert.deepEqual(await client.nextInputFocus(), { editable: true, type: "text" });
+
+      await tap(client, AT.pass);
+      assert.deepEqual(await client.nextInputFocus(), { editable: true, type: "password" });
+
+      await tap(client, AT.num);
+      assert.deepEqual(await client.nextInputFocus(), {
+        editable: true,
+        type: "text",
+        inputmode: "numeric",
+      });
+
+      await tap(client, AT.button);
+      assert.deepEqual(
+        await client.nextInputFocus(),
+        { editable: false },
+        "a button steals focus from the field but must read as not-editable",
+      );
+
+      await tap(client, AT.framed);
+      assert.deepEqual(
+        await client.nextInputFocus(),
+        { editable: true, type: "email" },
+        "a field inside an iframe must report through the same channel",
+      );
+    } finally {
+      client.close();
+      await stream.close();
+    }
+  } finally {
+    await browser.close();
+  }
+});

--- a/tests/test-browser-stream-focus.mjs
+++ b/tests/test-browser-stream-focus.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+
+// Wire contract of the `input_focus` status messages — the page-truth focus
+// signal viewers use to open/close their keyboard. Driven over real sockets
+// against a FAKE CDP session (no browser), like the resize tests: what is
+// under test is the stream side — dedup, suspend gating, broadcast shape, and
+// the join snapshot. The page side (init script → binding) is covered by the
+// local-only integration test in tests/integration/browser-focus-e2e.mjs.
+//
+// Run: node --test tests/test-browser-stream-focus.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import net from "node:net";
+import { once } from "node:events";
+
+import {
+  startStreamServer,
+  makeFrameParser,
+} from "../plugins/agent-id-browser/lib/stream-server.mjs";
+
+// ── fakes (the resize tests' shapes) ─────────────────────────────────────────
+
+function makeFakeSession() {
+  const handlers = new Map();
+  return {
+    on: (event, fn) => handlers.set(event, fn),
+    async send() { return {}; },
+    async detach() {},
+  };
+}
+
+function makeFakeState() {
+  const page = {
+    isClosed: () => false,
+    mouse: { move: async () => {}, down: async () => {}, up: async () => {}, wheel: async () => {} },
+    keyboard: { down: async () => {}, up: async () => {}, insertText: async () => {} },
+  };
+  return {
+    current: page,
+    invalidateRefs() {},
+    ctx: { newCDPSession: async () => makeFakeSession() },
+  };
+}
+
+// ── minimal WS client ────────────────────────────────────────────────────────
+
+function maskedTextFrame(payload) {
+  const data = Buffer.from(payload, "utf8");
+  const mask = crypto.randomBytes(4);
+  const masked = Buffer.from(data);
+  for (let i = 0; i < masked.length; i++) masked[i] ^= mask[i & 3];
+  let header;
+  if (data.length < 126) header = Buffer.from([0x81, 0x80 | data.length]);
+  else {
+    header = Buffer.alloc(4);
+    header[0] = 0x81;
+    header[1] = 0x80 | 126;
+    header.writeUInt16BE(data.length, 2);
+  }
+  return Buffer.concat([header, mask, masked]);
+}
+
+async function connectStream(port, token) {
+  const sock = net.connect(port, "127.0.0.1");
+  await once(sock, "connect");
+  const key = crypto.randomBytes(16).toString("base64");
+  sock.write(
+    `GET /?token=${token} HTTP/1.1\r\nHost: t\r\nUpgrade: websocket\r\n` +
+      `Connection: Upgrade\r\nSec-WebSocket-Key: ${key}\r\nSec-WebSocket-Version: 13\r\n\r\n`,
+  );
+  const queue = [];
+  const waiters = [];
+  const parse = makeFrameParser((m) => {
+    const w = waiters.shift();
+    if (w) w(m);
+    else queue.push(m);
+  });
+  let head = Buffer.alloc(0);
+  let upgraded = false;
+  await new Promise((resolve, reject) => {
+    sock.on("data", (d) => {
+      if (upgraded) return parse(d);
+      head = Buffer.concat([head, d]);
+      const end = head.indexOf("\r\n\r\n");
+      if (end < 0) return;
+      upgraded = true;
+      resolve();
+      parse(head.subarray(end + 4));
+    });
+    sock.on("error", reject);
+  });
+  return {
+    sock,
+    send: (obj) => sock.write(maskedTextFrame(JSON.stringify(obj))),
+    async next(timeoutMs = 2000) {
+      if (queue.length) return JSON.parse(queue.shift().payload.toString("utf8"));
+      const frame = await new Promise((resolve, reject) => {
+        const t = setTimeout(() => reject(new Error("timed out waiting for a frame")), timeoutMs);
+        waiters.push((m) => { clearTimeout(t); resolve(m); });
+      });
+      return JSON.parse(frame.payload.toString("utf8"));
+    },
+    close: () => sock.destroy(),
+  };
+}
+
+async function nextInputFocus(client) {
+  for (let i = 0; i < 10; i++) {
+    const msg = await client.next();
+    if (msg.input_focus !== undefined) return msg.input_focus;
+  }
+  throw new Error("no input_focus status arrived");
+}
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+test("a focus report reaches the viewer as an input_focus status", async () => {
+  const stream = await startStreamServer(makeFakeState(), { log: () => {} });
+  const client = await connectStream(stream.port, stream.token);
+  await client.next(); // join status
+  stream.inputFocus({ editable: true, type: "password" });
+  const focus = await nextInputFocus(client);
+  assert.deepEqual(focus, { editable: true, type: "password" });
+  client.close();
+  await stream.close();
+});
+
+test("identical consecutive reports are deduplicated", async () => {
+  const stream = await startStreamServer(makeFakeState(), { log: () => {} });
+  const client = await connectStream(stream.port, stream.token);
+  await client.next(); // join status
+  stream.inputFocus({ editable: true, type: "text" });
+  await nextInputFocus(client);
+  stream.inputFocus({ editable: true, type: "text" });
+  stream.inputFocus({ editable: false });
+  const focus = await nextInputFocus(client);
+  assert.deepEqual(
+    focus,
+    { editable: false },
+    "the duplicate must be swallowed, so the NEXT message is the blur",
+  );
+  client.close();
+  await stream.close();
+});
+
+test("focus reports are suppressed while a credential fill suspends the feed", async () => {
+  const state = makeFakeState();
+  const stream = await startStreamServer(state, { log: () => {} });
+  const client = await connectStream(stream.port, stream.token);
+  await client.next(); // join status
+  stream.suspend();
+  stream.inputFocus({ editable: true, type: "password" });
+  stream.resume();
+  stream.inputFocus({ editable: true, type: "email" });
+  const focus = await nextInputFocus(client);
+  assert.deepEqual(
+    focus,
+    { editable: true, type: "email" },
+    "the suspended-era report must never surface; the first visible one is post-resume",
+  );
+  client.close();
+  await stream.close();
+});
+
+test("a viewer joining with a field already focused learns it from the join status", async () => {
+  const stream = await startStreamServer(makeFakeState(), { log: () => {} });
+  const early = await connectStream(stream.port, stream.token);
+  await early.next(); // join status
+  stream.inputFocus({ editable: true, type: "email", inputmode: "email" });
+  await nextInputFocus(early);
+  const late = await connectStream(stream.port, stream.token);
+  const join = await late.next();
+  assert.deepEqual(join.input_focus, { editable: true, type: "email", inputmode: "email" });
+  early.close();
+  late.close();
+  await stream.close();
+});


### PR DESCRIPTION
While a viewer is attached, the stream polls the page (250 ms) for a
focused editable element and broadcasts input_focus status messages:
{editable, type?, inputmode?}, deduped, suppressed during credential
blackouts, and included in the join status so a viewer arriving at an
already-focused field learns it immediately. Frames are walked so a
field inside an iframe reports too — document.hasFocus() narrows to the
one document whose activeElement is editable.

Polled, not event-driven, deliberately: the stealth patching keeps the
CDP Runtime domain off, which is exactly what exposeBinding/initScript
reporting rides on (verified empirically — an injected binding never
fires), and a page-side beacon dies on strict CSPs. The isolated-world
evaluate sees the DOM without either. Runs only while watched, like the
screencast itself.

Wire-contract tests (fake CDP session) cover dedup, suspend gating,
broadcast shape and the join snapshot; a local-only real-browser e2e
(tests/integration, excluded from CI by the test glob) drives real taps
through the WS into installed Chrome against a fixture with text,
password, inputmode, button and iframe fields.

## Why polling

The event-driven route (`exposeBinding` + `addInitScript`) was implemented first and verified to be dead on arrival: the stealth patching avoids the CDP Runtime domain, which those APIs ride on — the binding never fires (empirically confirmed). A page-side beacon (`fetch`/`sendBeacon` to an intercepted URL) dies on strict `connect-src` CSPs — sign-in pages are exactly where those live. The isolated-world evaluate poll needs neither, is invisible to page JS, and is framework-agnostic (React/Vue synthetic events sit above native focus; contenteditable and shadow DOM are handled; iframes via frame walking).

## Tests

- `tests/test-browser-stream-focus.mjs` (CI): dedup, suspend gating, broadcast shape, join snapshot — 4/4.
- `tests/integration/browser-focus-e2e.mjs` (local-only, real Chrome via the plugin's own loader): WS taps at fixture coordinates → asserts `input_focus` for a text field, password, `inputmode=numeric`, a non-editable button, and a field inside an iframe — 1/1.
- Full suite: 662/662.
