### PR TITLE
proxy: opt-in data-plane authentication (--auth-token-file) + local preflight refusal

### DIFF
--- a/.changeset/proxy-data-plane-auth.md
+++ b/.changeset/proxy-data-plane-auth.md
@@ -1,0 +1,9 @@
+---
+"@alien-id/agent-id-proxy": minor
+---
+
+Opt-in data-plane authentication: `--auth-token-file <path>` makes the proxy
+require `X-Agent-Id-Proxy-Token` (constant-time compared) on every data-plane
+request and CONNECT, refused with 401 before any vault access. The header is
+stripped before forwarding upstream in both data-plane modes. CORS preflights
+are now always answered locally with 403 and never relayed upstream.

--- a/.changeset/proxy-data-plane-auth.md
+++ b/.changeset/proxy-data-plane-auth.md
@@ -4,6 +4,19 @@
 
 Opt-in data-plane authentication: `--auth-token-file <path>` makes the proxy
 require `X-Agent-Id-Proxy-Token` (constant-time compared) on every data-plane
-request and CONNECT, refused with 401 before any vault access. The header is
-stripped before forwarding upstream in both data-plane modes. CORS preflights
-are now always answered locally with 403 and never relayed upstream.
+request and CONNECT, refused with 401 before any vault access. The token file
+must be 0600 and hold printable ASCII, both checked before the vault is opened.
+The header is stripped before forwarding upstream in both data-plane modes.
+Repeated refusals are coalesced in the access log — one line per minute with a
+suppressed count — so an unauthenticated caller cannot grow the log at will.
+A CORS preflight is never relayed upstream: auth runs first, so an
+unauthenticated preflight is refused with 401 like any other request, and an
+authenticated one (or any preflight when auth is off) is answered locally with
+403 `cross_origin_refused` and no `Access-Control-Allow-*`.
+
+The CONNECT tunnel now also runs the SSRF guard the forwarded path has always
+run — link-local (incl. cloud metadata), unspecified and multicast targets are
+refused with 403 `upstream_blocked`, as are loopback/RFC1918/ULA targets under
+`--block-private-hosts`, for literal addresses and for hostnames that resolve
+into a blocked range — and it self-reopens an idle-locked vault on the
+auto-unlock path instead of refusing.

--- a/.changeset/proxy-data-plane-auth.md
+++ b/.changeset/proxy-data-plane-auth.md
@@ -8,7 +8,10 @@ request and CONNECT, refused with 401 before any vault access. The token file
 must be 0600 and hold printable ASCII, both checked before the vault is opened.
 The header is stripped before forwarding upstream in both data-plane modes.
 Repeated refusals are coalesced in the access log — one line per minute with a
-suppressed count — so an unauthenticated caller cannot grow the log at will.
+suppressed count — so an unauthenticated caller cannot grow the log at will;
+the count a window ends on is written out by the next log entry, or by
+`close()`, as `auth_failed_suppressed`, so a flood that simply stops still
+leaves a record.
 A CORS preflight is never relayed upstream: auth runs first, so an
 unauthenticated preflight is refused with 401 like any other request, and an
 authenticated one (or any preflight when auth is off) is answered locally with
@@ -18,5 +21,9 @@ The CONNECT tunnel now also runs the SSRF guard the forwarded path has always
 run — link-local (incl. cloud metadata), unspecified and multicast targets are
 refused with 403 `upstream_blocked`, as are loopback/RFC1918/ULA targets under
 `--block-private-hosts`, for literal addresses and for hostnames that resolve
-into a blocked range — and it self-reopens an idle-locked vault on the
-auto-unlock path instead of refusing.
+into a blocked range. Its target must be authority-form (`host:port`, numeric
+port in range): a malformed one is refused with 400 `bad_request` instead of
+throwing out of the handler. On an idle-locked vault the tunnel self-reopens
+only where a request would — the auto-unlock path with the control plane off;
+with the control plane on the unlock stays the owner's decision and the tunnel
+is refused with 401 `vault_locked`.

--- a/docs/VAULT-PROXY.md
+++ b/docs/VAULT-PROXY.md
@@ -303,7 +303,7 @@ New code should prefer Mode 1. Mode 2 stays for backward compatibility.
 
 ### CONNECT handling
 
-`CONNECT <host>:<port>` tunnels are forwarded transparently — no MITM, no injection. Stubs left inside an HTTPS CONNECT tunnel will be sent to upstream untouched.
+`CONNECT <host>:<port>` tunnels are forwarded transparently — no MITM, no injection. Stubs left inside an HTTPS CONNECT tunnel will be sent to upstream untouched. The tunnel is not a way around the perimeter, though: the SSRF guard below runs on the CONNECT target too (by literal address and by resolved name), and with `--auth-token-file` the tunnel needs the same token every request needs.
 
 ---
 
@@ -417,7 +417,7 @@ Two practical notes:
 | On-path network attacker between proxy and upstream | Bounded by upstream's TLS — the proxy verifies the upstream cert against the system CA bundle. |
 | On-path attacker between agent and proxy | Plain HTTP on `127.0.0.1` loopback. Same-host non-root user processes are the realistic concern; mitigation is OS file/socket perms. |
 | Reach the control plane (local process or LAN host) | Loopback-bound by default; mutating routes require the bearer token. The master key on `/approve` is always sealed to the proxy's pinned key. A network-exposed plane runs over TLS (self-signed, fingerprint pinned via the QR), so the token isn't sniffable either. Residual: the pin trusts the QR's out-of-band channel, and a stolen token is replayable until the proxy restarts (new token). |
-| Drive the agent to hit an internal/metadata host | SSRF guard refuses link-local (incl. `169.254.169.254`), unspecified, and multicast upstreams; `--block-private-hosts` adds loopback/RFC1918. Independent of the per-credential allowlist. |
+| Drive the agent to hit an internal/metadata host | SSRF guard refuses link-local (incl. `169.254.169.254`), unspecified, and multicast upstreams; `--block-private-hosts` adds loopback/RFC1918. Applies to forwarded requests and CONNECT tunnels alike. Independent of the per-credential allowlist. |
 | Get the wallet key to sign an arbitrary tx | Bounded by the credential's RPC-host allowlist, plus optional `chainIdAllowlist` / `toAllowlist` (EVM) and `programAllowlist` (Solana) enforced before signing. |
 | Steal proxy CA private key | Not applicable. **There is no CA**, because we use URL-rewrite instead of TLS interception. |
 

--- a/docs/VAULT-PROXY.md
+++ b/docs/VAULT-PROXY.md
@@ -303,7 +303,42 @@ New code should prefer Mode 1. Mode 2 stays for backward compatibility.
 
 ### CONNECT handling
 
-`CONNECT <host>:<port>` tunnels are forwarded transparently — no MITM, no injection. Stubs left inside an HTTPS CONNECT tunnel will be sent to upstream untouched. The tunnel is not a way around the perimeter, though: the SSRF guard below runs on the CONNECT target too (by literal address and by resolved name), and with `--auth-token-file` the tunnel needs the same token every request needs.
+`CONNECT <host>:<port>` tunnels are forwarded transparently — no MITM, no injection. Stubs left inside an HTTPS CONNECT tunnel will be sent to upstream untouched. The tunnel is not a way around the perimeter, though: it enforces the same gates the request path does.
+
+- **Authority-form target only.** The target must be `host:port` with a numeric port in range (RFC 9110 §9.3.6). Anything else — no port, a non-numeric port, an empty host — is refused with `400`, `X-AgentVault-Proxy-Error: bad_request`, before anything else happens.
+- **Token.** With `--auth-token-file` the tunnel needs the same token every request needs (`401`, `unauthorized`).
+- **SSRF guard.** It runs on the CONNECT target too, by literal address and by resolved name (`403`, `upstream_blocked`).
+- **Locked vault.** The tunnel gets the same treatment a request gets, under the same gate: with the control plane **off** and the agent-key unlock path wired, the proxy re-opens its own vault and the tunnel proceeds; with the control plane **on**, re-unlocking is the owner's decision, and since a tunnel has no parked-request path to wait in, it is refused with `401`, `vault_locked`. Self-reopen never stands in for an approval.
+
+Every refusal carries the machine-readable code in `X-AgentVault-Proxy-Error` and a zero-length body, so a tunnel client can tell them apart without parsing prose.
+
+---
+
+## Data-plane authentication (`--auth-token-file`)
+
+By default the data plane trusts anything that can reach its port. Loopback is a weak boundary wherever the network namespace is shared — a container, or a machine that also runs a browser rendering untrusted pages. `--auth-token-file` closes that:
+
+```bash
+# a random token, readable only by the account running the proxy
+head -c 32 /dev/urandom | base64 | tr -d '=+/' > ~/.agent-id-proxy-token
+chmod 600 ~/.agent-id-proxy-token
+agent-id-proxy start --auth-token-file ~/.agent-id-proxy-token
+```
+
+Every data-plane request **and every CONNECT** must then present the token in the `X-Agent-Id-Proxy-Token` header; without it the answer is `401 {error: "unauthorized"}` (`401 Unauthorized` / `unauthorized` on a tunnel):
+
+```bash
+curl -H "X-Agent-Id-Proxy-Token: $(cat ~/.agent-id-proxy-token)" \
+  http://localhost:48771/github-pat/api.github.com/user
+```
+
+Notes:
+
+- **A file, not a flag value** — argv is world-readable on a shared box. The file must not be group/world accessible (the proxy refuses to start otherwise), must be non-empty, and must hold printable ASCII (an HTTP header value cannot carry anything else; a multi-byte character would 401 every request with no diagnostic, so it is refused at startup instead).
+- **Checked before everything** — before the lock check and its self-reopen, before routing, the vault, the approval flow, or any upstream socket. An unauthenticated caller can only be refused, never observe or drive proxy state.
+- **Never forwarded.** The header is stripped from every upstream request, in both modes, whether or not authentication is enabled.
+- **Bounded logging.** Refusals are coalesced: the first of a window is logged verbatim, the rest are counted, and the count is written out with the next log entry (or when the proxy closes) as `auth_failed_suppressed` — so an unauthenticated flood cannot grow the log one line per request, and no refusal goes unrecorded either.
+- The control plane is unaffected: it has always had its own bearer token.
 
 ---
 
@@ -331,7 +366,7 @@ agent-id-proxy start --idle-timeout never     # disable, for unattended agents
 An unattended proxy — a supervisor spawning one daemon per principal, vault auto-unlocked through the agent-key slot — can re-open its own vault, because that slot needs no human. Wired **only** when the startup unlock actually used the agent key (never after `--unlock-form`, `--no-agent-key`, a passphrase or a passkey), it covers two cases:
 
 - **A credential written after start.** A `credential_not_found` triggers one vault re-read and one retry of the same lookup, so a credential another process added to `vault.enc` (e.g. `agent-id-vault add` after an out-of-band OAuth flow) is picked up on next use. Concurrent misses share a single re-read.
-- **Its own idle lock, with `--no-control`.** The next request re-opens instead of answering `401 vault_locked`. With the control plane on, the request parks for an owner approval exactly as before — self-reopen never replaces a consent/approval flow. Note the corollary: with the control plane on and **no** approver slot in the vault (nothing paired, no owner-approval slot), a locked proxy answers `401 no_unlock_method` and stays locked — self-reopen is not consulted there. Pair a device, or run that proxy with `--no-control`.
+- **Its own idle lock, with `--no-control`.** The next request — or CONNECT tunnel — re-opens instead of answering `401 vault_locked`. With the control plane on, a request parks for an owner approval exactly as before and a tunnel (which has nowhere to park) is refused: self-reopen never replaces a consent/approval flow, on either entrance. Note the corollary: with the control plane on and **no** approver slot in the vault (nothing paired, no owner-approval slot), a locked proxy answers `401 no_unlock_method` and stays locked — self-reopen is not consulted there. Pair a device, or run that proxy with `--no-control`.
 
 **Every write to `vault.enc` goes through a re-read handle.** `save()` re-encrypts the proxy's whole in-memory payload, so writing from the handle opened at start would erase everything another process added since — including a vault-generated wallet key that exists nowhere else. Both writers therefore re-read first, and **refuse to write when the vault cannot be re-read**:
 
@@ -415,7 +450,7 @@ Two practical notes:
 | Has agent's transcript | Sees credential names, request URLs, response bodies. **No credential values.** |
 | Has the upstream URL the agent typed | Sees the upstream hostname (also visible in DNS / TLS SNI / access logs anyway). |
 | On-path network attacker between proxy and upstream | Bounded by upstream's TLS — the proxy verifies the upstream cert against the system CA bundle. |
-| On-path attacker between agent and proxy | Plain HTTP on `127.0.0.1` loopback. Same-host non-root user processes are the realistic concern; mitigation is OS file/socket perms. |
+| On-path attacker between agent and proxy | Plain HTTP on `127.0.0.1` loopback. Same-host non-root user processes are the realistic concern; mitigation is OS file/socket perms, plus `--auth-token-file` — with it, requests and CONNECT tunnels need a shared secret only the agent's account can read, so reaching the port is no longer enough. |
 | Reach the control plane (local process or LAN host) | Loopback-bound by default; mutating routes require the bearer token. The master key on `/approve` is always sealed to the proxy's pinned key. A network-exposed plane runs over TLS (self-signed, fingerprint pinned via the QR), so the token isn't sniffable either. Residual: the pin trusts the QR's out-of-band channel, and a stolen token is replayable until the proxy restarts (new token). |
 | Drive the agent to hit an internal/metadata host | SSRF guard refuses link-local (incl. `169.254.169.254`), unspecified, and multicast upstreams; `--block-private-hosts` adds loopback/RFC1918. Applies to forwarded requests and CONNECT tunnels alike. Independent of the per-credential allowlist. |
 | Get the wallet key to sign an arbitrary tx | Bounded by the credential's RPC-host allowlist, plus optional `chainIdAllowlist` / `toAllowlist` (EVM) and `programAllowlist` (Solana) enforced before signing. |
@@ -463,8 +498,16 @@ agent-id-vault add --name openai --type header --header-name X-Api-Key \
 # Start the proxy
 agent-id-proxy start --passphrase-file ~/.agent-id-pass
 
+# …or with the data plane authenticated (0600 file, printable ASCII)
+agent-id-proxy start --passphrase-file ~/.agent-id-pass \
+  --auth-token-file ~/.agent-id-proxy-token
+
 # Use a credential
 curl http://localhost:48771/github-pat/api.github.com/user
+
+# …with the data plane authenticated
+curl -H "X-Agent-Id-Proxy-Token: $(cat ~/.agent-id-proxy-token)" \
+  http://localhost:48771/github-pat/api.github.com/user
 
 # Portability
 agent-id-vault export --out vault.enc           # copy to another machine

--- a/plugins/agent-id-proxy/bin/cli.mjs
+++ b/plugins/agent-id-proxy/bin/cli.mjs
@@ -419,6 +419,30 @@ async function cmdStart(flags) {
     return;
   }
 
+  // Data-plane shared secret (issue #104), read from a file because argv is
+  // world-readable. Read before the vault is opened so a bad flag fails the
+  // startup without ever unsealing anything.
+  const authTokenFile = flags["auth-token-file"];
+  if (authTokenFile === true) {
+    outputError("--auth-token-file needs a path");
+    return;
+  }
+  let authToken = null;
+  if (authTokenFile) {
+    try {
+      authToken = (await fs.readFile(String(authTokenFile), "utf8")).trim();
+    } catch (err) {
+      outputError(`Cannot read --auth-token-file ${authTokenFile}: ${err.message}`);
+      return;
+    }
+    if (!authToken) {
+      outputError(
+        `--auth-token-file ${authTokenFile} is empty — refusing to start unauthenticated.`,
+      );
+      return;
+    }
+  }
+
   const loaded = awaitMobile ? null : await loadVaultForProxy(stateDir, flags);
   const vault = loaded ? loaded.vault : null;
   // Self-reopen is wired only for the agent-key path — the one unlock method
@@ -491,6 +515,7 @@ async function cmdStart(flags) {
     requireConsent,
     grantTtlMs,
     oauthClientSecrets,
+    authToken,
     blockPrivateHosts: !!flags["block-private-hosts"],
     onLock: (reason) => {
       lockNotice({
@@ -728,6 +753,11 @@ function printHelp() {
       "        [--await-mobile]",
       "        [--require-consent] [--approval-timeout 2m] [--grant-ttl 1h]",
       "        [--block-private-hosts]",
+      "        [--auth-token-file F]   opt-in shared secret for the data plane: the proxy",
+      "                          then requires `X-Agent-Id-Proxy-Token: <file contents>` on",
+      "                          every request and CONNECT. Keep the file 0600; the token",
+      "                          never rides argv. Omitted, the data plane stays open to",
+      "                          anything that can reach the port.",
       "        [--oauth-secrets-file F]   0600 JSON {clientId: clientSecret} consulted for",
       "                          oauth2 creds that carry no clientSecret of their own",
       "                          (platform-managed connectors; env: AGENT_ID_OAUTH_SECRETS_FILE)",
@@ -760,6 +790,8 @@ function printHelp() {
       "    `agent-id-vault rekey add-mobile --device-pubkey HEX`, or add an SSO",
       "    owner-approval slot with `agent-id-vault rekey add-owner-approval`",
       "    (the proxy then drives owner approvals itself — no phone app needed).",
+      "CORS: browser preflights (OPTIONS + Access-Control-Request-Method) are always",
+      "  refused locally (403 cross_origin_refused) and never relayed upstream.",
       "SSRF guard: link-local (incl. 169.254.169.254 cloud metadata), unspecified,",
       "  and multicast upstreams are always refused (403 upstream_blocked).",
       "  --block-private-hosts also refuses loopback/RFC1918/ULA targets.",

--- a/plugins/agent-id-proxy/bin/cli.mjs
+++ b/plugins/agent-id-proxy/bin/cli.mjs
@@ -429,15 +429,34 @@ async function cmdStart(flags) {
   }
   let authToken = null;
   if (authTokenFile) {
+    const tokenPath = String(authTokenFile);
     try {
-      authToken = (await fs.readFile(String(authTokenFile), "utf8")).trim();
+      // Same bar as the oauth secrets file: a shared secret readable by every
+      // account on the box is not a boundary at all.
+      const stat = await fs.stat(tokenPath);
+      if (process.platform !== "win32" && (stat.mode & 0o077) !== 0) {
+        outputError(
+          `--auth-token-file ${tokenPath} must not be group/world accessible (chmod 600 it)`,
+        );
+        return;
+      }
+      authToken = (await fs.readFile(tokenPath, "utf8")).trim();
     } catch (err) {
-      outputError(`Cannot read --auth-token-file ${authTokenFile}: ${err.message}`);
+      outputError(`Cannot read --auth-token-file ${tokenPath}: ${err.message}`);
       return;
     }
     if (!authToken) {
+      outputError(`--auth-token-file ${tokenPath} is empty — refusing to start unauthenticated.`);
+      return;
+    }
+    // The file is read as utf8 but the token travels as an HTTP header value,
+    // which is latin1 on the wire — a multi-byte character would arrive as
+    // different bytes and 401 every request with no diagnostic. Refuse loudly
+    // at startup instead.
+    if (!/^[\x21-\x7e]+$/.test(authToken)) {
       outputError(
-        `--auth-token-file ${authTokenFile} is empty — refusing to start unauthenticated.`,
+        `--auth-token-file ${tokenPath} must contain printable ASCII only ` +
+          "(no spaces, no non-ASCII characters) — an HTTP header cannot carry it otherwise.",
       );
       return;
     }
@@ -755,9 +774,10 @@ function printHelp() {
       "        [--block-private-hosts]",
       "        [--auth-token-file F]   opt-in shared secret for the data plane: the proxy",
       "                          then requires `X-Agent-Id-Proxy-Token: <file contents>` on",
-      "                          every request and CONNECT. Keep the file 0600; the token",
-      "                          never rides argv. Omitted, the data plane stays open to",
-      "                          anything that can reach the port.",
+      "                          every request and CONNECT. The file must be 0600 and hold",
+      "                          printable ASCII (an HTTP header carries nothing else); the",
+      "                          token never rides argv. Omitted, the data plane stays open",
+      "                          to anything that can reach the port.",
       "        [--oauth-secrets-file F]   0600 JSON {clientId: clientSecret} consulted for",
       "                          oauth2 creds that carry no clientSecret of their own",
       "                          (platform-managed connectors; env: AGENT_ID_OAUTH_SECRETS_FILE)",
@@ -790,11 +810,13 @@ function printHelp() {
       "    `agent-id-vault rekey add-mobile --device-pubkey HEX`, or add an SSO",
       "    owner-approval slot with `agent-id-vault rekey add-owner-approval`",
       "    (the proxy then drives owner approvals itself — no phone app needed).",
-      "CORS: browser preflights (OPTIONS + Access-Control-Request-Method) are always",
-      "  refused locally (403 cross_origin_refused) and never relayed upstream.",
+      "CORS: a browser preflight (OPTIONS + Access-Control-Request-Method) is never",
+      "  relayed upstream — it is answered locally with 403 cross_origin_refused (or,",
+      "  with --auth-token-file on and no token presented, 401 like any other request).",
       "SSRF guard: link-local (incl. 169.254.169.254 cloud metadata), unspecified,",
       "  and multicast upstreams are always refused (403 upstream_blocked).",
       "  --block-private-hosts also refuses loopback/RFC1918/ULA targets.",
+      "  Applies to CONNECT tunnels too, by literal address and by resolved name.",
       "v1: HTTP only. HTTPS is CONNECT-tunneled without injection — TLS MITM is the next spike.",
     ].join("\n"),
   );

--- a/plugins/agent-id-proxy/lib/proxy.mjs
+++ b/plugins/agent-id-proxy/lib/proxy.mjs
@@ -21,6 +21,7 @@ import http from "node:http";
 import https from "node:https";
 import net from "node:net";
 import { createECDH, createHash, randomBytes, timingSafeEqual } from "node:crypto";
+import fsp from "node:fs/promises";
 import { URL } from "node:url";
 
 import { rewriteHeaders, rewriteUrl, StubError } from "./stub.mjs";
@@ -49,7 +50,7 @@ import {
 import { effectiveAccess, evaluateAccess } from "@alien-id/agent-id-vault/lib/access.mjs";
 import { unsealFromPublicKey } from "@alien-id/agent-id-vault/lib/format.mjs";
 import { fingerprintOfCertPem, generateControlCert } from "./control-tls.mjs";
-import { appendJsonl } from "@alien-id/agent-id-core/lib/state.mjs";
+import { appendJsonl, statePaths } from "@alien-id/agent-id-core/lib/state.mjs";
 
 export { PROXY_AUTH_HEADER };
 
@@ -370,12 +371,52 @@ export function createProxy({
   // reopen failed) refuse to write at all. Losing a rotated token is
   // recoverable — it stays in this process's cache and the owner can re-mint —
   // destroying another writer's credential is not.
+  // `save()` re-encrypts the WHOLE in-memory payload over `vault.enc`, so a
+  // handle that predates another writer's change would erase it. Re-reading
+  // first is the sound fix, but it needs an unlock method we may not have
+  // (passphrase/passkey starts wire no reopen). The fallback is a
+  // compare-and-swap: remember the raw file as we last saw it, and allow a
+  // stale-handle save only while the file is byte-identical — nobody else
+  // wrote, so our snapshot IS current. That keeps a rotated refresh token
+  // persisted for those starts (losing it bricks the credential on the next
+  // restart, since the provider has already retired the one on disk) while
+  // still refusing the one case that can destroy another writer's data.
+  async function readVaultFileText() {
+    if (!stateDir) return null;
+    try {
+      return await fsp.readFile(statePaths(stateDir).vaultFile, "utf8");
+    } catch {
+      return null;
+    }
+  }
+  /// Whether `vault.enc` is still byte-for-byte the envelope THIS handle was
+  /// built from — i.e. nobody else has written since we opened it.
+  ///
+  /// `save()` re-encrypts the whole in-memory payload over the file, so a
+  /// handle that predates another writer's change would erase it. Re-reading
+  /// first is the sound fix, but it needs an unlock method a passphrase/passkey
+  /// start does not have. This is the fallback: allow such a save only while
+  /// the comparison holds. The baseline is the handle's OWN envelope (`raw()`),
+  /// not a snapshot taken later — a snapshot could already include the other
+  /// writer's change and would wave the erasure through. Serialization matches
+  /// the vault's writer exactly (`JSON.stringify(file, null, 2)` + newline);
+  /// any drift there makes this read "changed" and fails closed.
+  async function vaultFileMatchesHandle() {
+    const onDisk = await readVaultFileText();
+    if (onDisk === null || !state.vault) return false;
+    try {
+      return onDisk === JSON.stringify(state.vault.raw(), null, 2) + "\n";
+    } catch {
+      return false;
+    }
+  }
+
   async function persistRotatedRefreshToken(name, refreshToken) {
-    if (!(await tryReopenVault("oauth_rotate"))) {
+    if (!(await tryReopenVault("oauth_rotate")) && !(await vaultFileMatchesHandle())) {
       logAccess({
         event: "oauth_rotate_persist_skipped",
         credential: name,
-        reason: "vault_not_rereadable",
+        reason: "vault_changed_and_not_rereadable",
       }).catch(() => {});
       return false;
     }
@@ -628,12 +669,12 @@ export function createProxy({
       return { ok: false, error: "vault_locked", status: 409 };
     }
     // Pairing writes `vault.enc`, and `save()` re-encrypts this process's whole
-    // in-memory payload — see persistRotatedRefreshToken. Add the slot to a
-    // freshly re-read handle, and when the vault cannot be re-read refuse: a
-    // pairing the owner can retry is cheaper than erasing a credential another
-    // process wrote after this proxy started.
-    if (!(await tryReopenVault("pairing"))) {
-      logAccess({ event: "mobile_register_refused", reason: "vault_not_rereadable" }).catch(
+    // in-memory payload — see persistRotatedRefreshToken. Prefer a freshly
+    // re-read handle; failing that, the compare-and-swap lets the write through
+    // only while nobody else has touched the file, so a pairing still works on
+    // a passphrase/passkey start without risking another writer's data.
+    if (!(await tryReopenVault("pairing")) && !(await vaultFileMatchesHandle())) {
+      logAccess({ event: "mobile_register_refused", reason: "vault_changed_and_not_rereadable" }).catch(
         () => {},
       );
       return { ok: false, error: "vault_reread_unavailable", status: 409 };

--- a/plugins/agent-id-proxy/lib/proxy.mjs
+++ b/plugins/agent-id-proxy/lib/proxy.mjs
@@ -20,7 +20,7 @@
 import http from "node:http";
 import https from "node:https";
 import net from "node:net";
-import { createECDH, randomBytes } from "node:crypto";
+import { createECDH, createHash, randomBytes, timingSafeEqual } from "node:crypto";
 import { URL } from "node:url";
 
 import { rewriteHeaders, rewriteUrl, StubError } from "./stub.mjs";
@@ -28,6 +28,7 @@ import {
   injectCredential,
   parseRewritePath,
   prepareUpstreamHeaders,
+  PROXY_AUTH_HEADER,
   resolveCredential,
   RewriteError,
 } from "./rewrite.mjs";
@@ -50,6 +51,8 @@ import { unsealFromPublicKey } from "@alien-id/agent-id-vault/lib/format.mjs";
 import { fingerprintOfCertPem, generateControlCert } from "./control-tls.mjs";
 import { appendJsonl } from "@alien-id/agent-id-core/lib/state.mjs";
 
+export { PROXY_AUTH_HEADER };
+
 const HOP_BY_HOP_HEADERS = new Set([
   "connection",
   "keep-alive",
@@ -59,6 +62,9 @@ const HOP_BY_HOP_HEADERS = new Set([
   "trailer",
   "transfer-encoding",
   "upgrade",
+  // Terminates at this proxy by definition — the legacy stub path forwards
+  // whatever the agent sent, so the strip has to be explicit here too.
+  PROXY_AUTH_HEADER,
 ]);
 
 function stripHopByHop(headers) {
@@ -159,6 +165,12 @@ export function createProxy({
   // recover from a credential written after spawn or from its own idle lock
   // instead of requiring a restart. Omitted, behavior is unchanged.
   reopenVault = null,
+  // Opt-in shared secret for the DATA plane (the control plane has its own
+  // bearer token). Set, every data-plane request and CONNECT must present it
+  // in the PROXY_AUTH_HEADER; unset, behavior is unchanged. Loopback alone is
+  // a weak boundary wherever the network namespace is shared — a container,
+  // or a machine also running a browser that renders untrusted pages.
+  authToken = null,
 }) {
   const controlEnabled = !!control;
   if (controlEnabled && !stateDir) {
@@ -243,6 +255,19 @@ export function createProxy({
 
   function touchActivity() {
     state.lastRequestAt = now();
+  }
+
+  // Constant-time token check. Both sides are hashed first so the digests are
+  // always 32 bytes and timingSafeEqual can never throw on a length mismatch
+  // (which would also leak the expected length).
+  function authOk(req) {
+    if (authToken === null) return true;
+    const presented = req.headers[PROXY_AUTH_HEADER];
+    if (typeof presented !== "string" || presented.length === 0) return false;
+    return timingSafeEqual(
+      createHash("sha256").update(presented).digest(),
+      createHash("sha256").update(authToken).digest(),
+    );
   }
 
   function doLock(reason) {
@@ -1048,6 +1073,41 @@ export function createProxy({
   const server = http.createServer(async (req, res) => {
     const start = Date.now();
 
+    // Auth runs before EVERYTHING — before the lock check and its self-reopen,
+    // before activity is touched, before routing, the vault, the approval flow
+    // or any upstream socket. An unauthenticated caller must not be able to
+    // observe or drive proxy state, only to be refused.
+    if (!authOk(req)) {
+      logAccess({
+        event: "auth_failed",
+        method: req.method,
+        path: (req.url || "").split("?")[0],
+      });
+      return structuredError(res, 401, {
+        error: "unauthorized",
+        message: `Missing or invalid ${PROXY_AUTH_HEADER} header.`,
+      });
+    }
+    // Defense in depth: the strip lists in prepareUpstreamHeaders and
+    // stripHopByHop are the guarantee, this makes the token unreachable from
+    // every downstream path regardless.
+    delete req.headers[PROXY_AUTH_HEADER];
+
+    // A browser cannot attach a custom header on a simple request, so a
+    // preflight is the only way it could reach an authenticated data plane —
+    // and relaying one upstream would hand a page the upstream's CORS answer.
+    // Refuse locally, with no Access-Control-Allow-* of our own, in both modes.
+    if (req.method === "OPTIONS" && req.headers["access-control-request-method"]) {
+      logAccess({
+        event: "preflight_refused",
+        path: (req.url || "").split("?")[0],
+      });
+      return structuredError(res, 403, {
+        error: "cross_origin_refused",
+        message: "The proxy data plane is not a browser-reachable origin; preflights are refused.",
+      });
+    }
+
     // Locked with no control plane to re-unlock → refuse immediately. When the
     // control plane is enabled the handlers park the request and ask the phone
     // to unlock, so we fall through.
@@ -1104,6 +1164,14 @@ export function createProxy({
     const start = Date.now();
     const [host, portStr] = (req.url || "").split(":");
     const port = parseInt(portStr || "443", 10);
+
+    if (!authOk(req)) {
+      logAccess({ event: "auth_failed", method: "CONNECT" });
+      clientSocket.write("HTTP/1.1 401 Unauthorized\r\n\r\n");
+      clientSocket.destroy();
+      return;
+    }
+    delete req.headers[PROXY_AUTH_HEADER];
 
     if (state.locked) {
       clientSocket.write(

--- a/plugins/agent-id-proxy/lib/proxy.mjs
+++ b/plugins/agent-id-proxy/lib/proxy.mjs
@@ -675,11 +675,33 @@ export function createProxy({
 
   const lookup = (name) => (state.vault ? state.vault.get(name) : null);
 
+  // Every access-log write in flight. Callers fire these and forget, so
+  // close() is the only place that can promise the log is on disk — an
+  // operator reading it after a stop, and every test tearing a state dir down,
+  // relies on that.
+  const pendingLogWrites = new Set();
+
   async function logAccess(entry) {
+    const write = (async () => {
+      try {
+        const owed = entry.event === "auth_failed" ? 0 : takeSuppressedAuthFailures();
+        if (owed > 0) {
+          await appendJsonl(logPath, {
+            ts: new Date().toISOString(),
+            event: "auth_failed_suppressed",
+            suppressed: owed,
+          });
+        }
+        await appendJsonl(logPath, { ts: new Date().toISOString(), ...entry });
+      } catch {
+        // never let logging break a request
+      }
+    })();
+    pendingLogWrites.add(write);
     try {
-      await appendJsonl(logPath, { ts: new Date().toISOString(), ...entry });
-    } catch {
-      // never let logging break a request
+      await write;
+    } finally {
+      pendingLogWrites.delete(write);
     }
   }
 
@@ -690,14 +712,23 @@ export function createProxy({
   // failure after the window carry that count as `suppressed`. Never silent:
   // there is always a record, only its resolution degrades under a flood.
   const authFailLog = { windowStartedAt: -Infinity, suppressed: 0 };
+
+  // The counter must not die with its window: a flood that simply stops leaves
+  // its tail owed a record. Any later log pays the debt, and close() pays
+  // whatever is left, so a suppressed count is never merely forgotten.
+  function takeSuppressedAuthFailures() {
+    const suppressed = authFailLog.suppressed;
+    authFailLog.suppressed = 0;
+    return suppressed;
+  }
+
   function logAuthFailure(entry) {
     if (now() - authFailLog.windowStartedAt < AUTH_FAIL_LOG_WINDOW_MS) {
       authFailLog.suppressed += 1;
       return;
     }
-    const suppressed = authFailLog.suppressed;
+    const suppressed = takeSuppressedAuthFailures();
     authFailLog.windowStartedAt = now();
-    authFailLog.suppressed = 0;
     logAccess({ event: "auth_failed", ...entry, suppressed });
   }
 
@@ -1193,11 +1224,41 @@ export function createProxy({
     clientSocket.destroy();
   }
 
+  // A CONNECT request-target is authority-form — `host:port`, port mandatory
+  // (RFC 9110 §9.3.6). Returns null for anything else, including a port that
+  // isn't a number in range: `net.connect` THROWS on such a port
+  // (ERR_SOCKET_BAD_PORT), and one malformed line must not be able to take the
+  // proxy down.
+  function parseConnectTarget(target) {
+    const m = /^(\[[0-9A-Fa-f:.]+\]|[^:[\]]+):(\d{1,5})$/.exec(target || "");
+    if (!m) return null;
+    const port = Number(m[2]);
+    if (port < 1 || port > 65535) return null;
+    // An IPv6 literal arrives bracketed; the SSRF guard and net.connect both
+    // want it bare.
+    return { host: m[1].replace(/^\[|\]$/g, ""), port };
+  }
+
   // CONNECT tunneling for HTTPS. No MITM in v1.
-  server.on("connect", async (req, clientSocket, head) => {
+  server.on("connect", (req, clientSocket, head) => {
+    // The handler is async, so anything it throws would surface as an
+    // unhandled rejection — process death for a proxy that is supposed to
+    // answer a bad request, not die of it.
+    handleConnect(req, clientSocket, head).catch((err) => {
+      refuseConnect(clientSocket, "500 Internal Server Error", "proxy_internal");
+      logAccess({
+        method: "CONNECT",
+        host: null,
+        path: null,
+        status: 500,
+        credentials: [],
+        error: (err && (err.code || err.message)) || "proxy_internal",
+      });
+    });
+  });
+
+  async function handleConnect(req, clientSocket, head) {
     const start = Date.now();
-    const [host, portStr] = (req.url || "").split(":");
-    const port = parseInt(portStr || "443", 10);
 
     if (!authOk(req)) {
       logAuthFailure({ method: "CONNECT" });
@@ -1206,17 +1267,35 @@ export function createProxy({
     }
     delete req.headers[PROXY_AUTH_HEADER];
 
-    // Same self-heal the request handler gets on an idle lock: on the
-    // auto-unlock path a reopen needs no human. A tunnel has no parked-request
-    // path to fall through to, so a failed reopen is still a refusal.
-    if (state.locked && !(await tryReopenVault("idle_lock"))) {
-      refuseConnect(clientSocket, "401 Vault Locked", "vault_locked");
+    // Before the lock check: a malformed target is refused on its own terms,
+    // never a reason to reopen a vault.
+    const target = parseConnectTarget(req.url);
+    if (!target) {
+      refuseConnect(clientSocket, "400 Bad Request", "bad_request");
+      logAccess({
+        method: "CONNECT",
+        host: null,
+        path: null,
+        status: 400,
+        credentials: [],
+        durationMs: Date.now() - start,
+        error: "bad_request",
+      });
       return;
     }
+    const { host, port } = target;
 
-    if (!host) {
-      refuseConnect(clientSocket, "400 Bad Request", "bad_request");
-      return;
+    // Same self-heal the request handler gets on an idle lock, under the same
+    // gate: on the unattended auto-unlock path (no control plane) a reopen
+    // needs no human. With the control plane on, the unlock is the owner's
+    // decision — and a tunnel has no parked-request path to fall through to,
+    // so there it stays a refusal.
+    if (state.locked) {
+      const reopened = !controlEnabled && (await tryReopenVault("idle_lock"));
+      if (!reopened) {
+        refuseConnect(clientSocket, "401 Vault Locked", "vault_locked");
+        return;
+      }
     }
 
     // SSRF guard, same two layers as forwardUpstream: a literal-IP target is
@@ -1283,7 +1362,7 @@ export function createProxy({
     });
 
     clientSocket.on("error", () => upstream.destroy());
-  });
+  }
 
   function handleStubError(res, err) {
     if (err instanceof StubError) {
@@ -1336,9 +1415,15 @@ export function createProxy({
     async close() {
       if (ticker) clearInterval(ticker);
       if (registry) registry.cancelAll("proxy_shutdown");
+      const owed = takeSuppressedAuthFailures();
+      if (owed > 0) await logAccess({ event: "auth_failed_suppressed", suppressed: owed });
       doLock("proxy_shutdown");
       if (controlServer) await controlServer.close();
       await new Promise((resolve) => server.close(() => resolve()));
+      // The log is written fire-and-forget everywhere else; a closed proxy owes
+      // the caller a settled log (nothing still writing into a state dir that
+      // is about to go).
+      await Promise.allSettled([...pendingLogWrites]);
     },
     get locked() {
       return state.locked;

--- a/plugins/agent-id-proxy/lib/proxy.mjs
+++ b/plugins/agent-id-proxy/lib/proxy.mjs
@@ -1167,7 +1167,11 @@ export function createProxy({
 
     if (!authOk(req)) {
       logAccess({ event: "auth_failed", method: "CONNECT" });
-      clientSocket.write("HTTP/1.1 401 Unauthorized\r\n\r\n");
+      clientSocket.write(
+        "HTTP/1.1 401 Unauthorized\r\n" +
+          "X-AgentVault-Proxy-Error: unauthorized\r\n" +
+          "Content-Length: 0\r\n\r\n",
+      );
       clientSocket.destroy();
       return;
     }

--- a/plugins/agent-id-proxy/lib/proxy.mjs
+++ b/plugins/agent-id-proxy/lib/proxy.mjs
@@ -133,6 +133,9 @@ function structuredError(res, status, body) {
 export const DEFAULT_IDLE_TIMEOUT_MS = 12 * 60 * 60 * 1000;
 const IDLE_TICK_MS = 60 * 1000;
 
+// Coalescing window for rejected-request logging (see logAuthFailure).
+const AUTH_FAIL_LOG_WINDOW_MS = 60 * 1000;
+
 export function createProxy({
   vault = null,
   logPath,
@@ -680,6 +683,24 @@ export function createProxy({
     }
   }
 
+  // An unauthenticated caller must not be able to grow the access log at will —
+  // the refusal is written before any other check, so anything that can reach
+  // the port could otherwise fill the disk one line per request. Policy: log
+  // the first failure of a window verbatim, count the rest, and let the first
+  // failure after the window carry that count as `suppressed`. Never silent:
+  // there is always a record, only its resolution degrades under a flood.
+  const authFailLog = { windowStartedAt: -Infinity, suppressed: 0 };
+  function logAuthFailure(entry) {
+    if (now() - authFailLog.windowStartedAt < AUTH_FAIL_LOG_WINDOW_MS) {
+      authFailLog.suppressed += 1;
+      return;
+    }
+    const suppressed = authFailLog.suppressed;
+    authFailLog.windowStartedAt = now();
+    authFailLog.suppressed = 0;
+    logAccess({ event: "auth_failed", ...entry, suppressed });
+  }
+
   // Stream the agent's request through to the configured upstream. Shared
   // by both URL-rewrite and stub-injection paths.
   function forwardUpstream({
@@ -1078,11 +1099,7 @@ export function createProxy({
     // or any upstream socket. An unauthenticated caller must not be able to
     // observe or drive proxy state, only to be refused.
     if (!authOk(req)) {
-      logAccess({
-        event: "auth_failed",
-        method: req.method,
-        path: (req.url || "").split("?")[0],
-      });
+      logAuthFailure({ method: req.method, path: (req.url || "").split("?")[0] });
       return structuredError(res, 401, {
         error: "unauthorized",
         message: `Missing or invalid ${PROXY_AUTH_HEADER} header.`,
@@ -1159,43 +1176,73 @@ export function createProxy({
     }
   });
 
+  // Every CONNECT refusal shares one wire shape — status line, a machine-
+  // readable error header, explicit zero-length body — so a tunnel client can
+  // tell the refusals apart without parsing prose.
+  function refuseConnect(clientSocket, statusLine, error) {
+    // The refusal can land after an await (the reopen attempt) or after the
+    // tunnel broke, so the client may already be gone — writing to it must not
+    // surface as an unhandled socket error.
+    clientSocket.on("error", () => {});
+    if (clientSocket.destroyed) return;
+    clientSocket.write(
+      `HTTP/1.1 ${statusLine}\r\n` +
+        `X-AgentVault-Proxy-Error: ${error}\r\n` +
+        "Content-Length: 0\r\n\r\n",
+    );
+    clientSocket.destroy();
+  }
+
   // CONNECT tunneling for HTTPS. No MITM in v1.
-  server.on("connect", (req, clientSocket, head) => {
+  server.on("connect", async (req, clientSocket, head) => {
     const start = Date.now();
     const [host, portStr] = (req.url || "").split(":");
     const port = parseInt(portStr || "443", 10);
 
     if (!authOk(req)) {
-      logAccess({ event: "auth_failed", method: "CONNECT" });
-      clientSocket.write(
-        "HTTP/1.1 401 Unauthorized\r\n" +
-          "X-AgentVault-Proxy-Error: unauthorized\r\n" +
-          "Content-Length: 0\r\n\r\n",
-      );
-      clientSocket.destroy();
+      logAuthFailure({ method: "CONNECT" });
+      refuseConnect(clientSocket, "401 Unauthorized", "unauthorized");
       return;
     }
     delete req.headers[PROXY_AUTH_HEADER];
 
-    if (state.locked) {
-      clientSocket.write(
-        "HTTP/1.1 401 Vault Locked\r\n" +
-          "X-AgentVault-Proxy-Error: vault_locked\r\n" +
-          "Content-Length: 0\r\n\r\n",
-      );
-      clientSocket.destroy();
+    // Same self-heal the request handler gets on an idle lock: on the
+    // auto-unlock path a reopen needs no human. A tunnel has no parked-request
+    // path to fall through to, so a failed reopen is still a refusal.
+    if (state.locked && !(await tryReopenVault("idle_lock"))) {
+      refuseConnect(clientSocket, "401 Vault Locked", "vault_locked");
       return;
     }
 
     if (!host) {
-      clientSocket.write("HTTP/1.1 400 Bad Request\r\n\r\n");
-      clientSocket.destroy();
+      refuseConnect(clientSocket, "400 Bad Request", "bad_request");
+      return;
+    }
+
+    // SSRF guard, same two layers as forwardUpstream: a literal-IP target is
+    // checked here (node skips `lookup` for literals), a hostname at connect
+    // time via the shared lookup below — so a tunnel can no more reach
+    // 169.254.169.254 (or, under --block-private-hosts, a loopback/RFC1918
+    // target) than a forwarded request can.
+    const literalBlock = blockedAddressReason(host, { blockPrivate: blockPrivateHosts });
+    if (literalBlock) {
+      refuseConnect(clientSocket, "403 Forbidden", "upstream_blocked");
+      logAccess({
+        method: "CONNECT",
+        host,
+        path: null,
+        status: 403,
+        credentials: [],
+        durationMs: Date.now() - start,
+        error: "upstream_blocked",
+        reason: literalBlock,
+      });
       return;
     }
 
     touchActivity();
 
-    const upstream = net.connect(port, host, () => {
+    const upstream = net.connect({ host, port, lookup: upstreamLookup }, () => {
       clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
       if (head.length) upstream.write(head);
       upstream.pipe(clientSocket);
@@ -1214,13 +1261,19 @@ export function createProxy({
     });
 
     upstream.on("error", (err) => {
-      clientSocket.write(`HTTP/1.1 502 Bad Gateway\r\n\r\n`);
-      clientSocket.destroy();
+      // The connect-time lookup rejected a resolved address → the same 403 the
+      // literal check gives, not a generic 502.
+      const blocked = err.code === "ESSRFBLOCKED";
+      refuseConnect(
+        clientSocket,
+        blocked ? "403 Forbidden" : "502 Bad Gateway",
+        blocked ? "upstream_blocked" : "upstream_error",
+      );
       logAccess({
         method: "CONNECT",
         host,
         path: null,
-        status: 502,
+        status: blocked ? 403 : 502,
         credentials: [],
         bytesIn: 0,
         bytesOut: 0,

--- a/plugins/agent-id-proxy/lib/rewrite.mjs
+++ b/plugins/agent-id-proxy/lib/rewrite.mjs
@@ -18,6 +18,11 @@
 import { generateTotp } from "./totp.mjs";
 import { hostMatchesAllowlist } from "@alien-id/agent-id-vault/lib/store.mjs";
 
+// Shared-secret header for the opt-in data-plane auth. It lives here rather
+// than in proxy.mjs because proxy.mjs imports this module — the reverse edge
+// would be an import cycle — and this is the module that strips it.
+export const PROXY_AUTH_HEADER = "x-agent-id-proxy-token";
+
 const CREDNAME_RE = /^[a-zA-Z0-9._-]{1,64}$/;
 const HOST_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9.-]{0,253}[a-zA-Z0-9])?(?::\d{1,5})?$/;
 
@@ -160,6 +165,7 @@ function appendCookie(existing, addition) {
  *
  *   - Host: will be set to the upstream's host below.
  *   - Origin / Referer: leak the proxy's localhost URL; strip.
+ *   - The proxy auth token: a proxy-hop secret, never an upstream's business.
  *   - Connection-class hop-by-hop headers: per RFC 9110 §7.6.1.
  *   - Authorization: only when the credential doesn't itself materialize
  *     into Authorization — otherwise the inject step replaces it anyway.
@@ -182,6 +188,7 @@ export function prepareUpstreamHeaders({ incoming, upstreamHost }) {
     if (HOP_BY_HOP.has(lk)) continue;
     if (lk === "host") continue;
     if (lk === "origin" || lk === "referer") continue;
+    if (lk === PROXY_AUTH_HEADER) continue;
     out[lk] = v;
   }
   out.host = upstreamHost;

--- a/plugins/agent-id-proxy/skills/agent-id-proxy/SKILL.md
+++ b/plugins/agent-id-proxy/skills/agent-id-proxy/SKILL.md
@@ -37,7 +37,21 @@ node CLI start --passphrase-file ~/.agent-id-pass
 
 # Idle auto-lock window (default 12h; "never" disables for unattended agents):
 node CLI start --idle-timeout 30m
+
+# Authenticate the data plane (loopback alone is a weak boundary in a shared
+# network namespace). The file must be 0600 and hold printable ASCII; the token
+# never rides argv:
+node CLI start --auth-token-file ~/.agent-id-proxy-token
 ```
+
+With `--auth-token-file`, every proxy call — including `CONNECT` tunnels — must present the token, or the answer is `401 {error: "unauthorized"}`:
+
+```bash
+curl -H "X-Agent-Id-Proxy-Token: $(cat ~/.agent-id-proxy-token)" \
+  http://localhost:48771/github-pat/api.github.com/user
+```
+
+The header is stripped before anything is forwarded upstream, and the check runs before the vault is touched at all. The control plane is unaffected — it has its own bearer token.
 
 The CLI prints the suggested env exports. Set them in any shell that should route through the proxy:
 
@@ -176,8 +190,8 @@ Prefer Mode 1 for new code.
 
 After `--idle-timeout` of no traffic (default **12h**, 1Password parity), the proxy zeroes the master key + drops decrypted credential records. What the next request gets depends on how the vault was unlocked at start:
 
-- **Agent-key auto-unlock** (the default — not `--unlock-form`, not `--no-agent-key`) **with `--no-control`:** the proxy re-opens the vault itself and the request proceeds. No human, no restart.
-- **Control plane on** (the default) with a phone or owner-approval slot: the request parks until the unlock is approved — unchanged, unlock stays an owner action there.
+- **Agent-key auto-unlock** (the default — not `--unlock-form`, not `--no-agent-key`) **with `--no-control`:** the proxy re-opens the vault itself and the request proceeds. No human, no restart. A `CONNECT` tunnel is re-opened the same way.
+- **Control plane on** (the default) with a phone or owner-approval slot: the request parks until the unlock is approved — unchanged, unlock stays an owner action there. A `CONNECT` tunnel has nowhere to park, so it is refused with `401 vault_locked` rather than re-unlocking itself.
 - **Control plane on with nothing to ask** (no paired device, no owner-approval slot): `401 {error: "no_unlock_method"}` on every request, agent key or not — self-reopen is reached only with `--no-control`. Pair a device before the lock, or restart the proxy.
 - **Anything else** (passphrase, passkey, `--unlock-form`): `401 {error: "vault_locked"}`; restart to re-unlock:
 
@@ -206,9 +220,10 @@ With agent-key auto-unlock (any control-plane setting), a `credential_not_found`
 { "ok": false, "error": "vault_locked", "reason": "idle_timeout" }
 { "ok": false, "error": "access_denied", "credential": "mail-ro", "access": "ro", "reason": "write_blocked" }
 { "ok": false, "error": "bad_request", "message": "..." }
+{ "ok": false, "error": "unauthorized", "message": "..." }
 ```
 
-The `X-AgentVault-Proxy-Error` response header carries the same code.
+The `X-AgentVault-Proxy-Error` response header carries the same code. A `CONNECT` refusal has no JSON body — it is a status line plus that header (`unauthorized`, `vault_locked`, `bad_request` for a target that is not `host:port`, `upstream_blocked`, `upstream_error`).
 
 ## Status + stop
 
@@ -219,7 +234,7 @@ node CLI stop
 
 ## Limitations
 
-- **HTTPS only at the upstream leg** in URL-rewrite mode. The agent-to-proxy leg is plain HTTP loopback by design.
+- **HTTPS only at the upstream leg** in URL-rewrite mode. The agent-to-proxy leg is plain HTTP loopback by design; `--auth-token-file` gates who may use it, but does not encrypt it.
 - Authorization gates: per-credential **host allowlist**, **access level**
   (`ro`/`rw` + rules), and — when started with `--require-consent` — a
   per-(credential, host) human consent grant.

--- a/tests/test-proxy-auth-cli.mjs
+++ b/tests/test-proxy-auth-cli.mjs
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+
+// `agent-id-proxy start --auth-token-file` end to end, through the REAL CLI.
+// The plumbing from the flag to the running proxy has to be exercised as a
+// whole: a typo in the option name, or a refactor that drops the field, would
+// otherwise start a fully UNAUTHENTICATED proxy while the operator believes
+// auth is on — a failure that is invisible until someone reaches the port.
+// The token file itself is held to the same 0600 bar as the other secret files
+// the proxy reads, and to a charset the wire can actually carry.
+//
+// Run: node --test tests/test-proxy-auth-cli.mjs
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { generateKeyPairSync } from "node:crypto";
+import fs from "node:fs/promises";
+import http from "node:http";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+
+import { initVault, openVault } from "../plugins/agent-id-vault/lib/vault.mjs";
+import { writeJsonFile, statePaths } from "../plugins/agent-id-core/lib/state.mjs";
+import { fingerprintPublicKeyPem } from "../plugins/agent-id-core/lib/crypto.mjs";
+import { PROXY_AUTH_HEADER } from "../plugins/agent-id-proxy/lib/proxy.mjs";
+
+const CLI = new URL("../plugins/agent-id-proxy/bin/cli.mjs", import.meta.url).pathname;
+const TOKEN = "cli-plumbing-token";
+
+function freePort() {
+  return new Promise((resolve) => {
+    const s = net.createServer();
+    s.listen(0, "127.0.0.1", () => {
+      const { port } = s.address();
+      s.close(() => resolve(port));
+    });
+  });
+}
+
+function startUpstream() {
+  return new Promise((resolve) => {
+    const requests = [];
+    const server = http.createServer((req, res) => {
+      requests.push({ url: req.url, authorization: req.headers.authorization || null });
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end('{"ok":true}');
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const a = server.address();
+      resolve({ server, requests, host: `${a.address}:${a.port}`, hostname: a.address });
+    });
+  });
+}
+
+// An agent-key vault: the one unlock path a spawned proxy can walk with no
+// human, so the CLI reaches "listening" unattended.
+async function makeAgentKeyVault(stateDir, upstreamHostname) {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const publicKeyPem = publicKey.export({ format: "pem", type: "spki" }).toString();
+  const privateKeyPem = privateKey.export({ format: "pem", type: "pkcs8" }).toString();
+  await writeJsonFile(statePaths(stateDir).mainKey, {
+    version: 1,
+    agentId: "main",
+    keyNonce: 0,
+    createdAt: 1,
+    publicKeyPem,
+    privateKeyPem,
+    fingerprint: fingerprintPublicKeyPem(publicKeyPem),
+  });
+  await initVault({ stateDir, privateKeyPem, agentId: "main" });
+  const v = await openVault({ stateDir, privateKeyPem });
+  v.add({
+    name: "tok",
+    type: "bearer",
+    domains: [upstreamHostname],
+    value: "SECRET-VALUE",
+    upstreamScheme: "http",
+  });
+  await v.save();
+  v.lock();
+}
+
+function spawnStart(args) {
+  const child = spawn("node", [CLI, "start", ...args], {
+    env: { ...process.env, AGENT_ID_NO_BROWSER: "1" },
+  });
+  const out = { stdout: "", stderr: "" };
+  child.stdout.on("data", (d) => (out.stdout += d));
+  child.stderr.on("data", (d) => (out.stderr += d));
+  return { child, out };
+}
+
+function waitForStderr({ child, out }, re, ms) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`timeout waiting for ${re}\n${out.stderr}\n${out.stdout}`)),
+      ms,
+    );
+    const check = () => {
+      const m = out.stderr.match(re);
+      if (m) {
+        clearTimeout(timer);
+        resolve(m[0]);
+      }
+    };
+    child.stderr.on("data", check);
+    child.on("exit", () => {
+      clearTimeout(timer);
+      reject(new Error(`proxy exited early\n${out.stderr}\n${out.stdout}`));
+    });
+    check();
+  });
+}
+
+// A CLI that refuses the token file must EXIT; a run that keeps going is the
+// bug under test, so the wait is bounded rather than hanging the suite.
+function waitForExit({ child, out }, ms = 15000) {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      resolve({ code: "still-running", ...out });
+    }, ms);
+    child.on("exit", (code) => {
+      clearTimeout(timer);
+      resolve({ code, ...out });
+    });
+  });
+}
+
+function proxyRequest({ port, target, headers = {} }) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { host: "127.0.0.1", port, method: "GET", path: target, headers },
+      (res) => {
+        const chunks = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () =>
+          resolve({ status: res.statusCode, body: Buffer.concat(chunks).toString("utf8") }),
+        );
+      },
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+describe("CLI --auth-token-file reaches the running data plane", () => {
+  let dir;
+  let upstream;
+  let proc;
+  let port;
+
+  before(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "proxy-auth-cli-"));
+    upstream = await startUpstream();
+    await makeAgentKeyVault(dir, upstream.hostname);
+    const tokenFile = path.join(dir, "token");
+    await fs.writeFile(tokenFile, `${TOKEN}\n`, { mode: 0o600 });
+    port = await freePort();
+    proc = spawnStart([
+      "--auth-token-file", tokenFile,
+      "--no-control",
+      "--idle-timeout", "never",
+      "--port", String(port),
+      "--state-dir", dir,
+    ]);
+    await waitForStderr(proc, /agent-id-proxy listening on/, 15000);
+  });
+
+  after(async () => {
+    proc?.child.kill("SIGKILL");
+    upstream?.server.close();
+    if (dir) await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("refuses a tokenless data-plane request", async () => {
+    const before = upstream.requests.length;
+    const r = await proxyRequest({ port, target: `/tok/${upstream.host}/a` });
+    assert.equal(r.status, 401);
+    assert.equal(JSON.parse(r.body).error, "unauthorized");
+    assert.equal(upstream.requests.length, before);
+  });
+
+  it("serves the same request when the token from the file is presented", async () => {
+    const r = await proxyRequest({
+      port,
+      target: `/tok/${upstream.host}/a`,
+      headers: { [PROXY_AUTH_HEADER]: TOKEN },
+    });
+    assert.equal(r.status, 200);
+    assert.equal(upstream.requests.at(-1).authorization, "Bearer SECRET-VALUE");
+  });
+
+  it("never leaks the token to the agent-visible streams", () => {
+    assert.ok(!proc.out.stdout.includes(TOKEN), "stdout leaked the token");
+    assert.ok(!proc.out.stderr.includes(TOKEN), "stderr leaked the token");
+  });
+});
+
+describe("CLI --auth-token-file validation", () => {
+  let dir;
+  let port;
+
+  before(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "proxy-auth-cli-bad-"));
+    await makeAgentKeyVault(dir, "127.0.0.1");
+    port = await freePort();
+  });
+
+  after(async () => {
+    if (dir) await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  async function startWithTokenFile(name, contents, mode) {
+    const tokenFile = path.join(dir, name);
+    await fs.writeFile(tokenFile, contents, { mode });
+    await fs.chmod(tokenFile, mode);
+    const proc = spawnStart([
+      "--auth-token-file", tokenFile,
+      "--no-control",
+      "--idle-timeout", "never",
+      "--port", String(port),
+      "--state-dir", dir,
+    ]);
+    const result = await waitForExit(proc);
+    return { ...result, tokenFile };
+  }
+
+  it("refuses a group/world-readable token file", async () => {
+    const r = await startWithTokenFile("loose-token", `${TOKEN}\n`, 0o644);
+    assert.equal(r.code, 1);
+    const payload = JSON.parse(r.stdout);
+    assert.equal(payload.ok, false);
+    assert.match(payload.error, /group\/world accessible/i);
+    assert.ok(payload.error.includes(r.tokenFile), "the error must name the offending path");
+  });
+
+  it("refuses a token that cannot survive an HTTP header", async () => {
+    const r = await startWithTokenFile("nonascii-token", "tökén-value\n", 0o600);
+    assert.equal(r.code, 1);
+    const payload = JSON.parse(r.stdout);
+    assert.equal(payload.ok, false);
+    assert.match(payload.error, /printable ASCII/i);
+    assert.ok(payload.error.includes(r.tokenFile), "the error must name the offending path");
+  });
+});

--- a/tests/test-proxy-auth.mjs
+++ b/tests/test-proxy-auth.mjs
@@ -174,7 +174,27 @@ describe("data-plane auth: stub-injection mode", () => {
     assert.equal(seen.headers[PROXY_AUTH_HEADER], undefined);
   });
 
-  it("refuses a CORS preflight locally", async () => {
+  // Auth runs first, so with a token configured an unauthenticated preflight is
+  // an auth failure, not a CORS one — the refusal must not tell an unauthorized
+  // caller anything more specific than "unauthorized".
+  it("answers an unauthenticated preflight with 401, not the CORS refusal", async () => {
+    const before = upstream.requests.length;
+    const r = await proxyRequest({
+      port: proxyPort,
+      target: `${upstream.url}/c`,
+      method: "OPTIONS",
+      headers: {
+        Origin: "https://evil.example",
+        "Access-Control-Request-Method": "GET",
+      },
+    });
+    assert.equal(r.status, 401);
+    assert.equal(JSON.parse(r.body).error, "unauthorized");
+    assert.equal(r.headers["access-control-allow-origin"], undefined);
+    assert.equal(upstream.requests.length, before);
+  });
+
+  it("refuses an authenticated CORS preflight locally", async () => {
     const before = upstream.requests.length;
     const r = await proxyRequest({
       port: proxyPort,
@@ -295,6 +315,81 @@ describe("data-plane auth precedes vault state", () => {
     });
     assert.equal(r.status, 200);
     assert.equal(reopenCalls, 1);
+  });
+});
+
+describe("auth_failed logging is bounded", () => {
+  let stateDir;
+  let upstream;
+  let proxy;
+  let proxyPort;
+  let logFile;
+  let clock;
+
+  const BURST = 30;
+
+  async function flood(tag) {
+    for (let i = 0; i < BURST; i++) {
+      const r = await proxyRequest({ port: proxyPort, target: `${upstream.url}/${tag}${i}` });
+      assert.equal(r.status, 401);
+    }
+    // logAccess is fire-and-forget on the request path — let the writes settle.
+    await new Promise((r) => setTimeout(r, 200));
+  }
+
+  async function authFailedLines() {
+    return (await fs.readFile(logFile, "utf8"))
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => JSON.parse(l))
+      .filter((e) => e.event === "auth_failed");
+  }
+
+  before(async () => {
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "proxy-auth-flood-"));
+    upstream = await startUpstream();
+    logFile = path.join(stateDir, "proxy.log");
+    clock = Date.now();
+    proxy = createProxy({
+      vault: await setupVault(stateDir, new URL(upstream.url).hostname),
+      logPath: logFile,
+      authToken: TOKEN,
+      now: () => clock,
+    });
+    proxyPort = (await proxy.listen()).port;
+  });
+
+  after(async () => {
+    await proxy?.close();
+    upstream?.server.close();
+    if (stateDir) await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  it("coalesces a flood of rejected requests instead of a line per request", async () => {
+    await flood("flood");
+    const lines = await authFailedLines();
+    assert.ok(lines.length >= 1, "the refusals must leave at least one record");
+    assert.ok(
+      lines.length <= 3,
+      `expected the ${BURST} refusals to coalesce, got ${lines.length} lines`,
+    );
+  });
+
+  it("reports how many refusals were suppressed once the window rolls over", async () => {
+    const before = (await authFailedLines()).length;
+    clock += 10 * 60 * 1000;
+    await flood("flood2");
+    const lines = await authFailedLines();
+    assert.ok(
+      lines.length <= before + 3,
+      `expected the second burst to coalesce, got ${lines.length - before} new lines`,
+    );
+    const rolled = lines[before];
+    assert.ok(rolled, "the rolled-over window must emit a line");
+    assert.ok(
+      rolled.suppressed >= BURST - 2,
+      `expected the suppressed count of the first burst, got ${rolled.suppressed}`,
+    );
   });
 });
 

--- a/tests/test-proxy-auth.mjs
+++ b/tests/test-proxy-auth.mjs
@@ -1,0 +1,357 @@
+#!/usr/bin/env node
+
+// Opt-in data-plane authentication (issue #104). Loopback possession alone
+// must not be enough to make the proxy attach a credential wherever the
+// network namespace is shared. The token check runs before the vault, and the
+// token itself never reaches an upstream. CORS preflights are refused locally
+// in both modes.
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { initVault, openVault } from "../plugins/agent-id-vault/lib/vault.mjs";
+import { createProxy, PROXY_AUTH_HEADER } from "../plugins/agent-id-proxy/lib/proxy.mjs";
+import { prepareUpstreamHeaders } from "../plugins/agent-id-proxy/lib/rewrite.mjs";
+
+const TOKEN = "s3cret-proxy-token";
+
+function startUpstream() {
+  return new Promise((resolve) => {
+    const requests = [];
+    const server = http.createServer((req, res) => {
+      requests.push({
+        url: req.url,
+        method: req.method,
+        authorization: req.headers.authorization || null,
+        headers: { ...req.headers },
+      });
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end('{"ok":true}');
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const a = server.address();
+      resolve({ server, url: `http://${a.address}:${a.port}`, requests });
+    });
+  });
+}
+
+// Absolute-URI target → legacy stub mode; a "/cred/host/path" target → the
+// URL-rewrite mode. Host is only defaulted for the former.
+function proxyRequest({ port, target, method = "GET", headers = {} }) {
+  return new Promise((resolve, reject) => {
+    const absolute = /^https?:\/\//i.test(target);
+    const baseHeaders = absolute ? { Host: new URL(target).host } : {};
+    const req = http.request(
+      {
+        host: "127.0.0.1",
+        port,
+        method,
+        path: target,
+        headers: { ...baseHeaders, ...headers },
+      },
+      (res) => {
+        const chunks = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () =>
+          resolve({
+            status: res.statusCode,
+            headers: res.headers,
+            body: Buffer.concat(chunks).toString("utf8"),
+          }),
+        );
+      },
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+async function setupVault(stateDir, upstreamHost) {
+  await initVault({ stateDir, passphrase: "p" });
+  const writer = await openVault({ stateDir, passphrase: "p" });
+  writer.add({
+    name: "tok",
+    type: "bearer",
+    domains: [upstreamHost],
+    value: "SECRET-VALUE",
+    upstreamScheme: "http",
+  });
+  await writer.save();
+  writer.lock();
+  return openVault({ stateDir, passphrase: "p" });
+}
+
+describe("upstream header preparation (unit)", () => {
+  it("drops the proxy auth token alongside origin/referer", () => {
+    const out = prepareUpstreamHeaders({
+      incoming: {
+        [PROXY_AUTH_HEADER]: TOKEN,
+        origin: "http://127.0.0.1:1",
+        referer: "http://127.0.0.1:1/x",
+        accept: "application/json",
+      },
+      upstreamHost: "api.example.com",
+    });
+    assert.equal(out[PROXY_AUTH_HEADER], undefined);
+    assert.equal(out.origin, undefined);
+    assert.equal(out.accept, "application/json");
+    assert.equal(out.host, "api.example.com");
+  });
+});
+
+describe("data-plane auth: stub-injection mode", () => {
+  let stateDir;
+  let upstream;
+  let proxy;
+  let proxyPort;
+
+  before(async () => {
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "proxy-auth-stub-"));
+    upstream = await startUpstream();
+    const vault = await setupVault(stateDir, new URL(upstream.url).hostname);
+    proxy = createProxy({
+      vault,
+      logPath: path.join(stateDir, "proxy.log"),
+      authToken: TOKEN,
+    });
+    proxyPort = (await proxy.listen()).port;
+  });
+
+  after(async () => {
+    await proxy?.close();
+    upstream?.server.close();
+    if (stateDir) await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  it("refuses a request with no token and never contacts the upstream", async () => {
+    const before = upstream.requests.length;
+    const r = await proxyRequest({
+      port: proxyPort,
+      target: `${upstream.url}/a`,
+      headers: { Authorization: "AgentVault tok" },
+    });
+    assert.equal(r.status, 401);
+    assert.equal(JSON.parse(r.body).error, "unauthorized");
+    assert.equal(upstream.requests.length, before);
+  });
+
+  it("refuses a wrong token and never contacts the upstream", async () => {
+    const before = upstream.requests.length;
+    const r = await proxyRequest({
+      port: proxyPort,
+      target: `${upstream.url}/b`,
+      headers: { Authorization: "AgentVault tok", [PROXY_AUTH_HEADER]: `${TOKEN}x` },
+    });
+    assert.equal(r.status, 401);
+    assert.equal(JSON.parse(r.body).error, "unauthorized");
+    assert.equal(upstream.requests.length, before);
+  });
+
+  it("refuses an empty token", async () => {
+    const before = upstream.requests.length;
+    const r = await proxyRequest({
+      port: proxyPort,
+      target: `${upstream.url}/b2`,
+      headers: { Authorization: "AgentVault tok", [PROXY_AUTH_HEADER]: "" },
+    });
+    assert.equal(r.status, 401);
+    assert.equal(upstream.requests.length, before);
+  });
+
+  it("injects the credential on a correct token, and the upstream never sees the token", async () => {
+    const r = await proxyRequest({
+      port: proxyPort,
+      target: `${upstream.url}/c`,
+      headers: { Authorization: "AgentVault tok", [PROXY_AUTH_HEADER]: TOKEN },
+    });
+    assert.equal(r.status, 200);
+    const seen = upstream.requests.at(-1);
+    assert.equal(seen.authorization, "Bearer SECRET-VALUE");
+    assert.equal(seen.headers[PROXY_AUTH_HEADER], undefined);
+  });
+
+  it("refuses a CORS preflight locally", async () => {
+    const before = upstream.requests.length;
+    const r = await proxyRequest({
+      port: proxyPort,
+      target: `${upstream.url}/c`,
+      method: "OPTIONS",
+      headers: {
+        Origin: "https://evil.example",
+        "Access-Control-Request-Method": "GET",
+        [PROXY_AUTH_HEADER]: TOKEN,
+      },
+    });
+    assert.equal(r.status, 403);
+    assert.equal(JSON.parse(r.body).error, "cross_origin_refused");
+    assert.equal(r.headers["access-control-allow-origin"], undefined);
+    assert.equal(upstream.requests.length, before);
+  });
+});
+
+describe("data-plane auth: URL-rewrite mode", () => {
+  let stateDir;
+  let upstream;
+  let proxy;
+  let proxyPort;
+  let upstreamAuthority;
+
+  before(async () => {
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "proxy-auth-rewrite-"));
+    upstream = await startUpstream();
+    upstreamAuthority = new URL(upstream.url).host;
+    const vault = await setupVault(stateDir, new URL(upstream.url).hostname);
+    proxy = createProxy({
+      vault,
+      logPath: path.join(stateDir, "proxy.log"),
+      authToken: TOKEN,
+    });
+    proxyPort = (await proxy.listen()).port;
+  });
+
+  after(async () => {
+    await proxy?.close();
+    upstream?.server.close();
+    if (stateDir) await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  it("refuses a request with no token and never contacts the upstream", async () => {
+    const before = upstream.requests.length;
+    const r = await proxyRequest({
+      port: proxyPort,
+      target: `/tok/${upstreamAuthority}/a`,
+    });
+    assert.equal(r.status, 401);
+    assert.equal(JSON.parse(r.body).error, "unauthorized");
+    assert.equal(upstream.requests.length, before);
+  });
+
+  it("injects the credential on a correct token, and the upstream never sees the token", async () => {
+    const r = await proxyRequest({
+      port: proxyPort,
+      target: `/tok/${upstreamAuthority}/c`,
+      headers: { [PROXY_AUTH_HEADER]: TOKEN },
+    });
+    assert.equal(r.status, 200);
+    const seen = upstream.requests.at(-1);
+    assert.equal(seen.url, "/c");
+    assert.equal(seen.authorization, "Bearer SECRET-VALUE");
+    assert.equal(seen.headers[PROXY_AUTH_HEADER], undefined);
+  });
+});
+
+describe("data-plane auth precedes vault state", () => {
+  let stateDir;
+  let upstream;
+  let proxy;
+  let proxyPort;
+  let reopenCalls;
+
+  before(async () => {
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "proxy-auth-locked-"));
+    upstream = await startUpstream();
+    const vault = await setupVault(stateDir, new URL(upstream.url).hostname);
+    reopenCalls = 0;
+    proxy = createProxy({
+      vault,
+      logPath: path.join(stateDir, "proxy.log"),
+      authToken: TOKEN,
+      reopenVault: async () => {
+        reopenCalls += 1;
+        return openVault({ stateDir, passphrase: "p" });
+      },
+    });
+    proxyPort = (await proxy.listen()).port;
+    proxy.forceLock("test");
+  });
+
+  after(async () => {
+    await proxy?.close();
+    upstream?.server.close();
+    if (stateDir) await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  it("answers unauthorized — not vault_locked — and never attempts a reopen", async () => {
+    const r = await proxyRequest({
+      port: proxyPort,
+      target: `${upstream.url}/a`,
+      headers: { Authorization: "AgentVault tok" },
+    });
+    assert.equal(r.status, 401);
+    assert.equal(JSON.parse(r.body).error, "unauthorized");
+    assert.equal(reopenCalls, 0);
+    assert.equal(upstream.requests.length, 0);
+  });
+
+  it("still reaches the locked vault once the token is correct", async () => {
+    const r = await proxyRequest({
+      port: proxyPort,
+      target: `${upstream.url}/a`,
+      headers: { Authorization: "AgentVault tok", [PROXY_AUTH_HEADER]: TOKEN },
+    });
+    assert.equal(r.status, 200);
+    assert.equal(reopenCalls, 1);
+  });
+});
+
+describe("no authToken configured", () => {
+  let stateDir;
+  let upstream;
+  let proxy;
+  let proxyPort;
+
+  before(async () => {
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "proxy-auth-off-"));
+    upstream = await startUpstream();
+    const vault = await setupVault(stateDir, new URL(upstream.url).hostname);
+    proxy = createProxy({ vault, logPath: path.join(stateDir, "proxy.log") });
+    proxyPort = (await proxy.listen()).port;
+  });
+
+  after(async () => {
+    await proxy?.close();
+    upstream?.server.close();
+    if (stateDir) await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  it("serves a tokenless request exactly as before", async () => {
+    const r = await proxyRequest({
+      port: proxyPort,
+      target: `${upstream.url}/a`,
+      headers: { Authorization: "AgentVault tok" },
+    });
+    assert.equal(r.status, 200);
+    assert.equal(upstream.requests.at(-1).authorization, "Bearer SECRET-VALUE");
+  });
+
+  it("still refuses a CORS preflight locally", async () => {
+    const before = upstream.requests.length;
+    const r = await proxyRequest({
+      port: proxyPort,
+      target: `${upstream.url}/a`,
+      method: "OPTIONS",
+      headers: {
+        Origin: "https://evil.example",
+        "Access-Control-Request-Method": "POST",
+      },
+    });
+    assert.equal(r.status, 403);
+    assert.equal(JSON.parse(r.body).error, "cross_origin_refused");
+    assert.equal(r.headers["access-control-allow-origin"], undefined);
+    assert.equal(upstream.requests.length, before);
+  });
+
+  it("strips a stray token header before the upstream even when auth is off", async () => {
+    const r = await proxyRequest({
+      port: proxyPort,
+      target: `${upstream.url}/a`,
+      headers: { Authorization: "AgentVault tok", [PROXY_AUTH_HEADER]: "leftover" },
+    });
+    assert.equal(r.status, 200);
+    assert.equal(upstream.requests.at(-1).headers[PROXY_AUTH_HEADER], undefined);
+  });
+});

--- a/tests/test-proxy-auth.mjs
+++ b/tests/test-proxy-auth.mjs
@@ -450,3 +450,80 @@ describe("no authToken configured", () => {
     assert.equal(upstream.requests.at(-1).headers[PROXY_AUTH_HEADER], undefined);
   });
 });
+
+// A suppressed count is a debt: the window it was accumulated in may be the
+// last one there ever is (the flood stops, the proxy is stopped), and the
+// refusals still have to leave a record.
+describe("the last window's suppressed count is never dropped", () => {
+  const BURST = 12;
+
+  async function floodedProxy(dirPrefix) {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), dirPrefix));
+    const upstream = await startUpstream();
+    const logFile = path.join(stateDir, "proxy.log");
+    let clock = Date.now();
+    const proxy = createProxy({
+      vault: await setupVault(stateDir, new URL(upstream.url).hostname),
+      logPath: logFile,
+      authToken: TOKEN,
+      now: () => clock,
+    });
+    const proxyPort = (await proxy.listen()).port;
+    for (let i = 0; i < BURST; i++) {
+      clock += 1000;
+      const r = await proxyRequest({ port: proxyPort, target: `${upstream.url}/${i}` });
+      assert.equal(r.status, 401);
+    }
+    return {
+      logFile,
+      proxy,
+      async teardown() {
+        await proxy.close();
+        upstream.server.close();
+        await fs.rm(stateDir, { recursive: true, force: true });
+      },
+    };
+  }
+
+  async function logLines(logFile) {
+    return (await fs.readFile(logFile, "utf8"))
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => JSON.parse(l));
+  }
+
+  it("flushes the count on close", async () => {
+    const ctx = await floodedProxy("proxy-auth-flush-close-");
+    try {
+      await ctx.proxy.close();
+      const flushed = (await logLines(ctx.logFile)).filter(
+        (e) => e.event === "auth_failed_suppressed",
+      );
+      assert.equal(flushed.length, 1, "the tail of the window must leave exactly one record");
+      assert.equal(flushed[0].suppressed, BURST - 1);
+    } finally {
+      await ctx.teardown();
+    }
+  });
+
+  it("flushes the count on the next log of any kind", async () => {
+    const ctx = await floodedProxy("proxy-auth-flush-next-");
+    try {
+      ctx.proxy.forceLock("manual");
+      await ctx.proxy.close();
+      const lines = await logLines(ctx.logFile);
+      const flushedAt = lines.findIndex((e) => e.event === "auth_failed_suppressed");
+      const lockedAt = lines.findIndex((e) => e.event === "vault_locked");
+      assert.notEqual(flushedAt, -1, "the suppressed count must be recorded");
+      assert.equal(lines[flushedAt].suppressed, BURST - 1);
+      assert.ok(lockedAt !== -1 && flushedAt < lockedAt, "the debt is paid before the next entry");
+      assert.equal(
+        lines.filter((e) => e.event === "auth_failed_suppressed").length,
+        1,
+        "close() must not record the same count twice",
+      );
+    } finally {
+      await ctx.teardown();
+    }
+  });
+});

--- a/tests/test-proxy-connect.mjs
+++ b/tests/test-proxy-connect.mjs
@@ -108,6 +108,23 @@ async function makeVault(stateDir) {
   return openVault({ stateDir, passphrase: "p" });
 }
 
+function closeServer(server) {
+  return new Promise((resolve) => (server ? server.close(() => resolve()) : resolve()));
+}
+
+async function readAccessLog(logFile) {
+  let raw = "";
+  try {
+    raw = await fs.readFile(logFile, "utf8");
+  } catch {
+    return [];
+  }
+  return raw
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
 describe("CONNECT: data-plane auth", () => {
   let stateDir;
   let upstream;
@@ -128,7 +145,7 @@ describe("CONNECT: data-plane auth", () => {
   after(async () => {
     destroyOpenSockets();
     await proxy?.close();
-    upstream?.server.close();
+    await closeServer(upstream?.server);
     if (stateDir) await fs.rm(stateDir, { recursive: true, force: true });
   });
 
@@ -198,11 +215,14 @@ describe("CONNECT: SSRF guard", () => {
     strictPort = (await strictProxy.listen()).port;
   });
 
+  // Ordered so nothing is still writing when the state dir goes: close() is the
+  // quiesce point for the access log (it awaits the fire-and-forget writes), and
+  // the upstream close is awaited rather than assumed done.
   after(async () => {
     destroyOpenSockets();
     await openProxy?.close();
     await strictProxy?.close();
-    upstream?.server.close();
+    await closeServer(upstream?.server);
     if (stateDir) await fs.rm(stateDir, { recursive: true, force: true });
   });
 
@@ -274,7 +294,7 @@ describe("CONNECT: self-reopen after an idle lock", () => {
   after(async () => {
     destroyOpenSockets();
     await proxy?.close();
-    upstream?.server.close();
+    await closeServer(upstream?.server);
     if (stateDir) await fs.rm(stateDir, { recursive: true, force: true });
   });
 
@@ -287,5 +307,130 @@ describe("CONNECT: self-reopen after an idle lock", () => {
     assert.equal(r.statusLine, "HTTP/1.1 200 Connection Established");
     assert.equal(reopenCalls, 1);
     r.socket.destroy();
+  });
+});
+
+// Self-reopen is a self-heal for the unattended setup, never a way around an
+// owner. With the control plane on, an unlock is the owner's decision — the
+// tunnel must refuse exactly as it did before self-reopen existed, the same
+// gate the request path applies.
+describe("CONNECT: self-reopen never bypasses the control plane", () => {
+  let stateDir;
+  let upstream;
+  let proxy;
+  let proxyPort;
+  let reopenCalls;
+
+  before(async () => {
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "proxy-connect-consent-"));
+    upstream = await startTcpUpstream();
+    reopenCalls = 0;
+    proxy = createProxy({
+      vault: await makeVault(stateDir),
+      stateDir,
+      logPath: path.join(stateDir, "proxy.log"),
+      authToken: TOKEN,
+      control: { listen: { port: 0, host: "127.0.0.1" }, approvalTimeoutMs: 1000 },
+      reopenVault: async () => {
+        reopenCalls += 1;
+        return openVault({ stateDir, passphrase: "p" });
+      },
+    });
+    proxyPort = (await proxy.listen()).port;
+    proxy.forceLock("test");
+  });
+
+  after(async () => {
+    destroyOpenSockets();
+    await proxy?.close();
+    await closeServer(upstream?.server);
+    if (stateDir) await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  it("refuses an authenticated CONNECT instead of re-unlocking behind the owner", async () => {
+    const before = upstream.state.connections;
+    const r = await rawConnect({
+      port: proxyPort,
+      target: `${upstream.host}:${upstream.port}`,
+      headers: { [PROXY_AUTH_HEADER]: TOKEN },
+    });
+    assert.equal(r.statusLine, "HTTP/1.1 401 Vault Locked");
+    assert.match(r.head, /X-AgentVault-Proxy-Error: vault_locked/i);
+    assert.equal(reopenCalls, 0, "the control plane owns the unlock — no self-reopen");
+    assert.equal(proxy.locked, true);
+    assert.equal(upstream.state.connections, before);
+  });
+});
+
+// A CONNECT target is attacker-shaped input: it arrives before any credential
+// is involved, so a malformed one must be refused, not thrown — an escaping
+// throw takes the whole proxy process down with it.
+describe("CONNECT: a malformed target is refused, not fatal", () => {
+  let stateDir;
+  let upstream;
+  let proxy;
+  let proxyPort;
+
+  before(async () => {
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "proxy-connect-malformed-"));
+    upstream = await startTcpUpstream();
+    proxy = createProxy({
+      vault: await makeVault(stateDir),
+      logPath: path.join(stateDir, "proxy.log"),
+    });
+    proxyPort = (await proxy.listen()).port;
+  });
+
+  after(async () => {
+    destroyOpenSockets();
+    await proxy?.close();
+    await closeServer(upstream?.server);
+    if (stateDir) await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  for (const target of ["bad-target", "example.com:not-a-port", "example.com:0", ":443", ""]) {
+    it(`refuses ${JSON.stringify(target)} and keeps serving`, async () => {
+      const before = upstream.state.connections;
+      const r = await rawConnect({ port: proxyPort, target });
+      assert.equal(r.statusLine, "HTTP/1.1 400 Bad Request");
+      assert.match(r.head, /X-AgentVault-Proxy-Error: bad_request/i);
+      assert.equal(upstream.state.connections, before);
+
+      // The proxy survived the malformed request and still tunnels.
+      const ok = await rawConnect({
+        port: proxyPort,
+        target: `${upstream.host}:${upstream.port}`,
+      });
+      assert.equal(ok.statusLine, "HTTP/1.1 200 Connection Established");
+      ok.socket.destroy();
+    });
+  }
+});
+
+// The access log is written fire-and-forget from the request path, so "the
+// response arrived" says nothing about the log. close() is the quiesce point
+// every teardown (and every operator reading the log after a stop) relies on.
+describe("close() settles the access log", () => {
+  it("has the refusal on disk by the time close() resolves", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "proxy-connect-quiesce-"));
+    const logFile = path.join(stateDir, "proxy.log");
+    const proxy = createProxy({
+      vault: await makeVault(stateDir),
+      logPath: logFile,
+    });
+    const proxyPort = (await proxy.listen()).port;
+    try {
+      const r = await rawConnect({ port: proxyPort, target: "169.254.169.254:80" });
+      assert.equal(r.statusLine, "HTTP/1.1 403 Forbidden");
+      await proxy.close();
+      const blocked = (await readAccessLog(logFile)).filter(
+        (e) => e.error === "upstream_blocked" && e.method === "CONNECT",
+      );
+      assert.equal(blocked.length, 1, "close() must not leave an access-log write in flight");
+    } finally {
+      destroyOpenSockets();
+      await proxy.close();
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/test-proxy-connect.mjs
+++ b/tests/test-proxy-connect.mjs
@@ -1,0 +1,291 @@
+#!/usr/bin/env node
+
+// The CONNECT tunnel is a second data-plane entrance, and it must enforce the
+// same rules as the request handler: the opt-in shared secret, the SSRF guard
+// (a tunnel to 169.254.169.254 is the same cloud-metadata reach a plain request
+// is refused), and the self-reopen an idle-locked vault gets.
+//
+// Run: node --test tests/test-proxy-connect.mjs
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+
+import { initVault, openVault } from "../plugins/agent-id-vault/lib/vault.mjs";
+import { createProxy, PROXY_AUTH_HEADER } from "../plugins/agent-id-proxy/lib/proxy.mjs";
+
+const TOKEN = "s3cret-proxy-token";
+
+// A plain TCP echo upstream: the tunnel target, and a connection counter that
+// proves a refusal never opened a socket.
+function startTcpUpstream() {
+  return new Promise((resolve) => {
+    const state = { connections: 0 };
+    const server = net.createServer((sock) => {
+      state.connections += 1;
+      sock.on("data", (d) => sock.write(d));
+      sock.on("error", () => {});
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const a = server.address();
+      resolve({ server, state, host: a.address, port: a.port });
+    });
+  });
+}
+
+// Every client socket this file opens, so a failed assertion can't leave an
+// established tunnel holding the proxy's close() open.
+const openSockets = new Set();
+function destroyOpenSockets() {
+  for (const s of openSockets) s.destroy();
+  openSockets.clear();
+}
+
+// A raw CONNECT, spoken by hand: the node http client hides the failure status
+// line behind its own upgrade handling, and the status line is exactly what
+// these tests assert on.
+function rawConnect({ port, target, headers = {}, timeoutMs = 4000 }) {
+  return new Promise((resolve, reject) => {
+    const socket = net.connect(port, "127.0.0.1", () => {
+      let raw = `CONNECT ${target} HTTP/1.1\r\nHost: ${target}\r\n`;
+      for (const [k, v] of Object.entries(headers)) raw += `${k}: ${v}\r\n`;
+      socket.write(`${raw}\r\n`);
+    });
+    openSockets.add(socket);
+    let buf = "";
+    let closed = false;
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      reject(new Error(`timeout waiting for a CONNECT response (got: ${JSON.stringify(buf)})`));
+    }, timeoutMs);
+    const settle = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      const head = buf.split("\r\n\r\n")[0];
+      resolve({
+        statusLine: head.split("\r\n")[0] || "",
+        head,
+        socket,
+        // Whether the proxy destroyed the connection after answering.
+        closedSoon: () =>
+          new Promise((r) => {
+            if (closed) return r(true);
+            const t = setTimeout(() => r(closed), 500);
+            socket.on("close", () => {
+              clearTimeout(t);
+              r(true);
+            });
+          }),
+      });
+    };
+    socket.on("data", (d) => {
+      buf += d.toString("latin1");
+      if (buf.includes("\r\n\r\n")) settle();
+    });
+    socket.on("close", () => {
+      closed = true;
+      openSockets.delete(socket);
+      settle();
+    });
+    socket.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+async function makeVault(stateDir) {
+  await initVault({ stateDir, passphrase: "p" });
+  return openVault({ stateDir, passphrase: "p" });
+}
+
+describe("CONNECT: data-plane auth", () => {
+  let stateDir;
+  let upstream;
+  let proxy;
+  let proxyPort;
+
+  before(async () => {
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "proxy-connect-auth-"));
+    upstream = await startTcpUpstream();
+    proxy = createProxy({
+      vault: await makeVault(stateDir),
+      logPath: path.join(stateDir, "proxy.log"),
+      authToken: TOKEN,
+    });
+    proxyPort = (await proxy.listen()).port;
+  });
+
+  after(async () => {
+    destroyOpenSockets();
+    await proxy?.close();
+    upstream?.server.close();
+    if (stateDir) await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  it("refuses a tokenless CONNECT with 401 and opens no upstream socket", async () => {
+    const before = upstream.state.connections;
+    const r = await rawConnect({
+      port: proxyPort,
+      target: `${upstream.host}:${upstream.port}`,
+    });
+    assert.equal(r.statusLine, "HTTP/1.1 401 Unauthorized");
+    assert.match(r.head, /X-AgentVault-Proxy-Error: unauthorized/i);
+    assert.equal(await r.closedSoon(), true);
+    assert.equal(upstream.state.connections, before);
+  });
+
+  it("refuses a wrong token", async () => {
+    const before = upstream.state.connections;
+    const r = await rawConnect({
+      port: proxyPort,
+      target: `${upstream.host}:${upstream.port}`,
+      headers: { [PROXY_AUTH_HEADER]: `${TOKEN}x` },
+    });
+    assert.equal(r.statusLine, "HTTP/1.1 401 Unauthorized");
+    assert.equal(upstream.state.connections, before);
+  });
+
+  it("establishes the tunnel on a correct token", async () => {
+    const before = upstream.state.connections;
+    const r = await rawConnect({
+      port: proxyPort,
+      target: `${upstream.host}:${upstream.port}`,
+      headers: { [PROXY_AUTH_HEADER]: TOKEN },
+    });
+    assert.equal(r.statusLine, "HTTP/1.1 200 Connection Established");
+    assert.equal(upstream.state.connections, before + 1);
+    const echoed = await new Promise((resolve, reject) => {
+      r.socket.once("data", (d) => resolve(d.toString("utf8")));
+      r.socket.on("error", reject);
+      r.socket.write("ping");
+    });
+    assert.equal(echoed, "ping");
+    r.socket.destroy();
+  });
+});
+
+describe("CONNECT: SSRF guard", () => {
+  let stateDir;
+  let upstream;
+  let openProxy;
+  let openPort;
+  let strictProxy;
+  let strictPort;
+
+  before(async () => {
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "proxy-connect-ssrf-"));
+    upstream = await startTcpUpstream();
+    openProxy = createProxy({
+      vault: await makeVault(stateDir),
+      logPath: path.join(stateDir, "proxy.log"),
+    });
+    openPort = (await openProxy.listen()).port;
+    strictProxy = createProxy({
+      vault: await openVault({ stateDir, passphrase: "p" }),
+      logPath: path.join(stateDir, "proxy-strict.log"),
+      blockPrivateHosts: true,
+    });
+    strictPort = (await strictProxy.listen()).port;
+  });
+
+  after(async () => {
+    destroyOpenSockets();
+    await openProxy?.close();
+    await strictProxy?.close();
+    upstream?.server.close();
+    if (stateDir) await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  it("refuses a link-local literal (cloud metadata) even with private hosts allowed", async () => {
+    const r = await rawConnect({ port: openPort, target: "169.254.169.254:80" });
+    assert.equal(r.statusLine, "HTTP/1.1 403 Forbidden");
+    assert.match(r.head, /X-AgentVault-Proxy-Error: upstream_blocked/i);
+    assert.equal(await r.closedSoon(), true);
+  });
+
+  it("still tunnels to an allowed target", async () => {
+    const before = upstream.state.connections;
+    const r = await rawConnect({
+      port: openPort,
+      target: `${upstream.host}:${upstream.port}`,
+    });
+    assert.equal(r.statusLine, "HTTP/1.1 200 Connection Established");
+    assert.equal(upstream.state.connections, before + 1);
+    r.socket.destroy();
+  });
+
+  it("refuses a loopback literal under --block-private-hosts, opening no socket", async () => {
+    const before = upstream.state.connections;
+    const r = await rawConnect({
+      port: strictPort,
+      target: `${upstream.host}:${upstream.port}`,
+    });
+    assert.equal(r.statusLine, "HTTP/1.1 403 Forbidden");
+    assert.match(r.head, /X-AgentVault-Proxy-Error: upstream_blocked/i);
+    assert.equal(upstream.state.connections, before);
+  });
+
+  it("refuses a hostname that RESOLVES into a blocked range", async () => {
+    const before = upstream.state.connections;
+    const r = await rawConnect({
+      port: strictPort,
+      target: `localhost:${upstream.port}`,
+    });
+    assert.equal(r.statusLine, "HTTP/1.1 403 Forbidden");
+    assert.match(r.head, /X-AgentVault-Proxy-Error: upstream_blocked/i);
+    assert.equal(upstream.state.connections, before);
+  });
+});
+
+describe("CONNECT: self-reopen after an idle lock", () => {
+  let stateDir;
+  let upstream;
+  let proxy;
+  let proxyPort;
+  let reopenCalls;
+
+  before(async () => {
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "proxy-connect-reopen-"));
+    upstream = await startTcpUpstream();
+    reopenCalls = 0;
+    proxy = createProxy({
+      vault: await makeVault(stateDir),
+      logPath: path.join(stateDir, "proxy.log"),
+      authToken: TOKEN,
+      reopenVault: async () => {
+        reopenCalls += 1;
+        return openVault({ stateDir, passphrase: "p" });
+      },
+    });
+    proxyPort = (await proxy.listen()).port;
+    proxy.forceLock("test");
+  });
+
+  after(async () => {
+    destroyOpenSockets();
+    await proxy?.close();
+    upstream?.server.close();
+    if (stateDir) await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  it("reopens the vault instead of refusing an authenticated CONNECT", async () => {
+    const r = await rawConnect({
+      port: proxyPort,
+      target: `${upstream.host}:${upstream.port}`,
+      headers: { [PROXY_AUTH_HEADER]: TOKEN },
+    });
+    assert.equal(r.statusLine, "HTTP/1.1 200 Connection Established");
+    assert.equal(reopenCalls, 1);
+    r.socket.destroy();
+  });
+});


### PR DESCRIPTION
Closes #104. Stacked on #105 (base branch `feat/proxy-vault-reload`) — only the last commit is this PR.

The data plane (`/credname/host/path` and the legacy absolute-URI stub mode) trusted possession of the loopback address alone. That is acceptable on a single-user workstation, but in shared network namespaces — a container, or a machine also running a browser that renders untrusted pages — it is an IMDSv1-class exposure: ports are enumerable in milliseconds and cred-path names are not secrets.

## What

- `--auth-token-file <path>` (opt-in): the token is read from a file (never argv — argv is world-readable), and every data-plane request **and CONNECT** must present it in `X-Agent-Id-Proxy-Token`. Comparison is constant-time (`timingSafeEqual` over sha256 digests). Failure → `401 unauthorized` **before** the lock check and its self-reopen, before activity touch, before routing, the vault, the approval flow, or any upstream socket. Without the flag, behavior is unchanged.
- The auth header is stripped before forwarding in both modes (`prepareUpstreamHeaders` skip-list + the stub path's hop-by-hop set), plus deleted from `req.headers` right after the check as defense in depth.
- CORS hardening, independent of auth: a preflight (`OPTIONS` + `Access-Control-Request-Method`) is **always** answered locally with `403 cross_origin_refused` and no `Access-Control-Allow-*` — relaying one upstream would hand a page the upstream's CORS answer.
- Startup fails loudly on a missing/empty token file (refusing to start silently unauthenticated), checked before the vault is unsealed.

## Tests

`tests/test-proxy-auth.mjs` — 13 tests / 5 suites, both data-plane modes: no/wrong/empty token → 401 with upstream untouched; correct token → injection with the auth header absent from recorded upstream headers; auth precedes vault state (locked + counting reopen callback → `401 unauthorized`, not `vault_locked`, zero reopens); preflight refused with auth on AND off; no-auth mode unchanged; stray token header stripped even with auth off; a unit test pinning the `prepareUpstreamHeaders` strip list.

Mutation-checked: forcing `authOk` → true reddens the 401 tests; removing the strip points reddens exactly the "upstream never sees the token" tests.

Full suite: 688/688 pass.


---

## Review pass (2026-08-11)

A critical review with adversarial verification found eight issues here; all are fixed in this branch, each with a test proven to fail without its fix.

- **CONNECT bypassed the SSRF guard entirely.** The tunnel went straight to `net.connect`, so the always-on link-local refusal (cloud metadata) and `--block-private-hosts` covered plain requests but not tunnels. It now runs both layers `forwardUpstream` runs: the literal-address check before any socket, and the resolving lookup so a hostname pointing into a blocked range is refused at connect time.
- **Three enforcement points had zero coverage** — the CLI plumbing (`--auth-token-file` → `createProxy({authToken})`), the CONNECT auth check, and an unauthenticated preflight. Deleting any of them left the suite green. Each now has a test (real CLI spawn; raw CONNECT over a socket).
- **CONNECT never self-healed** after an idle lock; it now takes the same reopen attempt the request path takes.
- **Token file hygiene**: 0600 is now required (matching the oauth-secrets precedent) and the token must be printable ASCII — a multi-byte token read as utf8 can never match a latin1 header value and would 401 forever with no diagnostic.
- **Unauthenticated log flood**: rejected-request logging coalesces per 60 s window and carries a `suppressed` count, so a caller who can reach the port can no longer grow the log without bound, while at least one record always survives.

Corrected claim (the earlier wording was wrong): a CORS preflight is never relayed upstream, but auth runs first — an unauthenticated preflight is refused with `401` like any other request, and an authenticated one (or any preflight when auth is off) is answered locally with `403 cross_origin_refused` and no `Access-Control-Allow-*`.

Suite: 704 tests, 0 failures.
