### PR TITLE
browser: optional HiDPI capture scale on the stream resize message

### DIFF
--- a/docs/BROWSER-STREAM.md
+++ b/docs/BROWSER-STREAM.md
@@ -278,7 +278,11 @@ phone-viewport capture costs ~20 ms, so scaled motion tops out around
 like classic delivery). Motion and the idle refinement use the same capture
 call, so their pixel dimensions are identical in every mode. Frame payloads
 become `viewport × scale` pixels; `metadata.deviceWidth/Height` and input
-coordinates stay CSS (see *Messages*).
+coordinates stay CSS (see *Messages*) — every scaled frame's metadata is
+normalized to the session's CSS geometry, because Chrome briefly reports the
+transitional surface size while an override settles. Dropping the scale
+clears the override explicitly (a merely-detached override re-pins the
+viewport to its stale size on every later navigation).
 
 Rules:
 
@@ -291,8 +295,11 @@ Rules:
   always did.
 - Budgets after multiplication: no axis of `viewport × scale` may exceed
   4096 device pixels, and the total may not exceed one 4K frame's worth of
-  pixels (3840×2160). A request over budget is served at the largest scale
-  that fits (down to 1), never refused.
+  pixels (3840×2160). A request over budget is served, never refused: the
+  scale drops first (layout beats density), and if the base viewport ALONE
+  exceeds the pixel budget (possible — 4096×4096 is ~2× the budget) it is
+  shrunk proportionally to fit. `resized` always mirrors the ACHIEVED
+  geometry and scale, not the request.
 - Requests are serialized behind pending viewer input, so a resize lands in
   arrival order relative to queued clicks and keys.
 - The achieved viewport is broadcast to **every** watcher as the `status`

--- a/docs/BROWSER-STREAM.md
+++ b/docs/BROWSER-STREAM.md
@@ -84,13 +84,18 @@ Client → server (always JSON text):
 // text-only char is valid. `keyDown`/`keyUp` require `key`. Input the server
 // cannot act on comes back to the SENDER as
 // {"type":"status","error":"…","for":"input_keyboard"} rather than vanishing.
-{ "type": "resize", "width": 390, "height": 844 }  // viewport, see below
+{ "type": "resize", "width": 390, "height": 844,
+  "scale": 2 }                                     // viewport + optional HiDPI
+                                                   // capture scale, see below
 { "type": "webrtc_offer", "sdp": "…" }             // experimental, see below
 { "type": "webrtc_ice", "candidate": { … } }
 ```
 
 Input coordinates are in `metadata.deviceWidth/Height` space (CSS viewport
-pixels — capture is clamped to the CSS viewport, so the mapping is 1:1).
+pixels). At the default 1× the capture is clamped to the CSS viewport, so the
+mapping is 1:1; after a `resize` with `scale` > 1 the payload carries
+`viewport × scale` pixels while coordinates and `metadata` stay CSS — map taps
+through `metadata`, never through the payload's pixel size.
 Mutating input (click, wheel, keydown, char) invalidates the agent's element
 refs, exactly like any page mutation.
 
@@ -195,8 +200,8 @@ across feeds).
 - A freshly spawned encoder arms an immediate refinement, so an h264 viewer
   joining a quiet page gets a picture within ~250 ms instead of black until
   the next repaint.
-- Dimension changes (tab switch, viewport resize) restart the encoder; a
-  crashed encoder restarts rate-limited (500 ms).
+- Dimension changes (tab switch, viewport resize, capture-scale change)
+  restart the encoder; a crashed encoder restarts rate-limited (500 ms).
 
 ## WebRTC (experimental)
 
@@ -252,15 +257,33 @@ chrome ate, grow the window by that delta. The result lands on the exact
 requested viewport (verified against headless Chrome: requesting 390×844
 yields a 390×844 viewport).
 
+An optional `scale` asks for the capture at `scale`× device pixels — a
+retina-density viewer sends its own `devicePixelRatio` and gets text crisp at
+native density instead of a 1× upscale. It is implemented as a per-page
+device-metrics override applied together with the window resize: the page
+keeps its CSS geometry and desktop UA, and the override sets `mobile: false`
+on purpose (no touch capability, no mobile emulation) — the only page-visible
+change is `devicePixelRatio`, the common desktop-retina configuration. Frame
+payloads become `viewport × scale` pixels; `metadata.deviceWidth/Height` and
+input coordinates stay CSS (see *Messages*). A later resize without `scale`
+(or with `scale: 1`) clears the override.
+
 Rules:
 
 - Dimensions clamp to **200–4096** per axis. Non-numeric dimensions are
   ignored entirely (not resized-to-minimum).
+- `scale` clamps to **1–3**; a missing or non-numeric `scale` means 1, so the
+  two-field message behaves exactly as it always did.
 - Requests are serialized behind pending viewer input, so a resize lands in
   arrival order relative to queued clicks and keys.
 - The achieved viewport is broadcast to **every** watcher as the `status`
-  message above — the request mirror in `resized`, the authoritative result
-  in `viewport`. Do coordinate math against `viewport`.
+  message above — the request mirror in `resized` (which also carries the
+  achieved `scale`, informational only), the authoritative result in
+  `viewport`. Do coordinate math against `viewport`; frame payload dimensions
+  follow the frames themselves.
+- A scale change restarts the screencast and the shared encoder (fresh
+  SPS/PPS + IDR at the new pixel dimensions) — expect one keyframe's worth of
+  latency, as on a tab switch.
 - A resize does not invalidate element refs (the DOM is untouched; refs are
   sparse and stable) — but screenshot coordinates taken before the resize are
   stale, as after any reflow.

--- a/docs/BROWSER-STREAM.md
+++ b/docs/BROWSER-STREAM.md
@@ -259,31 +259,53 @@ yields a 390×844 viewport).
 
 An optional `scale` asks for the capture at `scale`× device pixels — a
 retina-density viewer sends its own `devicePixelRatio` and gets text crisp at
-native density instead of a 1× upscale. It is implemented as a per-page
-device-metrics override applied together with the window resize: the page
-keeps its CSS geometry and desktop UA, and the override sets `mobile: false`
-on purpose (no touch capability, no mobile emulation) — the only page-visible
-change is `devicePixelRatio`, the common desktop-retina configuration. Frame
-payloads become `viewport × scale` pixels; `metadata.deviceWidth/Height` and
-input coordinates stay CSS (see *Messages*). A later resize without `scale`
-(or with `scale: 1`) clears the override.
+native density instead of a 1× upscale. It is implemented as a device-metrics
+override (`deviceScaleFactor: scale, mobile: false`) held on the capture's own
+CDP session: the page keeps its CSS geometry and desktop UA, no touch
+capability, no mobile emulation — the only page-visible change is
+`devicePixelRatio`, the common desktop-retina configuration. The override
+follows the capture: switching tabs moves it to the new tab (the old one
+reverts), and a later resize without `scale` (or with `scale: 1`) drops it.
+
+How a scaled session captures (all of it measured against real Chrome):
+Chrome's screencast delivers CSS-pixel frames regardless of
+`devicePixelRatio`, while `Page.captureScreenshot` renders at device pixels.
+A scaled session therefore keeps the screencast running only as a damage
+detector — its 1× frames are never delivered — and serves screenshot
+captures as motion frames instead, coalesced to at most one in flight. A 2×
+phone-viewport capture costs ~20 ms, so scaled motion tops out around
+30–50 fps and idle cost is unchanged (captures are damage-driven, exactly
+like classic delivery). Motion and the idle refinement use the same capture
+call, so their pixel dimensions are identical in every mode. Frame payloads
+become `viewport × scale` pixels; `metadata.deviceWidth/Height` and input
+coordinates stay CSS (see *Messages*).
 
 Rules:
 
 - Dimensions clamp to **200–4096** per axis. Non-numeric dimensions are
   ignored entirely (not resized-to-minimum).
-- `scale` clamps to **1–3**; a missing or non-numeric `scale` means 1, so the
-  two-field message behaves exactly as it always did.
+- `scale` is rounded to the **nearest integer** and clamped to **1–3**
+  (fractional pixel dimensions are rejected at the CDP layer, and integer
+  factors keep every capture path on identical dimensions); a missing or
+  non-numeric `scale` means 1, so the two-field message behaves exactly as it
+  always did.
+- Budgets after multiplication: no axis of `viewport × scale` may exceed
+  4096 device pixels, and the total may not exceed one 4K frame's worth of
+  pixels (3840×2160). A request over budget is served at the largest scale
+  that fits (down to 1), never refused.
 - Requests are serialized behind pending viewer input, so a resize lands in
   arrival order relative to queued clicks and keys.
 - The achieved viewport is broadcast to **every** watcher as the `status`
   message above — the request mirror in `resized` (which also carries the
-  achieved `scale`, informational only), the authoritative result in
-  `viewport`. Do coordinate math against `viewport`; frame payload dimensions
-  follow the frames themselves.
-- A scale change restarts the screencast and the shared encoder (fresh
-  SPS/PPS + IDR at the new pixel dimensions) — expect one keyframe's worth of
-  latency, as on a tab switch.
+  achieved `scale` after budgets, informational only), the authoritative
+  result in `viewport`. For a scaled resize the viewport is re-measured after
+  the override lands, so it reports what the page actually became. Do
+  coordinate math against `viewport`; frame payload dimensions follow the
+  frames themselves.
+- A resize that enters, leaves, or changes a scaled mode restarts the
+  screencast and the shared encoder (fresh SPS/PPS + IDR at the new pixel
+  dimensions) — expect one keyframe's worth of latency, as on a tab switch.
+  A 1× resize from a 1× session keeps the classic no-restart behavior.
 - A resize does not invalidate element refs (the DOM is untouched; refs are
   sparse and stable) — but screenshot coordinates taken before the resize are
   stale, as after any reflow.

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -978,19 +978,60 @@ export function chromeCompensatedBounds(want, got) {
   return { width, height };
 }
 
+// One short-lived page CDP session around `fn` — the same session mechanics
+// resizeWindow uses, shared by the device-metrics override below.
+async function withPageCdp(state, page, fn) {
+  const cdp = await state.ctx.newCDPSession(page);
+  try {
+    return await fn(cdp);
+  } finally {
+    await cdp.detach().catch(() => {});
+  }
+}
+
 // Viewer-driven resize (stream protocol `resize` message): width/height are
 // the viewer's SCREEN — i.e. the desired page VIEWPORT, not the outer window
 // size the `resize` action takes. A phone watching the stream sends its own
 // dimensions and the page reflows into its mobile layout instead of staying a
 // shrunken desktop. One compensation pass converts viewport → outer: resize to
 // the requested size, measure the chrome the window ate, grow by that delta.
-async function resizeToViewport(state, width, height) {
+//
+// `scale` > 1 (a viewer that wants a HiDPI stream) additionally applies a
+// per-page device-metrics override so capture happens at scale× device
+// pixels. Same CSS geometry, same desktop UA, and `mobile: false` on purpose —
+// no touch capability, no mobile emulation; the only page-visible change is
+// `devicePixelRatio` (the common desktop-retina configuration). A later 1×
+// request clears the override again; a session no viewer ever scaled never
+// sees an Emulation call. Exported for tests.
+export async function resizeToViewport(state, width, height, scale = 1) {
   const page = state.current;
   if (!page || page.isClosed?.()) return null;
+  const wantScale = Number.isFinite(scale) && scale > 1 ? scale : 1;
+  // A live override pins window.innerWidth/Height to its own CSS size, which
+  // would blind the chrome measurement below (the inner size stops tracking
+  // the window). Lift it first — the window already matches the old viewport,
+  // so the page barely moves.
+  if ((state.deviceScaleOverride ?? 1) > 1) {
+    await withPageCdp(state, page, (cdp) => cdp.send("Emulation.clearDeviceMetricsOverride"));
+    state.deviceScaleOverride = 1;
+  }
   const first = await resizeWindow(state, page, width, height);
   const second = chromeCompensatedBounds({ width, height }, first);
-  if (!second) return first;
-  return (await resizeWindow(state, page, second.width, second.height)) ?? first;
+  const achieved = second
+    ? (await resizeWindow(state, page, second.width, second.height)) ?? first
+    : first;
+  if (wantScale > 1) {
+    await withPageCdp(state, page, (cdp) =>
+      cdp.send("Emulation.setDeviceMetricsOverride", {
+        width,
+        height,
+        deviceScaleFactor: wantScale,
+        mobile: false,
+      }),
+    );
+    state.deviceScaleOverride = wantScale;
+  }
+  return achieved;
 }
 
 // Exported for tests: the suspend/resume contract around credential fills is
@@ -1732,7 +1773,7 @@ export async function runSession({
     // h264 becomes the default for codec=auto viewers ONLY on a host the
     // owner provisioned via `agent-id-browser install-codecs`.
     h264Config: await loadCodecConfig(stateDir),
-    resize: (width, height) => resizeToViewport(state, width, height),
+    resize: (width, height, scale) => resizeToViewport(state, width, height, scale),
     onActivity: touch,
   });
   state.stream = stream;

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -978,60 +978,19 @@ export function chromeCompensatedBounds(want, got) {
   return { width, height };
 }
 
-// One short-lived page CDP session around `fn` — the same session mechanics
-// resizeWindow uses, shared by the device-metrics override below.
-async function withPageCdp(state, page, fn) {
-  const cdp = await state.ctx.newCDPSession(page);
-  try {
-    return await fn(cdp);
-  } finally {
-    await cdp.detach().catch(() => {});
-  }
-}
-
 // Viewer-driven resize (stream protocol `resize` message): width/height are
 // the viewer's SCREEN — i.e. the desired page VIEWPORT, not the outer window
 // size the `resize` action takes. A phone watching the stream sends its own
 // dimensions and the page reflows into its mobile layout instead of staying a
 // shrunken desktop. One compensation pass converts viewport → outer: resize to
 // the requested size, measure the chrome the window ate, grow by that delta.
-//
-// `scale` > 1 (a viewer that wants a HiDPI stream) additionally applies a
-// per-page device-metrics override so capture happens at scale× device
-// pixels. Same CSS geometry, same desktop UA, and `mobile: false` on purpose —
-// no touch capability, no mobile emulation; the only page-visible change is
-// `devicePixelRatio` (the common desktop-retina configuration). A later 1×
-// request clears the override again; a session no viewer ever scaled never
-// sees an Emulation call. Exported for tests.
-export async function resizeToViewport(state, width, height, scale = 1) {
+async function resizeToViewport(state, width, height) {
   const page = state.current;
   if (!page || page.isClosed?.()) return null;
-  const wantScale = Number.isFinite(scale) && scale > 1 ? scale : 1;
-  // A live override pins window.innerWidth/Height to its own CSS size, which
-  // would blind the chrome measurement below (the inner size stops tracking
-  // the window). Lift it first — the window already matches the old viewport,
-  // so the page barely moves.
-  if ((state.deviceScaleOverride ?? 1) > 1) {
-    await withPageCdp(state, page, (cdp) => cdp.send("Emulation.clearDeviceMetricsOverride"));
-    state.deviceScaleOverride = 1;
-  }
   const first = await resizeWindow(state, page, width, height);
   const second = chromeCompensatedBounds({ width, height }, first);
-  const achieved = second
-    ? (await resizeWindow(state, page, second.width, second.height)) ?? first
-    : first;
-  if (wantScale > 1) {
-    await withPageCdp(state, page, (cdp) =>
-      cdp.send("Emulation.setDeviceMetricsOverride", {
-        width,
-        height,
-        deviceScaleFactor: wantScale,
-        mobile: false,
-      }),
-    );
-    state.deviceScaleOverride = wantScale;
-  }
-  return achieved;
+  if (!second) return first;
+  return (await resizeWindow(state, page, second.width, second.height)) ?? first;
 }
 
 // Exported for tests: the suspend/resume contract around credential fills is
@@ -1773,7 +1732,7 @@ export async function runSession({
     // h264 becomes the default for codec=auto viewers ONLY on a host the
     // owner provisioned via `agent-id-browser install-codecs`.
     h264Config: await loadCodecConfig(stateDir),
-    resize: (width, height, scale) => resizeToViewport(state, width, height, scale),
+    resize: (width, height) => resizeToViewport(state, width, height),
     onActivity: touch,
   });
   state.stream = stream;

--- a/plugins/agent-id-browser/lib/stream-server.mjs
+++ b/plugins/agent-id-browser/lib/stream-server.mjs
@@ -600,10 +600,18 @@ export async function startStreamServer(
     let msg = null;
     for (const client of clients) {
       if (client.codec !== "h264") continue;
+      // Same metadata rule as deliverFrame: EVERY envelope builder must ship
+      // CSS geometry at scale — this one stamped raw cast metadata (device
+      // pixels while scaled), doubling h264 viewers' tap coordinates.
       msg ??= wsFrame(
         0x2,
         encodeFrameBinary(
-          { type: "frame", seq: ++frameSeq, codec: "h264", metadata: lastMetadata },
+          {
+            type: "frame",
+            seq: ++frameSeq,
+            codec: "h264",
+            metadata: streamScale > 1 ? scaledMetadata() : lastMetadata,
+          },
           chunk,
         ),
       );

--- a/plugins/agent-id-browser/lib/stream-server.mjs
+++ b/plugins/agent-id-browser/lib/stream-server.mjs
@@ -57,13 +57,16 @@
 // delivered size — while Page.captureScreenshot DOES render at device pixels
 // (clip.scale=1 under a scale-2 override delivers exactly viewport×2). So a
 // scaled session applies Emulation.setDeviceMetricsOverride on the SAME
-// long-lived CDP session that runs the screencast (overrides revert when
-// their session detaches, so the override lives exactly as long as the cast:
-// retargeting to another tab moves it, closing reverts it), keeps the
-// screencast running purely as a damage detector, and delivers coalesced
-// captureScreenshot frames instead of the 1× cast payloads. Refinement uses
-// the same capture call, so motion and refinement frames are identical in
-// pixel dimensions — the invariant the encoders depend on.
+// long-lived CDP session that runs the screencast — the override lives
+// exactly as long as the cast (retargeting to another tab moves it there),
+// and stopping the cast clears it EXPLICITLY before detaching (detach alone
+// leaves a dormant registration that re-pins the viewport on later
+// navigations — measured). The screencast keeps running purely as a damage
+// detector, and delivery is coalesced captureScreenshot frames instead of
+// the 1× cast payloads, with metadata normalized to the session's CSS
+// geometry. Refinement uses the same capture call, so motion and refinement
+// frames are identical in pixel dimensions — the invariant the encoders
+// depend on.
 //
 // SEAL PRESERVED: this never opens a CDP debug port — frames come from a
 // patchright CDPSession over the existing pipe, input goes through
@@ -324,8 +327,7 @@ const SCALE_MAX = 3;
 const SCALE_MAX_PIXELS = 3840 * 2160;
 
 // The largest integer scale (1..requested) whose scaled capture fits the
-// axis and pixel budgets. Scale 1 always fits: width/height are already
-// clamped to RESIZE_MAX. Exported for tests.
+// axis budget and comes closest to the pixel budget. Exported for tests.
 export function effectiveScale(width, height, requested) {
   let scale = Math.min(Math.max(Math.round(requested), SCALE_MIN), SCALE_MAX);
   while (
@@ -337,6 +339,29 @@ export function effectiveScale(width, height, requested) {
     scale--;
   }
   return scale;
+}
+
+// The applied-geometry policy for a resize request, in order:
+//   1. each axis clamps to RESIZE_MIN..RESIZE_MAX (as always);
+//   2. the scale drops until the SCALED capture fits the axis and pixel
+//      budgets — layout beats density, so density gives way first;
+//   3. if the base viewport ALONE still exceeds the pixel budget (possible:
+//      RESIZE_MAX² is ~2× the budget), it shrinks proportionally to fit —
+//      scale reduction cannot fix what the base already breaks.
+// Everything returned is what will actually be applied and broadcast — the
+// `resized` status mirrors the ACHIEVED geometry, not the request.
+// Exported for tests.
+export function budgetedResize(width, height, requested) {
+  const clamp = (n) => Math.min(Math.max(n, RESIZE_MIN), RESIZE_MAX);
+  let w = clamp(width);
+  let h = clamp(height);
+  const scale = effectiveScale(w, h, requested);
+  if (w * h * scale * scale > SCALE_MAX_PIXELS) {
+    const f = Math.sqrt(SCALE_MAX_PIXELS / (w * h * scale * scale));
+    w = Math.max(RESIZE_MIN, Math.floor(w * f));
+    h = Math.max(RESIZE_MIN, Math.floor(h * f));
+  }
+  return { width: w, height: h, scale };
 }
 
 export async function startStreamServer(
@@ -358,8 +383,13 @@ export async function startStreamServer(
   // pipeline. At scale > 1 the screencast is demoted to a damage detector
   // and both frame sources are captureScreenshot calls — identical pixel
   // dimensions by construction (the encoders choke on dimension flips).
+  // streamView is the last MEASURED viewport (what the page actually became,
+  // vs streamDims = what was asked): the cast caps follow it so cast frames
+  // are never silently downscaled out of agreement with the refinement pass.
   let streamScale = 1;
   let streamDims = null;
+  let streamView = null;
+  let castCaps = null;
   // Input events apply strictly in arrival order. page.mouse/keyboard calls are
   // async; firing them unawaited lets a press overtake the move before it (or a
   // release overtake the press), which drops clicks sent in a burst.
@@ -684,6 +714,20 @@ export async function startStreamServer(
   // which serves any viewer that joined meanwhile.
   let reshaping = false;
 
+  // Frame metadata is the client's coordinate space and must be CSS px in
+  // every frame. Chrome's cast metadata is CSS in steady state, but frames
+  // emitted while an override is being applied or lifted can carry the
+  // transitional surface size (measured: 780×1688 interleaved with 390×844
+  // on the same scaled session) — so scaled delivery normalizes every
+  // frame's metadata to the session's own CSS geometry, which the override
+  // pins authoritatively.
+  function scaledMetadata() {
+    return {
+      ...(lastMetadata ?? {}),
+      ...(streamDims ? { deviceWidth: streamDims.width, deviceHeight: streamDims.height } : {}),
+    };
+  }
+
   async function pumpScaledCapture(session) {
     if (scaledBusy) return;
     scaledBusy = true;
@@ -692,7 +736,7 @@ export async function startStreamServer(
         scaledDirty = false;
         const shot = await captureShot(session, STREAM_QUALITY);
         if (closed || suspended > 0 || session !== cdp) return;
-        deliverFrame({ data: shot.data, metadata: lastMetadata });
+        deliverFrame({ data: shot.data, metadata: scaledMetadata() });
         if (encoderSinks.size > 0) {
           const jpeg = Buffer.from(shot.data, "base64");
           for (const sink of encoderSinks) sink.write(jpeg);
@@ -702,6 +746,11 @@ export async function startStreamServer(
       /* navigating/detached — the next damage tick retries */
     } finally {
       scaledBusy = false;
+      // A capture that straddled a cast switch exits with the dirty flag
+      // still set (its session lost the cast mid-flight) — re-dispatch for
+      // the live session, or the new tab's first damage tick would sit
+      // stranded behind the stale busy flag until the next tick.
+      if (scaledDirty && !closed && cdp && cdp !== session) void pumpScaledCapture(cdp);
     }
   }
 
@@ -730,25 +779,64 @@ export async function startStreamServer(
     return got;
   }
 
-  async function stopScreencast() {
+  // Cast start/stop are SERIALIZED behind one promise chain: concurrent
+  // joins used to race startScreencast's idempotence guard — a real-Chrome
+  // probe with delayed attaches left THREE live CDP sessions, each keeping
+  // its override and captures alive. An epoch stamps every state change; a
+  // session whose attach outlives its epoch (close, retarget, another
+  // start) is detached and never installed.
+  let castChain = Promise.resolve();
+  let castEpoch = 0;
+  let castOverride = false; // the CURRENT cast session applied a device-metrics override
+
+  function stopScreencast() {
+    castChain = castChain.then(stopScreencastNow).catch(() => {});
+    return castChain;
+  }
+
+  function startScreencast() {
+    castChain = castChain.then(startScreencastNow).catch(() => {});
+    return castChain;
+  }
+
+  async function stopScreencastNow() {
+    castEpoch++;
     const session = cdp;
+    const hadOverride = castOverride;
     cdp = null;
     cdpPage = null;
+    castOverride = false;
     if (!session) return;
+    // An applied override must be cleared EXPLICITLY before its session goes
+    // away: detach alone reverts the live values but leaves a dormant
+    // registration that re-pins the viewport to the stale size on every
+    // later NAVIGATION (measured: a 2040×2040 window snapped back to the old
+    // 390×844 on goto until a clear was sent). Sent only when this session
+    // applied one, so never-scaled sessions still see zero Emulation traffic.
+    if (hadOverride) {
+      try { await session.send("Emulation.clearDeviceMetricsOverride"); } catch { /* page gone */ }
+    }
     try { await session.send("Page.stopScreencast"); } catch { /* page gone */ }
     try { await session.detach(); } catch { /* already detached */ }
   }
 
-  async function startScreencast() {
+  async function startScreencastNow() {
     if (closed || clients.size === 0) return;
     const page = state.current;
     if (!page || page.isClosed?.() || (cdp && cdpPage === page)) return;
-    await stopScreencast();
+    await stopScreencastNow();
+    const epoch = ++castEpoch;
     let session;
     try {
       session = await state.ctx.newCDPSession(page);
     } catch (err) {
       log(`stream: cdp attach failed: ${err.message || err}`);
+      return;
+    }
+    // The world may have moved during the attach (close, retarget to another
+    // tab, a newer start/stop): discard the session — detach, never install.
+    if (closed || epoch !== castEpoch || state.current !== page) {
+      try { await session.detach(); } catch { /* already gone */ }
       return;
     }
     cdp = session;
@@ -789,6 +877,7 @@ export async function startStreamServer(
           deviceScaleFactor: streamScale,
           mobile: false,
         });
+        castOverride = true;
       } catch (err) {
         log(`stream: device-scale override failed, continuing at 1x: ${err.message || err}`);
         streamScale = 1;
@@ -800,17 +889,27 @@ export async function startStreamServer(
     // damage ticks, never delivered, so CSS size keeps them cheap — the
     // delivered device-pixel frames come from captureScreenshot instead
     // (the cast cannot deliver above 1× whatever the override says — measured).
+    // With no explicit context viewport the caps follow the MEASURED viewport
+    // (floored at the legacy defaults): fixed fallback caps silently
+    // downscaled big viewports' cast frames out of agreement with the
+    // refinement pass (measured: 1253×1200 cast vs 2040×1953 refinement).
     const vp = page.viewportSize?.() ?? null;
+    castCaps = vp
+      ? { width: Math.round(vp.width), height: Math.round(vp.height) }
+      : {
+          width: Math.max(Math.round(streamView?.width ?? 0), 1600),
+          height: Math.max(Math.round(streamView?.height ?? 0), 1200),
+        };
     try {
       await session.send("Page.startScreencast", {
         format: "jpeg",
         quality: STREAM_QUALITY,
-        maxWidth: Math.round(vp?.width ?? 1600),
-        maxHeight: Math.round(vp?.height ?? 1200),
+        maxWidth: castCaps.width,
+        maxHeight: castCaps.height,
       });
     } catch (err) {
       log(`stream: screencast start failed: ${err.message || err}`);
-      await stopScreencast();
+      await stopScreencastNow();
       return;
     }
     // New capture epoch (join/tab-switch/resume): restart the shared encoder
@@ -841,7 +940,11 @@ export async function startStreamServer(
       // motion frames in every mode — the encoders choke on dimension flips.
       const shot = await captureShot(session, REFINE_QUALITY);
       if (closed || suspended > 0 || session !== cdp) return;
-      deliverFrame({ data: shot.data, metadata: lastMetadata, refinement: true });
+      deliverFrame({
+        data: shot.data,
+        metadata: streamScale > 1 ? scaledMetadata() : lastMetadata,
+        refinement: true,
+      });
       // The encoder gets refinements too — on a damage-driven screencast this
       // is what keeps an h264 viewer's picture alive across idle stretches.
       // Written TWICE: raw MJPEG only delimits frame N when frame N+1's SOI
@@ -1009,15 +1112,17 @@ export async function startStreamServer(
         const width = Math.round(Number(msg.width));
         const height = Math.round(Number(msg.height));
         if (!resize || ![width, height].every(Number.isFinite)) return;
-        const clamp = (n) => Math.min(Math.max(n, RESIZE_MIN), RESIZE_MAX);
-        const w = clamp(width);
-        const h = clamp(height);
         // Optional HiDPI knob: a retina-density viewer asks for the capture
-        // at scale× device pixels — integer, budget-reduced (effectiveScale).
-        // Absent/garbage → 1, so clients that only ever send width/height
-        // keep their exact pre-`scale` behavior.
-        const requested = Number(msg.scale);
-        const scale = Number.isFinite(requested) ? effectiveScale(w, h, requested) : SCALE_MIN;
+        // at scale× device pixels. Absent/garbage → 1, so clients that only
+        // ever send width/height keep their exact pre-`scale` behavior. The
+        // request then passes the geometry policy (axis clamps, integer
+        // scale, axis + pixel budgets — see budgetedResize).
+        const requestedScale = Number(msg.scale);
+        const { width: w, height: h, scale } = budgetedResize(
+          width,
+          height,
+          Number.isFinite(requestedScale) ? requestedScale : SCALE_MIN,
+        );
         inputChain = inputChain
           .then(async () => {
             if (suspended > 0) return;
@@ -1039,13 +1144,17 @@ export async function startStreamServer(
                 viewport = await resize(w, h);
                 streamScale = scale;
                 streamDims = { width: w, height: h };
+                streamView = viewport ?? streamDims;
                 await stopScreencast(); // belt: kill anything that slipped in
                 await startScreencast();
                 // The override pins the viewport AFTER the measurement inside
                 // resize() — remeasure so the broadcast reports what the page
                 // actually became. (startScreencast may have downgraded
                 // streamScale to 1 if Chrome refused the override.)
-                if (streamScale > 1) viewport = (await measureViewport(streamDims)) ?? viewport;
+                if (streamScale > 1) {
+                  viewport = (await measureViewport(streamDims)) ?? viewport;
+                  streamView = viewport ?? streamDims;
+                }
               } finally {
                 reshaping = false;
               }
@@ -1053,6 +1162,15 @@ export async function startStreamServer(
               viewport = await resize(w, h);
               streamScale = scale;
               streamDims = { width: w, height: h };
+              streamView = viewport ?? streamDims;
+              // Frames larger than the running cast's caps would be silently
+              // downscaled out of agreement with the refinement pass — grow
+              // into fresh caps. Resizes within the caps keep the classic
+              // no-restart behavior.
+              if (cdp && castCaps && (streamView.width > castCaps.width || streamView.height > castCaps.height)) {
+                await stopScreencast();
+                await startScreencast();
+              }
             }
             broadcastStatus({
               type: "status",

--- a/plugins/agent-id-browser/lib/stream-server.mjs
+++ b/plugins/agent-id-browser/lib/stream-server.mjs
@@ -28,7 +28,7 @@
 //                     {"type":"ack","seq":N}
 //                     {"type":"config","maxFps":N,"pacing":"ack"|"push"}
 //                     {"type":"status_request"}
-//                     {"type":"resize","width":W,"height":H}
+//                     {"type":"resize","width":W,"height":H[,"scale":S]}
 //                     {"type":"webrtc_offer"|"webrtc_ice", ...}  (experimental)
 //
 // Delivery is latest-frame-wins: each JPEG client has ONE pending slot that
@@ -44,8 +44,12 @@
 // `resize` is our one extension beyond agent-browser's shapes (harmless there —
 // unknown types are ignored). width/height are the VIEWER's dimensions — the
 // desired page viewport — so a phone-sized viewer gets the page's mobile
-// layout, not a shrunken desktop one. The resulting viewport is broadcast to
-// every watcher as {"type":"status","resized":{...},"viewport":{...}}.
+// layout, not a shrunken desktop one. An optional `scale` (1–3, default 1)
+// asks for the capture at scale× device pixels so a retina-density viewer
+// gets text crisp at native density; the page keeps its CSS geometry and
+// desktop UA — the only page-visible change is devicePixelRatio. The
+// resulting viewport is broadcast to every watcher as
+// {"type":"status","resized":{...},"viewport":{...}}.
 //
 // SEAL PRESERVED: this never opens a CDP debug port — frames come from a
 // patchright CDPSession over the existing pipe, input goes through
@@ -291,6 +295,12 @@ function mutatesPage(msg) {
 // page is unusable, above 4096 a typo'd request could balloon the framebuffer.
 const RESIZE_MIN = 200;
 const RESIZE_MAX = 4096;
+// The optional capture scale is clamped too: 1 is the classic CSS-pixel
+// capture, 3 covers the densest phone screens — beyond that the quadratic
+// pixel cost buys nothing a display can show. Anything unparseable means 1,
+// so the pre-`scale` message shape keeps its exact behavior.
+const SCALE_MIN = 1;
+const SCALE_MAX = 3;
 
 export async function startStreamServer(
   state,
@@ -306,6 +316,10 @@ export async function startStreamServer(
   let lastFrameAt = 0;
   let lastMetadata = null;
   let refined = true; // no refinement until at least one screencast frame
+  // The session's current capture scale (viewer-set via `resize`). Screencast
+  // caps and the refinement clip both follow it, so every frame source agrees
+  // on pixel dimensions — the encoders choke on dimension flips.
+  let streamScale = 1;
   // Input events apply strictly in arrival order. page.mouse/keyboard calls are
   // async; firing them unawaited lets a press overtake the move before it (or a
   // release overtake the press), which drops clicks sent in a burst.
@@ -632,15 +646,19 @@ export async function startStreamServer(
         for (const sink of encoderSinks) sink.write(jpeg);
       }
     });
-    // Capture is clamped to the CSS viewport so HiDPI doesn't ship 2× pixels
-    // that the viewer scales straight back down (input mapping is 1:1 too).
+    // Capture is capped at the CSS viewport × the session's scale. At the
+    // default 1× that stops HiDPI hosts shipping 2× pixels the viewer scales
+    // straight back down; a viewer that asked for a scaled stream (`resize`
+    // with scale > 1) raises the cap so device-pixel frames come through.
+    // Input mapping stays in CSS space either way — frame metadata reports
+    // CSS (DIP) dimensions whatever the payload's pixel size.
     const vp = page.viewportSize?.() ?? null;
     try {
       await session.send("Page.startScreencast", {
         format: "jpeg",
         quality: STREAM_QUALITY,
-        maxWidth: vp?.width ?? 1600,
-        maxHeight: vp?.height ?? 1200,
+        maxWidth: (vp?.width ?? 1600) * streamScale,
+        maxHeight: (vp?.height ?? 1200) * streamScale,
       });
     } catch (err) {
       log(`stream: screencast start failed: ${err.message || err}`);
@@ -670,13 +688,14 @@ export async function startStreamServer(
     if (Date.now() - lastFrameAt < REFINE_AFTER_MS) return;
     refined = true;
     try {
-      // clip.scale=1 pins the output to CSS-viewport pixels so it matches the
-      // screencast frame size exactly — the encoders choke on dimension flips.
+      // clip.scale mirrors the session's capture scale so the output matches
+      // the screencast frame size exactly — the encoders choke on dimension
+      // flips. (Scale 1, the default, means CSS-viewport pixels.)
       const vp = state.current?.viewportSize?.() ?? null;
       const shot = await session.send("Page.captureScreenshot", {
         format: "jpeg",
         quality: REFINE_QUALITY,
-        ...(vp ? { clip: { x: 0, y: 0, width: vp.width, height: vp.height, scale: 1 } } : {}),
+        ...(vp ? { clip: { x: 0, y: 0, width: vp.width, height: vp.height, scale: streamScale } } : {}),
       });
       if (closed || suspended > 0 || session !== cdp) return;
       deliverFrame({ data: shot.data, metadata: lastMetadata, refinement: true });
@@ -848,16 +867,29 @@ export async function startStreamServer(
         const height = Math.round(Number(msg.height));
         if (!resize || ![width, height].every(Number.isFinite)) return;
         const clamp = (n) => Math.min(Math.max(n, RESIZE_MIN), RESIZE_MAX);
+        // Optional HiDPI knob: a retina-density viewer asks for the capture
+        // at scale× device pixels. Absent/garbage → 1, so clients that only
+        // ever send width/height keep their exact pre-`scale` behavior.
+        const scale = Number.isFinite(Number(msg.scale))
+          ? Math.min(Math.max(Number(msg.scale), SCALE_MIN), SCALE_MAX)
+          : SCALE_MIN;
         inputChain = inputChain
           .then(async () => {
             if (suspended > 0) return;
-            const viewport = await resize(clamp(width), clamp(height));
+            const viewport = await resize(clamp(width), clamp(height), scale);
+            const scaleChanged = streamScale !== scale;
+            streamScale = scale;
             broadcastStatus({
               type: "status",
               source: "alien",
-              resized: { width: clamp(width), height: clamp(height) },
+              resized: { width: clamp(width), height: clamp(height), scale },
               ...(viewport ? { viewport } : {}),
             });
+            // The screencast's pixel caps follow the scale, so a scale change
+            // must restart the cast — and with it the shared encoder, so h264
+            // viewers get fresh SPS/PPS + an IDR at the new dimensions
+            // instead of a decoder stall.
+            if (scaleChanged) await stopScreencast().then(() => startScreencast());
           })
           .catch(() => {});
         return;

--- a/plugins/agent-id-browser/lib/stream-server.mjs
+++ b/plugins/agent-id-browser/lib/stream-server.mjs
@@ -44,12 +44,26 @@
 // `resize` is our one extension beyond agent-browser's shapes (harmless there —
 // unknown types are ignored). width/height are the VIEWER's dimensions — the
 // desired page viewport — so a phone-sized viewer gets the page's mobile
-// layout, not a shrunken desktop one. An optional `scale` (1–3, default 1)
-// asks for the capture at scale× device pixels so a retina-density viewer
-// gets text crisp at native density; the page keeps its CSS geometry and
-// desktop UA — the only page-visible change is devicePixelRatio. The
+// layout, not a shrunken desktop one. An optional integer `scale` (1–3,
+// default 1) asks for the capture at scale× device pixels so a retina-density
+// viewer gets text crisp at native density; the page keeps its CSS geometry
+// and desktop UA — the only page-visible change is devicePixelRatio. The
 // resulting viewport is broadcast to every watcher as
 // {"type":"status","resized":{...},"viewport":{...}}.
+//
+// HOW scaled capture works (all of it measured against real Chrome, not
+// assumed): the screencast delivers CSS-pixel frames no matter what
+// devicePixelRatio is — a device-metrics override does not change the cast's
+// delivered size — while Page.captureScreenshot DOES render at device pixels
+// (clip.scale=1 under a scale-2 override delivers exactly viewport×2). So a
+// scaled session applies Emulation.setDeviceMetricsOverride on the SAME
+// long-lived CDP session that runs the screencast (overrides revert when
+// their session detaches, so the override lives exactly as long as the cast:
+// retargeting to another tab moves it, closing reverts it), keeps the
+// screencast running purely as a damage detector, and delivers coalesced
+// captureScreenshot frames instead of the 1× cast payloads. Refinement uses
+// the same capture call, so motion and refinement frames are identical in
+// pixel dimensions — the invariant the encoders depend on.
 //
 // SEAL PRESERVED: this never opens a CDP debug port — frames come from a
 // patchright CDPSession over the existing pipe, input goes through
@@ -295,12 +309,35 @@ function mutatesPage(msg) {
 // page is unusable, above 4096 a typo'd request could balloon the framebuffer.
 const RESIZE_MIN = 200;
 const RESIZE_MAX = 4096;
-// The optional capture scale is clamped too: 1 is the classic CSS-pixel
-// capture, 3 covers the densest phone screens — beyond that the quadratic
-// pixel cost buys nothing a display can show. Anything unparseable means 1,
-// so the pre-`scale` message shape keeps its exact behavior.
+// The optional capture scale: integers only (Chrome hard-rejects fractional
+// pixel dimensions in CDP — a fractional maxWidth kills the screencast — and
+// a fractional factor would let the capture paths disagree by a rounding
+// step), rounded to nearest, 1..3: 1 is the classic capture, 3 covers the
+// densest phone screens — beyond that the quadratic pixel cost buys nothing
+// a display can show. Anything unparseable means 1, so the pre-`scale`
+// message shape keeps its exact behavior. On top of the per-axis clamp the
+// scaled request must fit a total budget: no axis over RESIZE_MAX device
+// pixels and no more pixels than one 4K frame — otherwise 4096-per-axis and
+// scale 3 could combine into a 12288×12288 capture.
 const SCALE_MIN = 1;
 const SCALE_MAX = 3;
+const SCALE_MAX_PIXELS = 3840 * 2160;
+
+// The largest integer scale (1..requested) whose scaled capture fits the
+// axis and pixel budgets. Scale 1 always fits: width/height are already
+// clamped to RESIZE_MAX. Exported for tests.
+export function effectiveScale(width, height, requested) {
+  let scale = Math.min(Math.max(Math.round(requested), SCALE_MIN), SCALE_MAX);
+  while (
+    scale > 1 &&
+    (width * scale > RESIZE_MAX ||
+      height * scale > RESIZE_MAX ||
+      width * height * scale * scale > SCALE_MAX_PIXELS)
+  ) {
+    scale--;
+  }
+  return scale;
+}
 
 export async function startStreamServer(
   state,
@@ -316,10 +353,13 @@ export async function startStreamServer(
   let lastFrameAt = 0;
   let lastMetadata = null;
   let refined = true; // no refinement until at least one screencast frame
-  // The session's current capture scale (viewer-set via `resize`). Screencast
-  // caps and the refinement clip both follow it, so every frame source agrees
-  // on pixel dimensions — the encoders choke on dimension flips.
+  // The session's current capture scale and CSS geometry (viewer-set via
+  // `resize`). At scale 1 everything below is byte-identical to the classic
+  // pipeline. At scale > 1 the screencast is demoted to a damage detector
+  // and both frame sources are captureScreenshot calls — identical pixel
+  // dimensions by construction (the encoders choke on dimension flips).
   let streamScale = 1;
+  let streamDims = null;
   // Input events apply strictly in arrival order. page.mouse/keyboard calls are
   // async; firing them unawaited lets a press overtake the move before it (or a
   // release overtake the press), which drops clicks sent in a burst.
@@ -610,6 +650,86 @@ export async function startStreamServer(
     }
   }
 
+  // One viewport screenshot at the page's device pixels. clip.scale stays 1
+  // in every mode: under a device-metrics override Chrome already renders
+  // the capture at devicePixelRatio (a 390×844 clip delivers 780×1688 at
+  // scale 2 — measured), so multiplying by the scale again would deliver 4×.
+  // No viewport to clip to (viewport:null launches) means "whole visible
+  // viewport" — the same delivered dimensions.
+  function captureShot(session, quality) {
+    const vp = state.current?.viewportSize?.() ?? null;
+    return session.send("Page.captureScreenshot", {
+      format: "jpeg",
+      quality,
+      ...(vp
+        ? { clip: { x: 0, y: 0, width: Math.round(vp.width), height: Math.round(vp.height), scale: 1 } }
+        : {}),
+    });
+  }
+
+  // Scaled motion path: coalesced device-pixel captures — at most one in
+  // flight, latest damage wins. A 2× phone-viewport capture costs ~20ms
+  // (measured), so scaled motion tops out around 30–50fps, and idle costs
+  // nothing extra: captures happen only when the damage-driven cast reports
+  // a change, exactly like classic frame delivery.
+  let scaledDirty = false;
+  let scaledBusy = false;
+
+  // While a scaled resize is reshaping the window and override, nothing else
+  // may (re)start the cast: a cast started mid-resize re-applies the OLD
+  // override after the new geometry was already measured — and in headless
+  // an override also sizes the platform window in a way its later removal
+  // does not undo (measured), so one stale mid-resize override permanently
+  // poisons the window size. The in-flight resize ends with its own restart,
+  // which serves any viewer that joined meanwhile.
+  let reshaping = false;
+
+  async function pumpScaledCapture(session) {
+    if (scaledBusy) return;
+    scaledBusy = true;
+    try {
+      while (scaledDirty && !closed && session === cdp && suspended === 0) {
+        scaledDirty = false;
+        const shot = await captureShot(session, STREAM_QUALITY);
+        if (closed || suspended > 0 || session !== cdp) return;
+        deliverFrame({ data: shot.data, metadata: lastMetadata });
+        if (encoderSinks.size > 0) {
+          const jpeg = Buffer.from(shot.data, "base64");
+          for (const sink of encoderSinks) sink.write(jpeg);
+        }
+      }
+    } catch {
+      /* navigating/detached — the next damage tick retries */
+    } finally {
+      scaledBusy = false;
+    }
+  }
+
+  // The truth about the viewport, read from the page itself. A scaled resize
+  // needs it AFTER the override lands: the override pins the viewport to the
+  // requested CSS size, so anything measured before it is stale (measured:
+  // 500×844 before the override vs 390×844 after, when the window cannot
+  // shrink to the request). Polls briefly for the expected size — the
+  // renderer applies the override a beat after the CDP ack.
+  async function measureViewport(expected) {
+    let got = null;
+    for (let attempt = 0; attempt < 20; attempt++) {
+      const page = state.current;
+      if (!page || page.isClosed?.() || typeof page.evaluate !== "function") return got;
+      let next = null;
+      try {
+        next = await page.evaluate(() => ({ width: window.innerWidth, height: window.innerHeight }));
+      } catch {
+        return got;
+      }
+      if (!next) return got;
+      got = next;
+      if (!expected || (got.width === expected.width && got.height === expected.height)) return got;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    return got;
+  }
+
   async function stopScreencast() {
     const session = cdp;
     cdp = null;
@@ -640,25 +760,53 @@ export async function startStreamServer(
       lastFrameAt = Date.now();
       lastMetadata = ev.metadata;
       refined = false;
+      if (streamScale > 1) {
+        // Scaled session: the cast's CSS-pixel payload is never delivered
+        // (wrong dimensions for this stream) — the frame is the damage tick
+        // that drives the device-pixel capture.
+        scaledDirty = true;
+        void pumpScaledCapture(session);
+        return;
+      }
       deliverFrame({ data: ev.data, metadata: ev.metadata });
       if (encoderSinks.size > 0) {
         const jpeg = Buffer.from(ev.data, "base64");
         for (const sink of encoderSinks) sink.write(jpeg);
       }
     });
-    // Capture is capped at the CSS viewport × the session's scale. At the
-    // default 1× that stops HiDPI hosts shipping 2× pixels the viewer scales
-    // straight back down; a viewer that asked for a scaled stream (`resize`
-    // with scale > 1) raises the cap so device-pixel frames come through.
-    // Input mapping stays in CSS space either way — frame metadata reports
-    // CSS (DIP) dimensions whatever the payload's pixel size.
+    // A scaled session's device-metrics override lives on THIS session, so
+    // it spans exactly the life of the capture: a retarget applies it to the
+    // new tab and the old tab reverts when its session detaches (overrides
+    // do not survive their session — measured). mobile:false on purpose —
+    // no touch capability, no mobile emulation; the page's only new surface
+    // is devicePixelRatio. If Chrome refuses the override, fall back to the
+    // classic 1× pipeline rather than stream mismatched dimensions.
+    if (streamScale > 1 && streamDims) {
+      try {
+        await session.send("Emulation.setDeviceMetricsOverride", {
+          width: Math.round(streamDims.width),
+          height: Math.round(streamDims.height),
+          deviceScaleFactor: streamScale,
+          mobile: false,
+        });
+      } catch (err) {
+        log(`stream: device-scale override failed, continuing at 1x: ${err.message || err}`);
+        streamScale = 1;
+      }
+    }
+    // Capture is clamped to the CSS viewport so HiDPI doesn't ship 2× pixels
+    // that the viewer scales straight back down (input mapping is 1:1 too).
+    // That clamp is also right for scaled sessions: their cast frames are
+    // damage ticks, never delivered, so CSS size keeps them cheap — the
+    // delivered device-pixel frames come from captureScreenshot instead
+    // (the cast cannot deliver above 1× whatever the override says — measured).
     const vp = page.viewportSize?.() ?? null;
     try {
       await session.send("Page.startScreencast", {
         format: "jpeg",
         quality: STREAM_QUALITY,
-        maxWidth: (vp?.width ?? 1600) * streamScale,
-        maxHeight: (vp?.height ?? 1200) * streamScale,
+        maxWidth: Math.round(vp?.width ?? 1600),
+        maxHeight: Math.round(vp?.height ?? 1200),
       });
     } catch (err) {
       log(`stream: screencast start failed: ${err.message || err}`);
@@ -672,7 +820,7 @@ export async function startStreamServer(
 
   // Follow the current tab; also (re)starts after a resume-forced restart.
   const retarget = setInterval(() => {
-    if (closed || clients.size === 0 || suspended > 0) return;
+    if (closed || clients.size === 0 || suspended > 0 || reshaping) return;
     if (state.current !== cdpPage) void startScreencast();
   }, RETARGET_POLL_MS);
   retarget.unref?.();
@@ -688,15 +836,10 @@ export async function startStreamServer(
     if (Date.now() - lastFrameAt < REFINE_AFTER_MS) return;
     refined = true;
     try {
-      // clip.scale mirrors the session's capture scale so the output matches
-      // the screencast frame size exactly — the encoders choke on dimension
-      // flips. (Scale 1, the default, means CSS-viewport pixels.)
-      const vp = state.current?.viewportSize?.() ?? null;
-      const shot = await session.send("Page.captureScreenshot", {
-        format: "jpeg",
-        quality: REFINE_QUALITY,
-        ...(vp ? { clip: { x: 0, y: 0, width: vp.width, height: vp.height, scale: streamScale } } : {}),
-      });
+      // Same capture call as the scaled motion path (captureShot pins
+      // clip.scale to 1), so the refinement's pixel dimensions match the
+      // motion frames in every mode — the encoders choke on dimension flips.
+      const shot = await captureShot(session, REFINE_QUALITY);
       if (closed || suspended > 0 || session !== cdp) return;
       deliverFrame({ data: shot.data, metadata: lastMetadata, refinement: true });
       // The encoder gets refinements too — on a damage-driven screencast this
@@ -720,7 +863,7 @@ export async function startStreamServer(
   // always means the picture is wrong, whatever the cause (dead CDP session,
   // a screencast Chrome stopped feeding, an encoder that never started).
   const watchdog = setInterval(() => {
-    if (closed || WATCHDOG_MS <= 0 || suspended > 0 || clients.size === 0) return;
+    if (closed || WATCHDOG_MS <= 0 || suspended > 0 || clients.size === 0 || reshaping) return;
     const page = state.current;
     if (!page || page.isClosed?.()) return;
     if (cdp && Date.now() - lastFrameAt < WATCHDOG_MS) return;
@@ -867,29 +1010,56 @@ export async function startStreamServer(
         const height = Math.round(Number(msg.height));
         if (!resize || ![width, height].every(Number.isFinite)) return;
         const clamp = (n) => Math.min(Math.max(n, RESIZE_MIN), RESIZE_MAX);
+        const w = clamp(width);
+        const h = clamp(height);
         // Optional HiDPI knob: a retina-density viewer asks for the capture
-        // at scale× device pixels. Absent/garbage → 1, so clients that only
-        // ever send width/height keep their exact pre-`scale` behavior.
-        const scale = Number.isFinite(Number(msg.scale))
-          ? Math.min(Math.max(Number(msg.scale), SCALE_MIN), SCALE_MAX)
-          : SCALE_MIN;
+        // at scale× device pixels — integer, budget-reduced (effectiveScale).
+        // Absent/garbage → 1, so clients that only ever send width/height
+        // keep their exact pre-`scale` behavior.
+        const requested = Number(msg.scale);
+        const scale = Number.isFinite(requested) ? effectiveScale(w, h, requested) : SCALE_MIN;
         inputChain = inputChain
           .then(async () => {
             if (suspended > 0) return;
-            const viewport = await resize(clamp(width), clamp(height), scale);
-            const scaleChanged = streamScale !== scale;
-            streamScale = scale;
+            // An active override pins the viewport (blinding the window
+            // resize's chrome measurement) and lives on the cast session —
+            // drop the cast first, and hold the `reshaping` gate so no other
+            // path casts (and re-applies a stale override) mid-resize. The
+            // closing restart applies the override at the new geometry and
+            // replaces the shared encoder, so h264 viewers get fresh SPS/PPS
+            // + an IDR at the new pixel dimensions instead of a decoder
+            // stall. A 1×→1× resize skips all of this and keeps the classic
+            // behavior.
+            const scaling = scale > 1 || streamScale > 1;
+            let viewport;
+            if (scaling) {
+              reshaping = true;
+              try {
+                await stopScreencast();
+                viewport = await resize(w, h);
+                streamScale = scale;
+                streamDims = { width: w, height: h };
+                await stopScreencast(); // belt: kill anything that slipped in
+                await startScreencast();
+                // The override pins the viewport AFTER the measurement inside
+                // resize() — remeasure so the broadcast reports what the page
+                // actually became. (startScreencast may have downgraded
+                // streamScale to 1 if Chrome refused the override.)
+                if (streamScale > 1) viewport = (await measureViewport(streamDims)) ?? viewport;
+              } finally {
+                reshaping = false;
+              }
+            } else {
+              viewport = await resize(w, h);
+              streamScale = scale;
+              streamDims = { width: w, height: h };
+            }
             broadcastStatus({
               type: "status",
               source: "alien",
-              resized: { width: clamp(width), height: clamp(height), scale },
+              resized: { width: w, height: h, scale: streamScale },
               ...(viewport ? { viewport } : {}),
             });
-            // The screencast's pixel caps follow the scale, so a scale change
-            // must restart the cast — and with it the shared encoder, so h264
-            // viewers get fresh SPS/PPS + an IDR at the new dimensions
-            // instead of a decoder stall.
-            if (scaleChanged) await stopScreencast().then(() => startScreencast());
           })
           .catch(() => {});
         return;
@@ -941,9 +1111,12 @@ export async function startStreamServer(
     // that is forever, and a blank canvas reads as "the browser view is
     // broken". Restart the cast so Chrome emits a fresh first frame for it
     // (the same trick `resume` uses); otherwise this is the first watcher and
-    // starting the feed produces that frame anyway.
-    if (cdp) void stopScreencast().then(() => startScreencast());
-    else void startScreencast();
+    // starting the feed produces that frame anyway. A join mid-(scaled-)resize
+    // must not start its own cast — the resize's closing restart serves it.
+    if (!reshaping) {
+      if (cdp) void stopScreencast().then(() => startScreencast());
+      else void startScreencast();
+    }
     ensureFocusPoller();
   });
 

--- a/tests/test-browser-stream-resize.mjs
+++ b/tests/test-browser-stream-resize.mjs
@@ -23,6 +23,7 @@ import {
   startStreamServer,
   makeFrameParser,
   effectiveScale,
+  budgetedResize,
 } from "../plugins/agent-id-browser/lib/stream-server.mjs";
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
@@ -44,7 +45,7 @@ async function until(fn, ms = 2000) {
 
 // ── fakes ────────────────────────────────────────────────────────────────────
 
-function makeFakeSession(page) {
+function makeFakeSession(page, { captureDelayMs = 0 } = {}) {
   const handlers = new Map();
   const session = {
     page,
@@ -53,7 +54,10 @@ function makeFakeSession(page) {
     on: (event, fn) => handlers.set(event, fn),
     async send(method, params) {
       session.sent.push({ method, params });
-      if (method === "Page.captureScreenshot") return { data: SHOT_B64 };
+      if (method === "Page.captureScreenshot") {
+        if (captureDelayMs) await sleep(captureDelayMs);
+        return { data: SHOT_B64 };
+      }
       return {};
     },
     async detach() { session.detached = true; },
@@ -76,7 +80,7 @@ function makeFakePage(inner = { width: 390, height: 844 }) {
   };
 }
 
-function makeFakeState(inner) {
+function makeFakeState(inner, { attachDelayMs = 0, captureDelayMs = 0 } = {}) {
   const sessions = [];
   return {
     current: makeFakePage(inner),
@@ -87,7 +91,8 @@ function makeFakeState(inner) {
       [...sessions].reverse().find((s) => !s.detached && s.sent.some((x) => x.method === "Page.startScreencast")),
     ctx: {
       newCDPSession: async (page) => {
-        const session = makeFakeSession(page);
+        if (attachDelayMs) await sleep(attachDelayMs);
+        const session = makeFakeSession(page, { captureDelayMs });
         sessions.push(session);
         return session;
       },
@@ -308,8 +313,11 @@ test("scaled resize: override on the cast session, capture-delivered frames, rem
     assert.equal(cast.params.maxHeight, 844);
 
     // Motion: a screencast frame is a damage tick — the delivered frame is
-    // the capture's payload, never the cast's CSS-pixel payload.
-    live.emitFrame(CAST_B64);
+    // the capture's payload, never the cast's CSS-pixel payload. The tick
+    // deliberately carries TRANSITIONAL metadata (the surface size Chrome
+    // reports while an override settles): delivered metadata must be
+    // normalized to CSS geometry on every frame, motion and refinement.
+    live.emitFrame(CAST_B64, { deviceWidth: 780, deviceHeight: 1688, timestamp: Date.now() });
     const frames = [];
     while (!frames.some((f) => f.refinement)) {
       const msg = await client.next(3000);
@@ -318,9 +326,10 @@ test("scaled resize: override on the cast session, capture-delivered frames, rem
     assert.ok(frames.length >= 2, "a motion frame and a refinement frame arrived");
     for (const f of frames) {
       assert.equal(f.data, SHOT_B64, "every delivered frame comes from captureScreenshot");
+      assert.equal(f.metadata.deviceWidth, 390, "metadata normalized to CSS width on every frame");
+      assert.equal(f.metadata.deviceHeight, 844, "metadata normalized to CSS height on every frame");
     }
     assert.ok(frames.some((f) => !f.refinement), "the damage tick produced a motion frame");
-    assert.equal(frames[0].metadata.deviceWidth, 390, "metadata stays CSS");
 
     // Both capture calls pin clip.scale=1 (the override already renders at
     // device pixels — a further multiply would deliver 4×): motion at the
@@ -421,6 +430,12 @@ test("the override follows the cast: retargets to the new tab, dies at 1×", asy
     const retargeted = state.liveCast();
     assert.equal(retargeted.page, pageB, "the cast follows the current tab");
     assert.ok(scaledSession.detached, "the old tab's session (and its override) is gone");
+    // Detach alone leaves a dormant override that re-pins the viewport on
+    // every later navigation (measured) — the stop must clear it explicitly.
+    assert.ok(
+      scaledSession.sent.some((s) => s.method === "Emulation.clearDeviceMetricsOverride"),
+      "the override is explicitly cleared before its session detaches",
+    );
     const methods = retargeted.sent.map((s) => s.method);
     const dsoAt = methods.indexOf("Emulation.setDeviceMetricsOverride");
     assert.ok(dsoAt >= 0 && dsoAt < methods.indexOf("Page.startScreencast"),
@@ -443,6 +458,130 @@ test("the override follows the cast: retargets to the new tab, dies at 1×", asy
     );
   } finally {
     client.close();
+    stream.close();
+  }
+});
+
+test("budgetedResize: axis clamps, scale-first policy, base pixel clamp", () => {
+  assert.deepEqual(budgetedResize(390, 844, 2), { width: 390, height: 844, scale: 2 });
+  // Layout beats density: the scale gives way before the geometry does.
+  assert.deepEqual(budgetedResize(2040, 2040, 2), { width: 2040, height: 2040, scale: 1 });
+  // The base viewport ALONE can exceed the pixel budget (RESIZE_MAX² is ~2×
+  // the 4K budget) — scale reduction cannot fix that, so the base shrinks
+  // proportionally to fit.
+  assert.deepEqual(budgetedResize(4096, 4096, 1), { width: 2880, height: 2880, scale: 1 });
+  assert.deepEqual(budgetedResize(4096, 4096, 3), { width: 2880, height: 2880, scale: 1 });
+  // Axis clamps come first, exactly as the pre-scale pipeline did them.
+  assert.deepEqual(budgetedResize(50, 99999, 1), { width: 200, height: 4096, scale: 1 });
+});
+
+test("a base viewport over the pixel budget is shrunk and broadcast truthfully", async () => {
+  const stream = await startStreamServer(makeFakeState({ width: 390, height: 844 }), {
+    resize: async (w, h) => ({ width: w, height: h }),
+  });
+  const client = await connectStream(stream.port, stream.token);
+  try {
+    await client.next(); // greeting
+    client.send({ type: "resize", width: 4096, height: 4096, scale: 3 });
+    const status = await client.nextStatus();
+    // `resized` mirrors the ACHIEVED geometry after the policy, not the ask.
+    assert.deepEqual(status.resized, { width: 2880, height: 2880, scale: 1 });
+  } finally {
+    client.close();
+    stream.close();
+  }
+});
+
+test("overlapping joins settle to exactly one live cast session", async () => {
+  // Two viewers join while CDP attach is slow — the raced start used to
+  // install BOTH sessions (a real-Chrome probe found three live sessions,
+  // each keeping overrides and captures alive). Start/stop are serialized,
+  // so exactly one session may survive.
+  const state = makeFakeState({ width: 390, height: 844 }, { attachDelayMs: 40 });
+  const stream = await startStreamServer(state, {
+    resize: async (w, h) => ({ width: w, height: h }),
+  });
+  let c1 = null;
+  let c2 = null;
+  try {
+    [c1, c2] = await Promise.all([
+      connectStream(stream.port, stream.token),
+      connectStream(stream.port, stream.token),
+    ]);
+    await until(() => state.sessions.length > 0 && state.sessions.some((s) => !s.detached));
+    await sleep(300); // let every queued start settle
+    const live = state.sessions.filter((s) => !s.detached);
+    assert.equal(live.length, 1, `exactly one live session (got ${live.length})`);
+    assert.ok(live[0].sent.some((x) => x.method === "Page.startScreencast"));
+  } finally {
+    c1?.close();
+    c2?.close();
+    stream.close();
+  }
+});
+
+test("a cast attach that loses its epoch is discarded, never installed", async () => {
+  // The current tab flips while the attach is in flight (retarget mid-join):
+  // the late session must be detached without ever casting — installing it
+  // would cast the WRONG tab and leak the session.
+  const state = makeFakeState({ width: 390, height: 844 }, { attachDelayMs: 80 });
+  const stream = await startStreamServer(state, {
+    resize: async (w, h) => ({ width: w, height: h }),
+  });
+  const pageA = state.current;
+  const client = await connectStream(stream.port, stream.token);
+  try {
+    await sleep(20); // the pageA attach is now in flight
+    const pageB = makeFakePage({ width: 390, height: 844 });
+    state.current = pageB;
+    await until(() => state.liveCast()?.page === pageB, 3000);
+    const live = state.sessions.filter((s) => !s.detached);
+    assert.equal(live.length, 1, `exactly one live session (got ${live.length})`);
+    assert.equal(live[0].page, pageB, "the survivor casts the current tab");
+    for (const s of state.sessions.filter((x) => x.page === pageA)) {
+      assert.ok(s.detached, "the stale attach is detached");
+      assert.ok(
+        !s.sent.some((x) => x.method === "Page.startScreencast"),
+        "a session that lost its epoch never casts",
+      );
+    }
+  } finally {
+    client.close();
+    stream.close();
+  }
+});
+
+test("a capture straddling a cast switch cannot strand the next session's first tick", async () => {
+  const state = makeFakeState({ width: 390, height: 844 }, { captureDelayMs: 200 });
+  const stream = await startStreamServer(state, {
+    resize: async (w, h) => ({ width: w, height: h }),
+  });
+  const c1 = await connectStream(stream.port, stream.token);
+  let c2 = null;
+  try {
+    await c1.next(); // greeting
+    c1.send({ type: "resize", width: 390, height: 844, scale: 2 });
+    await c1.nextStatus();
+    const s1 = state.liveCast();
+    s1.emitFrame(CAST_B64); // capture now in flight for 200ms
+    await sleep(30);
+    // A second join restarts the cast → new live session while the stale
+    // capture still holds the (previously global) busy flag.
+    c2 = await connectStream(stream.port, stream.token);
+    await until(() => state.liveCast() && state.liveCast() !== s1);
+    const s2 = state.liveCast();
+    s2.emitFrame(CAST_B64); // first damage tick of the NEW session
+    // The stale capture resolves, sees it lost the cast, and must hand the
+    // dirty flag to the live session — a quality-80 (motion) capture on s2,
+    // well before the quality-90 refinement could mask it.
+    const shot = await until(
+      () => s2.sent.find((x) => x.method === "Page.captureScreenshot" && x.params.quality === 80),
+      2000,
+    );
+    assert.ok(shot, "the new session's first damage tick is not stranded behind the stale capture");
+  } finally {
+    c1.close();
+    c2?.close();
     stream.close();
   }
 });

--- a/tests/test-browser-stream-resize.mjs
+++ b/tests/test-browser-stream-resize.mjs
@@ -2,11 +2,13 @@
 
 // Tests for the stream protocol's `resize` message — the one extension beyond
 // agent-browser's message shapes. A viewer (typically a phone) sends its own
-// dimensions and the session reshapes the page viewport to match; without it
-// there is no way to get a mobile-sized viewport through the stream. Driven
-// end-to-end over real sockets against a FAKE CDP session (no browser): the
-// resize itself is the injected callback, so what's under test is the wire
-// contract — parse, clamp, suspend gating, and the status broadcast.
+// dimensions — and optionally a HiDPI capture `scale` — and the session
+// reshapes the page viewport to match; without it there is no way to get a
+// mobile-sized viewport through the stream. Driven end-to-end over real
+// sockets against a FAKE CDP session (no browser). Some tests inject the
+// resize callback (wire contract: parse, clamp, suspend gating, broadcast);
+// the scale tests wire the REAL resizeToViewport so the device-metrics
+// override and the capture-cap plumbing are observable in the CDP traffic.
 //
 // Run: node --test tests/test-browser-stream-resize.mjs
 
@@ -20,30 +22,82 @@ import {
   startStreamServer,
   makeFrameParser,
 } from "../plugins/agent-id-browser/lib/stream-server.mjs";
+import { resizeToViewport } from "../plugins/agent-id-browser/lib/session-server.mjs";
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const FRAME_B64 = Buffer.from("motion-frame-bytes").toString("base64");
+
+// Poll until `fn` returns truthy (the resize pipeline is async behind the
+// input chain).
+async function until(fn, ms = 2000) {
+  const deadline = Date.now() + ms;
+  for (;;) {
+    const v = fn();
+    if (v || Date.now() > deadline) return v;
+    await sleep(25);
+  }
+}
 
 // ── fakes ────────────────────────────────────────────────────────────────────
 
 function makeFakeSession() {
   const handlers = new Map();
-  return {
+  const session = {
+    sent: [],
+    detached: false,
     on: (event, fn) => handlers.set(event, fn),
-    async send() { return {}; },
-    async detach() {},
+    async send(method, params) {
+      session.sent.push({ method, params });
+      if (method === "Page.captureScreenshot") return { data: FRAME_B64 };
+      return {};
+    },
+    async detach() { session.detached = true; },
+    emitFrame(data, metadata = { deviceWidth: 390, deviceHeight: 844, timestamp: Date.now() }) {
+      handlers.get("Page.screencastFrame")?.({ data, metadata, sessionId: 1 });
+    },
   };
+  return session;
 }
 
-function makeFakeState() {
+// A page + CDP-session pair complete enough for the REAL resizeToViewport:
+// window-bounds changes land on a fake inner viewport whose height loses
+// `chrome` px to window chrome (which is what the compensation pass measures
+// and corrects for). Every created session records its CDP traffic; state.sent()
+// is the union.
+function makeFakeState({ chrome = 87, inner = { width: 1440, height: 813 } } = {}) {
+  const sessions = [];
   const page = {
     isClosed: () => false,
+    viewportSize: () => ({ ...inner }),
+    // resizeWindow evaluates two shapes: the [innerWidth, innerHeight] probe
+    // and the {width, height} result. Sniffed by source — the object shape
+    // must stay a plain object (it is JSON-serialized into the broadcast).
+    evaluate: async (fn) =>
+      String(fn).includes("[window.innerWidth") ? [inner.width, inner.height] : { ...inner },
+    waitForFunction: async () => {},
     mouse: { move: async () => {}, down: async () => {}, up: async () => {}, wheel: async () => {} },
     keyboard: { down: async () => {}, up: async () => {}, insertText: async () => {} },
   };
   return {
     current: page,
     invalidateRefs() {},
-    ctx: { newCDPSession: async () => makeFakeSession() },
+    sessions,
+    sent: () => sessions.flatMap((s) => s.sent),
+    ctx: {
+      newCDPSession: async () => {
+        const session = makeFakeSession();
+        const send = session.send;
+        session.send = async (method, params) => {
+          if (method === "Browser.setWindowBounds" && params?.bounds?.width) {
+            inner.width = params.bounds.width;
+            inner.height = params.bounds.height - chrome;
+          }
+          return send(method, params);
+        };
+        sessions.push(session);
+        return session;
+      },
+    },
   };
 }
 
@@ -125,7 +179,7 @@ test("resize: viewer dimensions reach the callback; the viewport is broadcast", 
     const status = await client.next();
     assert.deepEqual(resizes, [[390, 844]]);
     assert.equal(status.type, "status");
-    assert.deepEqual(status.resized, { width: 390, height: 844 });
+    assert.deepEqual(status.resized, { width: 390, height: 844, scale: 1 });
     assert.deepEqual(status.viewport, { width: 390, height: 757 });
   } finally {
     client.close();
@@ -135,9 +189,9 @@ test("resize: viewer dimensions reach the callback; the viewport is broadcast", 
 
 test("resize with unknown extra fields is applied and the extras ignored", async () => {
   // Forward compatibility: a viewer from a newer protocol revision may attach
-  // fields this daemon does not know (say, a display scale). The handler reads
-  // only width/height, so the message must behave exactly like the 2-field
-  // resize — applied, broadcast, extras neither acted on nor echoed.
+  // fields this daemon does not know. The handler reads only the known
+  // fields, so the message must behave exactly like a plain resize —
+  // applied, broadcast, extras neither acted on nor echoed.
   const resizes = [];
   const stream = await startStreamServer(makeFakeState(), {
     resize: async (w, h) => { resizes.push([w, h]); return { width: w, height: h - 87 }; },
@@ -146,13 +200,13 @@ test("resize with unknown extra fields is applied and the extras ignored", async
   try {
     const hello = await client.next();
     assert.equal(hello.type, "status");
-    client.send({ type: "resize", width: 390, height: 844, scale: 2 });
+    client.send({ type: "resize", width: 390, height: 844, tint: "sepia", hdr: true });
     const status = await client.next();
     assert.deepEqual(resizes, [[390, 844]]);
     assert.equal(status.type, "status");
-    assert.deepEqual(status.resized, { width: 390, height: 844 });
+    assert.deepEqual(status.resized, { width: 390, height: 844, scale: 1 });
     assert.deepEqual(status.viewport, { width: 390, height: 757 });
-    assert.ok(!("scale" in status), "unknown fields are not echoed back");
+    assert.ok(!("tint" in status) && !("hdr" in status), "unknown fields are not echoed back");
   } finally {
     client.close();
     stream.close();
@@ -208,6 +262,141 @@ test("resize: dropped while a credential fill has the stream suspended", async (
     await sleep(150);
     assert.deepEqual(resizes, []);
     stream.resume();
+  } finally {
+    client.close();
+    stream.close();
+  }
+});
+
+// ── the HiDPI capture scale ──────────────────────────────────────────────────
+
+test("resize with scale: override applied, capture caps and refinement follow", async () => {
+  const state = makeFakeState();
+  const stream = await startStreamServer(state, {
+    resize: (w, h, s) => resizeToViewport(state, w, h, s),
+  });
+  const client = await connectStream(stream.port, stream.token);
+  try {
+    await client.next(); // greeting
+    client.send({ type: "resize", width: 390, height: 844, scale: 2 });
+    const status = await client.next();
+    assert.equal(status.type, "status");
+    assert.deepEqual(status.resized, { width: 390, height: 844, scale: 2 });
+    assert.deepEqual(status.viewport, { width: 390, height: 844 });
+
+    // The device-metrics override carries the scale — and deliberately no
+    // mobile emulation: the page's only new tell is devicePixelRatio.
+    const dso = state.sent().find((s) => s.method === "Emulation.setDeviceMetricsOverride");
+    assert.ok(dso, "a scaled resize applies a device-metrics override");
+    assert.deepEqual(dso.params, {
+      width: 390,
+      height: 844,
+      deviceScaleFactor: 2,
+      mobile: false,
+    });
+
+    // The screencast restarts with pixel caps at viewport × scale, so the
+    // device-pixel frames actually come through.
+    const cast = await until(() =>
+      state
+        .sent()
+        .filter((s) => s.method === "Page.startScreencast")
+        .find((s) => s.params.maxWidth === 780),
+    );
+    assert.ok(cast, "screencast restarted with scaled caps");
+    assert.equal(cast.params.maxHeight, 1688);
+
+    // The refinement screenshot keeps the same pixel dimensions: CSS clip
+    // geometry at clip.scale = the capture scale (the encoders choke on
+    // dimension flips between the two frame sources).
+    const live = [...state.sessions]
+      .reverse()
+      .find((s) => !s.detached && s.sent.some((x) => x.method === "Page.startScreencast"));
+    live.emitFrame(FRAME_B64);
+    const shot = await until(
+      () => state.sent().find((s) => s.method === "Page.captureScreenshot"),
+      3000,
+    );
+    assert.ok(shot, "refinement fired after the screencast went quiet");
+    assert.deepEqual(shot.params.clip, { x: 0, y: 0, width: 390, height: 844, scale: 2 });
+  } finally {
+    client.close();
+    stream.close();
+  }
+});
+
+test("scale clamps to 1..3; garbage means 1", async () => {
+  const scales = [];
+  const stream = await startStreamServer(makeFakeState(), {
+    resize: async (w, h, s) => { scales.push(s); return { width: w, height: h }; },
+  });
+  const client = await connectStream(stream.port, stream.token);
+  try {
+    await client.next(); // greeting
+    client.send({ type: "resize", width: 390, height: 844, scale: 0.5 });
+    assert.equal((await client.next()).resized.scale, 1);
+    client.send({ type: "resize", width: 390, height: 844, scale: 7 });
+    assert.equal((await client.next()).resized.scale, 3);
+    client.send({ type: "resize", width: 390, height: 844, scale: "dense" });
+    assert.equal((await client.next()).resized.scale, 1);
+    assert.deepEqual(scales, [1, 3, 1]);
+  } finally {
+    client.close();
+    stream.close();
+  }
+});
+
+test("a two-field resize never touches device metrics (pre-scale behavior)", async () => {
+  // Back compatibility: clients that only ever send width/height must get
+  // the exact pre-scale pipeline — window resize + chrome compensation and
+  // nothing else. No Emulation call may appear anywhere in the CDP traffic.
+  const state = makeFakeState();
+  const stream = await startStreamServer(state, {
+    resize: (w, h, s) => resizeToViewport(state, w, h, s),
+  });
+  const client = await connectStream(stream.port, stream.token);
+  try {
+    await client.next(); // greeting
+    client.send({ type: "resize", width: 390, height: 844 });
+    const status = await client.next();
+    assert.deepEqual(status.resized, { width: 390, height: 844, scale: 1 });
+    assert.deepEqual(status.viewport, { width: 390, height: 844 });
+    await sleep(100); // any (wrong) trailing async CDP work gets to surface
+    const emulation = state.sent().filter((s) => s.method.startsWith("Emulation."));
+    assert.deepEqual(emulation, [], "no device-metrics traffic for a 1× resize");
+  } finally {
+    client.close();
+    stream.close();
+  }
+});
+
+test("re-scaling lifts the stale override before measuring; 1× clears it", async () => {
+  const state = makeFakeState();
+  const stream = await startStreamServer(state, {
+    resize: (w, h, s) => resizeToViewport(state, w, h, s),
+  });
+  const client = await connectStream(stream.port, stream.token);
+  try {
+    await client.next(); // greeting
+    client.send({ type: "resize", width: 390, height: 844, scale: 2 });
+    await client.next();
+    // A scaled session pins its viewport to the override, which would blind
+    // the chrome-compensation measurement of the NEXT resize — the override
+    // must be lifted first, then re-applied at the new geometry (the rotated
+    // phone case).
+    client.send({ type: "resize", width: 844, height: 390, scale: 2 });
+    const rotated = await client.next();
+    assert.deepEqual(rotated.resized, { width: 844, height: 390, scale: 2 });
+    assert.deepEqual(rotated.viewport, { width: 844, height: 390 });
+    // Dropping back to 1× clears the override for good.
+    client.send({ type: "resize", width: 844, height: 390 });
+    const flat = await client.next();
+    assert.deepEqual(flat.resized, { width: 844, height: 390, scale: 1 });
+    const emulation = state
+      .sent()
+      .filter((s) => s.method.startsWith("Emulation."))
+      .map((s) => (s.method === "Emulation.setDeviceMetricsOverride" ? `set@${s.params.width}x${s.params.height}` : "clear"));
+    assert.deepEqual(emulation, ["set@390x844", "clear", "set@844x390", "clear"]);
   } finally {
     client.close();
     stream.close();

--- a/tests/test-browser-stream-resize.mjs
+++ b/tests/test-browser-stream-resize.mjs
@@ -5,10 +5,11 @@
 // dimensions — and optionally a HiDPI capture `scale` — and the session
 // reshapes the page viewport to match; without it there is no way to get a
 // mobile-sized viewport through the stream. Driven end-to-end over real
-// sockets against a FAKE CDP session (no browser). Some tests inject the
-// resize callback (wire contract: parse, clamp, suspend gating, broadcast);
-// the scale tests wire the REAL resizeToViewport so the device-metrics
-// override and the capture-cap plumbing are observable in the CDP traffic.
+// sockets against FAKE CDP sessions (no browser): the window resize is the
+// injected callback, and every created CDP session records its traffic so the
+// scale tests can pin the override lifecycle, the capture calls, and what
+// actually got delivered. Delivered PIXEL dimensions against real Chrome are
+// covered separately by test-browser-stream-scale-live.mjs.
 //
 // Run: node --test tests/test-browser-stream-resize.mjs
 
@@ -21,11 +22,14 @@ import { once } from "node:events";
 import {
   startStreamServer,
   makeFrameParser,
+  effectiveScale,
 } from "../plugins/agent-id-browser/lib/stream-server.mjs";
-import { resizeToViewport } from "../plugins/agent-id-browser/lib/session-server.mjs";
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
-const FRAME_B64 = Buffer.from("motion-frame-bytes").toString("base64");
+// What the fake captureScreenshot returns vs what the fake screencast emits —
+// distinct payloads, so a test can tell WHICH source a delivered frame came from.
+const SHOT_B64 = Buffer.from("capture-screenshot-bytes").toString("base64");
+const CAST_B64 = Buffer.from("raw-screencast-bytes").toString("base64");
 
 // Poll until `fn` returns truthy (the resize pipeline is async behind the
 // input chain).
@@ -40,60 +44,50 @@ async function until(fn, ms = 2000) {
 
 // ── fakes ────────────────────────────────────────────────────────────────────
 
-function makeFakeSession() {
+function makeFakeSession(page) {
   const handlers = new Map();
   const session = {
+    page,
     sent: [],
     detached: false,
     on: (event, fn) => handlers.set(event, fn),
     async send(method, params) {
       session.sent.push({ method, params });
-      if (method === "Page.captureScreenshot") return { data: FRAME_B64 };
+      if (method === "Page.captureScreenshot") return { data: SHOT_B64 };
       return {};
     },
     async detach() { session.detached = true; },
-    emitFrame(data, metadata = { deviceWidth: 390, deviceHeight: 844, timestamp: Date.now() }) {
+    emitFrame(data = CAST_B64, metadata = { deviceWidth: 390, deviceHeight: 844, timestamp: Date.now() }) {
       handlers.get("Page.screencastFrame")?.({ data, metadata, sessionId: 1 });
     },
   };
   return session;
 }
 
-// A page + CDP-session pair complete enough for the REAL resizeToViewport:
-// window-bounds changes land on a fake inner viewport whose height loses
-// `chrome` px to window chrome (which is what the compensation pass measures
-// and corrects for). Every created session records its CDP traffic; state.sent()
-// is the union.
-function makeFakeState({ chrome = 87, inner = { width: 1440, height: 813 } } = {}) {
-  const sessions = [];
-  const page = {
+function makeFakePage(inner = { width: 390, height: 844 }) {
+  return {
+    inner,
     isClosed: () => false,
     viewportSize: () => ({ ...inner }),
-    // resizeWindow evaluates two shapes: the [innerWidth, innerHeight] probe
-    // and the {width, height} result. Sniffed by source — the object shape
-    // must stay a plain object (it is JSON-serialized into the broadcast).
-    evaluate: async (fn) =>
-      String(fn).includes("[window.innerWidth") ? [inner.width, inner.height] : { ...inner },
-    waitForFunction: async () => {},
+    // measureViewport reads the page's own innerWidth/innerHeight.
+    evaluate: async () => ({ ...inner }),
     mouse: { move: async () => {}, down: async () => {}, up: async () => {}, wheel: async () => {} },
     keyboard: { down: async () => {}, up: async () => {}, insertText: async () => {} },
   };
+}
+
+function makeFakeState(inner) {
+  const sessions = [];
   return {
-    current: page,
+    current: makeFakePage(inner),
     invalidateRefs() {},
     sessions,
     sent: () => sessions.flatMap((s) => s.sent),
+    liveCast: () =>
+      [...sessions].reverse().find((s) => !s.detached && s.sent.some((x) => x.method === "Page.startScreencast")),
     ctx: {
-      newCDPSession: async () => {
-        const session = makeFakeSession();
-        const send = session.send;
-        session.send = async (method, params) => {
-          if (method === "Browser.setWindowBounds" && params?.bounds?.width) {
-            inner.width = params.bounds.width;
-            inner.height = params.bounds.height - chrome;
-          }
-          return send(method, params);
-        };
+      newCDPSession: async (page) => {
+        const session = makeFakeSession(page);
         sessions.push(session);
         return session;
       },
@@ -159,11 +153,19 @@ async function connectStream(port, token) {
       });
       return JSON.parse(frame.payload.toString("utf8"));
     },
+    // Skip frames until the next `status` message (scaled sessions interleave
+    // delivered frames with broadcasts).
+    async nextStatus(timeoutMs = 2000) {
+      for (;;) {
+        const msg = await this.next(timeoutMs);
+        if (msg.type === "status") return msg;
+      }
+    },
     close: () => sock.destroy(),
   };
 }
 
-// ── tests ────────────────────────────────────────────────────────────────────
+// ── the classic resize contract ──────────────────────────────────────────────
 
 test("resize: viewer dimensions reach the callback; the viewport is broadcast", async () => {
   const resizes = [];
@@ -176,9 +178,8 @@ test("resize: viewer dimensions reach the callback; the viewport is broadcast", 
     const hello = await client.next();
     assert.equal(hello.type, "status");
     client.send({ type: "resize", width: 390, height: 844 });
-    const status = await client.next();
+    const status = await client.nextStatus();
     assert.deepEqual(resizes, [[390, 844]]);
-    assert.equal(status.type, "status");
     assert.deepEqual(status.resized, { width: 390, height: 844, scale: 1 });
     assert.deepEqual(status.viewport, { width: 390, height: 757 });
   } finally {
@@ -201,9 +202,8 @@ test("resize with unknown extra fields is applied and the extras ignored", async
     const hello = await client.next();
     assert.equal(hello.type, "status");
     client.send({ type: "resize", width: 390, height: 844, tint: "sepia", hdr: true });
-    const status = await client.next();
+    const status = await client.nextStatus();
     assert.deepEqual(resizes, [[390, 844]]);
-    assert.equal(status.type, "status");
     assert.deepEqual(status.resized, { width: 390, height: 844, scale: 1 });
     assert.deepEqual(status.viewport, { width: 390, height: 757 });
     assert.ok(!("tint" in status) && !("hdr" in status), "unknown fields are not echoed back");
@@ -222,7 +222,7 @@ test("resize: out-of-range dimensions clamp instead of failing the viewer", asyn
   try {
     await client.next(); // greeting
     client.send({ type: "resize", width: 50, height: 99999 });
-    await client.next();
+    await client.nextStatus();
     assert.deepEqual(resizes, [[200, 4096]]);
   } finally {
     client.close();
@@ -270,76 +270,102 @@ test("resize: dropped while a credential fill has the stream suspended", async (
 
 // ── the HiDPI capture scale ──────────────────────────────────────────────────
 
-test("resize with scale: override applied, capture caps and refinement follow", async () => {
-  const state = makeFakeState();
+test("scaled resize: override on the cast session, capture-delivered frames, remeasured viewport", async () => {
+  const state = makeFakeState({ width: 390, height: 844 });
   const stream = await startStreamServer(state, {
-    resize: (w, h, s) => resizeToViewport(state, w, h, s),
+    // The callback's measurement is deliberately STALE (what a window that
+    // cannot shrink to the request reports): the broadcast must carry the
+    // post-override remeasure instead.
+    resize: async () => ({ width: 500, height: 844 }),
   });
   const client = await connectStream(stream.port, stream.token);
   try {
     await client.next(); // greeting
     client.send({ type: "resize", width: 390, height: 844, scale: 2 });
-    const status = await client.next();
-    assert.equal(status.type, "status");
+    const status = await client.nextStatus();
     assert.deepEqual(status.resized, { width: 390, height: 844, scale: 2 });
+    // Remeasured after the override landed — NOT the callback's stale value.
     assert.deepEqual(status.viewport, { width: 390, height: 844 });
 
-    // The device-metrics override carries the scale — and deliberately no
-    // mobile emulation: the page's only new tell is devicePixelRatio.
-    const dso = state.sent().find((s) => s.method === "Emulation.setDeviceMetricsOverride");
-    assert.ok(dso, "a scaled resize applies a device-metrics override");
-    assert.deepEqual(dso.params, {
+    // The override rides the live cast session, before the cast starts, with
+    // exact params — and deliberately no mobile emulation.
+    const live = state.liveCast();
+    assert.ok(live, "a cast session is live after the scaled resize");
+    const methods = live.sent.map((s) => s.method);
+    const dsoAt = methods.indexOf("Emulation.setDeviceMetricsOverride");
+    assert.ok(dsoAt >= 0, "the scaled cast session carries the override");
+    assert.ok(dsoAt < methods.indexOf("Page.startScreencast"), "override applied before the cast starts");
+    assert.deepEqual(live.sent[dsoAt].params, {
       width: 390,
       height: 844,
       deviceScaleFactor: 2,
       mobile: false,
     });
+    // The cast stays a CSS-sized damage feed (integer caps, not multiplied):
+    // delivered scaled frames come from captureScreenshot instead.
+    const cast = live.sent.find((s) => s.method === "Page.startScreencast");
+    assert.equal(cast.params.maxWidth, 390);
+    assert.equal(cast.params.maxHeight, 844);
 
-    // The screencast restarts with pixel caps at viewport × scale, so the
-    // device-pixel frames actually come through.
-    const cast = await until(() =>
-      state
-        .sent()
-        .filter((s) => s.method === "Page.startScreencast")
-        .find((s) => s.params.maxWidth === 780),
-    );
-    assert.ok(cast, "screencast restarted with scaled caps");
-    assert.equal(cast.params.maxHeight, 1688);
+    // Motion: a screencast frame is a damage tick — the delivered frame is
+    // the capture's payload, never the cast's CSS-pixel payload.
+    live.emitFrame(CAST_B64);
+    const frames = [];
+    while (!frames.some((f) => f.refinement)) {
+      const msg = await client.next(3000);
+      if (msg.type === "frame") frames.push(msg);
+    }
+    assert.ok(frames.length >= 2, "a motion frame and a refinement frame arrived");
+    for (const f of frames) {
+      assert.equal(f.data, SHOT_B64, "every delivered frame comes from captureScreenshot");
+    }
+    assert.ok(frames.some((f) => !f.refinement), "the damage tick produced a motion frame");
+    assert.equal(frames[0].metadata.deviceWidth, 390, "metadata stays CSS");
 
-    // The refinement screenshot keeps the same pixel dimensions: CSS clip
-    // geometry at clip.scale = the capture scale (the encoders choke on
-    // dimension flips between the two frame sources).
-    const live = [...state.sessions]
-      .reverse()
-      .find((s) => !s.detached && s.sent.some((x) => x.method === "Page.startScreencast"));
-    live.emitFrame(FRAME_B64);
-    const shot = await until(
-      () => state.sent().find((s) => s.method === "Page.captureScreenshot"),
-      3000,
-    );
-    assert.ok(shot, "refinement fired after the screencast went quiet");
-    assert.deepEqual(shot.params.clip, { x: 0, y: 0, width: 390, height: 844, scale: 2 });
+    // Both capture calls pin clip.scale=1 (the override already renders at
+    // device pixels — a further multiply would deliver 4×): motion at the
+    // stream quality, refinement at the refinement quality.
+    const shots = live.sent.filter((s) => s.method === "Page.captureScreenshot");
+    assert.ok(shots.length >= 2, "motion capture and refinement capture both fired");
+    assert.equal(shots[0].params.quality, 80);
+    assert.equal(shots[shots.length - 1].params.quality, 90);
+    for (const s of shots) {
+      assert.deepEqual(s.params.clip, { x: 0, y: 0, width: 390, height: 844, scale: 1 });
+    }
   } finally {
     client.close();
     stream.close();
   }
 });
 
-test("scale clamps to 1..3; garbage means 1", async () => {
-  const scales = [];
-  const stream = await startStreamServer(makeFakeState(), {
-    resize: async (w, h, s) => { scales.push(s); return { width: w, height: h }; },
+test("effectiveScale: nearest-integer rounding, axis and pixel budgets", () => {
+  // Rounding to nearest integer, clamped 1..3.
+  assert.equal(effectiveScale(390, 844, 2), 2);
+  assert.equal(effectiveScale(390, 844, 0.5), 1);
+  assert.equal(effectiveScale(390, 844, 1.4), 1);
+  assert.equal(effectiveScale(390, 844, 2.5), 3);
+  assert.equal(effectiveScale(390, 844, 7), 3);
+  // Axis budget: no scaled axis over 4096 device pixels.
+  assert.equal(effectiveScale(2000, 1000, 3), 2);
+  assert.equal(effectiveScale(2100, 2100, 2), 1);
+  // Pixel budget: axes fit (4080 ≤ 4096) but 4080×4080 outgrows one 4K frame.
+  assert.equal(effectiveScale(2040, 2040, 2), 1);
+  assert.equal(effectiveScale(4096, 4096, 3), 1);
+});
+
+test("scale over budget is served at the largest scale that fits", async () => {
+  const stream = await startStreamServer(makeFakeState({ width: 2000, height: 1000 }), {
+    resize: async (w, h) => ({ width: w, height: h }),
   });
   const client = await connectStream(stream.port, stream.token);
   try {
     await client.next(); // greeting
-    client.send({ type: "resize", width: 390, height: 844, scale: 0.5 });
-    assert.equal((await client.next()).resized.scale, 1);
-    client.send({ type: "resize", width: 390, height: 844, scale: 7 });
-    assert.equal((await client.next()).resized.scale, 3);
+    client.send({ type: "resize", width: 2000, height: 1000, scale: 3 });
+    assert.equal((await client.nextStatus()).resized.scale, 2); // 3× would breach the 4096 axis
+    client.send({ type: "resize", width: 2040, height: 2040, scale: 2 });
+    assert.equal((await client.nextStatus()).resized.scale, 1); // 2× fits the axes, not the pixel budget
     client.send({ type: "resize", width: 390, height: 844, scale: "dense" });
-    assert.equal((await client.next()).resized.scale, 1);
-    assert.deepEqual(scales, [1, 3, 1]);
+    assert.equal((await client.nextStatus()).resized.scale, 1); // garbage means 1
   } finally {
     client.close();
     stream.close();
@@ -348,55 +374,73 @@ test("scale clamps to 1..3; garbage means 1", async () => {
 
 test("a two-field resize never touches device metrics (pre-scale behavior)", async () => {
   // Back compatibility: clients that only ever send width/height must get
-  // the exact pre-scale pipeline — window resize + chrome compensation and
-  // nothing else. No Emulation call may appear anywhere in the CDP traffic.
-  const state = makeFakeState();
+  // the exact pre-scale pipeline — the injected window resize and nothing
+  // else. No Emulation call may appear anywhere in the CDP traffic, and the
+  // cast must not restart.
+  const state = makeFakeState({ width: 390, height: 844 });
   const stream = await startStreamServer(state, {
-    resize: (w, h, s) => resizeToViewport(state, w, h, s),
+    resize: async (w, h) => ({ width: w, height: h }),
   });
   const client = await connectStream(stream.port, stream.token);
   try {
     await client.next(); // greeting
+    await until(() => state.liveCast());
+    const preCast = state.liveCast();
     client.send({ type: "resize", width: 390, height: 844 });
-    const status = await client.next();
+    const status = await client.nextStatus();
     assert.deepEqual(status.resized, { width: 390, height: 844, scale: 1 });
-    assert.deepEqual(status.viewport, { width: 390, height: 844 });
     await sleep(100); // any (wrong) trailing async CDP work gets to surface
     const emulation = state.sent().filter((s) => s.method.startsWith("Emulation."));
     assert.deepEqual(emulation, [], "no device-metrics traffic for a 1× resize");
+    assert.equal(state.liveCast(), preCast, "a 1×→1× resize does not restart the cast");
   } finally {
     client.close();
     stream.close();
   }
 });
 
-test("re-scaling lifts the stale override before measuring; 1× clears it", async () => {
-  const state = makeFakeState();
+test("the override follows the cast: retargets to the new tab, dies at 1×", async () => {
+  const state = makeFakeState({ width: 390, height: 844 });
   const stream = await startStreamServer(state, {
-    resize: (w, h, s) => resizeToViewport(state, w, h, s),
+    resize: async (w, h) => ({ width: w, height: h }),
   });
   const client = await connectStream(stream.port, stream.token);
   try {
     await client.next(); // greeting
     client.send({ type: "resize", width: 390, height: 844, scale: 2 });
-    await client.next();
-    // A scaled session pins its viewport to the override, which would blind
-    // the chrome-compensation measurement of the NEXT resize — the override
-    // must be lifted first, then re-applied at the new geometry (the rotated
-    // phone case).
-    client.send({ type: "resize", width: 844, height: 390, scale: 2 });
-    const rotated = await client.next();
-    assert.deepEqual(rotated.resized, { width: 844, height: 390, scale: 2 });
-    assert.deepEqual(rotated.viewport, { width: 844, height: 390 });
-    // Dropping back to 1× clears the override for good.
-    client.send({ type: "resize", width: 844, height: 390 });
-    const flat = await client.next();
-    assert.deepEqual(flat.resized, { width: 844, height: 390, scale: 1 });
-    const emulation = state
-      .sent()
-      .filter((s) => s.method.startsWith("Emulation."))
-      .map((s) => (s.method === "Emulation.setDeviceMetricsOverride" ? `set@${s.params.width}x${s.params.height}` : "clear"));
-    assert.deepEqual(emulation, ["set@390x844", "clear", "set@844x390", "clear"]);
+    await client.nextStatus();
+    const scaledSession = state.liveCast();
+    assert.ok(scaledSession.sent.some((s) => s.method === "Emulation.setDeviceMetricsOverride"));
+
+    // Tab switch: the retarget poll must attach to the NEW page and apply
+    // the override THERE (overrides revert with their session, so the old
+    // tab needs no explicit cleanup — its session detaches).
+    const pageB = makeFakePage({ width: 390, height: 844 });
+    state.current = pageB;
+    await until(() => state.liveCast() !== scaledSession && state.liveCast()?.page === pageB);
+    const retargeted = state.liveCast();
+    assert.equal(retargeted.page, pageB, "the cast follows the current tab");
+    assert.ok(scaledSession.detached, "the old tab's session (and its override) is gone");
+    const methods = retargeted.sent.map((s) => s.method);
+    const dsoAt = methods.indexOf("Emulation.setDeviceMetricsOverride");
+    assert.ok(dsoAt >= 0 && dsoAt < methods.indexOf("Page.startScreencast"),
+      "the new tab gets the override before its cast starts");
+    assert.deepEqual(retargeted.sent[dsoAt].params, {
+      width: 390, height: 844, deviceScaleFactor: 2, mobile: false,
+    });
+
+    // Back to 1×: the replacement cast session carries no override at all.
+    client.send({ type: "resize", width: 390, height: 844 });
+    const status = await client.nextStatus();
+    assert.equal(status.resized.scale, 1);
+    await until(() => state.liveCast() && state.liveCast() !== retargeted);
+    const flat = state.liveCast();
+    assert.ok(retargeted.detached, "the scaled session is replaced");
+    assert.equal(
+      flat.sent.filter((s) => s.method.startsWith("Emulation.")).length,
+      0,
+      "a 1× session never sees an Emulation call",
+    );
   } finally {
     client.close();
     stream.close();

--- a/tests/test-browser-stream-scale-live.mjs
+++ b/tests/test-browser-stream-scale-live.mjs
@@ -222,12 +222,28 @@ test(
       assert.deepEqual(status.viewport, { width: 390, height: 844 });
       assert.equal(await pageA.evaluate(() => devicePixelRatio), 2, "the override is live on the page");
 
+      // Overlapping joins while scaled: two more viewers connect
+      // concurrently. Start/stop are serialized, so exactly one cast session
+      // may exist — a leaked session would keep its override alive, which
+      // the end-of-test 1× DPR assertions would expose.
+      const [extraA, extraB] = await Promise.all([
+        connectStream(stream.port, stream.token),
+        connectStream(stream.port, stream.token),
+      ]);
+
       const scaled = { width: 780, height: 1688 };
+      const cssOf = (frames, want) => {
+        // EVERY scaled frame's metadata must be CSS geometry — a single
+        // device-pixel metadata frame doubles the viewer's tap coordinates.
+        for (const f of frames) {
+          if (!f.dims || f.dims.width !== want.width) continue;
+          assert.equal(f.metadata.deviceWidth, 390, "metadata stays CSS px on every frame");
+          assert.equal(f.metadata.deviceHeight, 844, "metadata stays CSS px on every frame");
+        }
+      };
       const motion = await collectFrames(client, { want: 4, dims: scaled });
       assertStableAfterSwitch(motion, scaled, "scale-2 motion");
-      const anyScaled = motion.find((f) => f.dims && f.dims.width === scaled.width);
-      assert.equal(anyScaled.metadata.deviceWidth, 390, "metadata stays CSS px");
-      assert.equal(anyScaled.metadata.deviceHeight, 844, "metadata stays CSS px");
+      cssOf(motion, scaled);
 
       // Quiet page → the refinement path must produce the SAME dimensions.
       await pageA.goto(STATIC);
@@ -244,6 +260,7 @@ test(
       const refinement = refined.find((f) => f.refinement);
       assert.ok(refinement, "a refinement frame arrived on the quiet page");
       assert.deepEqual(refinement.dims, scaled, "refinement pixels match motion pixels exactly");
+      cssOf(refined, scaled);
 
       // ── tab switch: the override follows the cast to the new tab ─────────
       const pageB = await ctx.newPage();
@@ -261,6 +278,9 @@ test(
       assert.equal(await pageA.evaluate(() => devicePixelRatio), 1, "the old tab reverts (override died with its session)");
       const afterSwitch = await collectFrames(client, { want: 3, dims: scaled });
       assertStableAfterSwitch(afterSwitch, scaled, "post-retarget");
+      cssOf(afterSwitch, scaled);
+      extraA.close();
+      extraB.close();
 
       // ── back to 1×: override gone, delivered pixels match the viewport ───
       client.send({ type: "resize", width: 390, height: 844 });
@@ -275,6 +295,42 @@ test(
       assert.notDeepEqual(flat, scaled, "the 1× viewport is not the scaled pixel size");
       const flatFrames = await collectFrames(client, { want: 2, dims: flat });
       assertStableAfterSwitch(flatFrames, flat, "back-to-1x");
+
+      // ── over-budget request: scale falls back, dimensions still agree ────
+      // 2040×2040 at scale 2 would be 16.6M pixels — over the 4K budget, so
+      // the achieved scale is 1. The invariant must hold here too: every
+      // delivered frame (motion and refinement) identical, equal to the
+      // broadcast viewport, with CSS metadata — the legacy fixed cast caps
+      // used to downscale exactly this case out of agreement with the
+      // refinement pass (measured: 1253×1200 vs 2040×1953).
+      client.send({ type: "resize", width: 2040, height: 2040, scale: 2 });
+      for (;;) {
+        status = await client.nextStatus(15000);
+        if (status.resized) break;
+      }
+      assert.deepEqual(status.resized, { width: 2040, height: 2040, scale: 1 });
+      assert.equal(await pageB.evaluate(() => devicePixelRatio), 1, "an effective 1× applies no override");
+      assert.ok(status.viewport, "the over-budget resize reports its viewport");
+      const big = { width: status.viewport.width, height: status.viewport.height };
+      const bigMotion = await collectFrames(client, { want: 3, dims: big, timeoutMs: 20000 });
+      assertStableAfterSwitch(bigMotion, big, "over-budget motion");
+      await pageB.goto(STATIC);
+      const bigFrames = await (async () => {
+        const frames = [];
+        const deadline = Date.now() + 12000;
+        while (!frames.some((f) => f.refinement) && Date.now() < deadline) {
+          frames.push(...(await collectFrames(client, { want: 1, dims: big, timeoutMs: 3000 })));
+        }
+        return frames;
+      })();
+      const bigRefinement = bigFrames.find((f) => f.refinement);
+      assert.ok(bigRefinement, "a refinement frame arrived on the quiet over-budget page");
+      assert.deepEqual(bigRefinement.dims, big, "over-budget refinement matches motion exactly");
+      for (const f of [...bigMotion, ...bigFrames]) {
+        if (!f.dims || f.dims.width !== big.width) continue;
+        assert.equal(f.metadata.deviceWidth, big.width, "metadata stays CSS px at 1×");
+        assert.equal(f.metadata.deviceHeight, big.height, "metadata stays CSS px at 1×");
+      }
     } finally {
       client?.close();
       stream?.close();

--- a/tests/test-browser-stream-scale-live.mjs
+++ b/tests/test-browser-stream-scale-live.mjs
@@ -1,0 +1,285 @@
+#!/usr/bin/env node
+
+// LIVE test for the stream's HiDPI capture scale — real Chrome, real pixels.
+//
+// The fake-CDP suites pin the protocol and the CDP call shapes; this one pins
+// what actually matters and cannot be faked: the PIXEL DIMENSIONS of the
+// frames a viewer receives. Chrome's screencast delivers CSS-pixel frames no
+// matter what devicePixelRatio says, and captureScreenshot renders at device
+// pixels — so the invariant under test is that at any scale, every delivered
+// frame (motion and refinement alike) has identical viewport×scale
+// dimensions, that the device-metrics override really lands (and follows a
+// tab switch), and that the broadcast viewport is the page's post-override
+// truth rather than the stale pre-override measurement.
+//
+// Skips automatically when patchright / Chrome are not installed.
+//
+// Run: node --test tests/test-browser-stream-scale-live.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs/promises";
+import { once } from "node:events";
+
+import { resolvePatchright, launchContext } from "../plugins/agent-id-browser/lib/launch.mjs";
+import { startStreamServer, makeFrameParser } from "../plugins/agent-id-browser/lib/stream-server.mjs";
+import { chromeCompensatedBounds } from "../plugins/agent-id-browser/lib/session-server.mjs";
+
+const patchrightAvailable = !!resolvePatchright();
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// A page that repaints continuously (screencast damage); refinement needs a
+// QUIET page, so tests navigate to the static page when they want it.
+const ANIMATED = "data:text/html," + encodeURIComponent(`<!doctype html>
+<title>scale probe</title><body style="margin:0">
+<div id="t" style="font:20px monospace">tick</div>
+<script>
+  setInterval(() => { t.textContent = Date.now() + " " + Math.random(); }, 30);
+</script>`);
+const STATIC = "data:text/html," + encodeURIComponent(`<!doctype html>
+<title>quiet probe</title><body style="margin:0"><p style="font:20px monospace">still</p>`);
+
+// ── jpeg dimensions (SOF scan) ───────────────────────────────────────────────
+
+function jpegDims(b64) {
+  const buf = Buffer.from(b64, "base64");
+  let i = 2;
+  while (i < buf.length - 9) {
+    if (buf[i] !== 0xff) { i++; continue; }
+    const marker = buf[i + 1];
+    if (marker >= 0xc0 && marker <= 0xcf && ![0xc4, 0xc8, 0xcc].includes(marker)) {
+      return { height: buf.readUInt16BE(i + 5), width: buf.readUInt16BE(i + 7) };
+    }
+    i += 2 + buf.readUInt16BE(i + 2);
+  }
+  return null;
+}
+
+// ── the session-side resize (window bounds + chrome compensation) ────────────
+
+async function resizeWindowOnce(ctx, page, width, height) {
+  const cdp = await ctx.newCDPSession(page);
+  try {
+    const { windowId } = await cdp.send("Browser.getWindowForTarget");
+    await cdp.send("Browser.setWindowBounds", { windowId, bounds: { windowState: "normal" } }).catch(() => {});
+    await cdp.send("Browser.setWindowBounds", { windowId, bounds: { width, height } });
+  } finally {
+    await cdp.detach().catch(() => {});
+  }
+  await sleep(250);
+  return page.evaluate(() => ({ width: window.innerWidth, height: window.innerHeight })).catch(() => null);
+}
+
+async function resizeToViewport(ctx, state, width, height) {
+  const page = state.current;
+  if (!page || page.isClosed?.()) return null;
+  const first = await resizeWindowOnce(ctx, page, width, height);
+  const second = chromeCompensatedBounds({ width, height }, first);
+  if (!second) return first;
+  return (await resizeWindowOnce(ctx, page, second.width, second.height)) ?? first;
+}
+
+// ── minimal WS client (masked frames, RFC 6455) ──────────────────────────────
+
+function maskedTextFrame(payload) {
+  const data = Buffer.from(payload, "utf8");
+  const mask = crypto.randomBytes(4);
+  const masked = Buffer.from(data);
+  for (let i = 0; i < masked.length; i++) masked[i] ^= mask[i & 3];
+  let header;
+  if (data.length < 126) header = Buffer.from([0x81, 0x80 | data.length]);
+  else {
+    header = Buffer.alloc(4);
+    header[0] = 0x81;
+    header[1] = 0x80 | 126;
+    header.writeUInt16BE(data.length, 2);
+  }
+  return Buffer.concat([header, mask, masked]);
+}
+
+async function connectStream(port, token) {
+  const sock = net.connect(port, "127.0.0.1");
+  await once(sock, "connect");
+  const key = crypto.randomBytes(16).toString("base64");
+  sock.write(
+    `GET /?token=${token} HTTP/1.1\r\nHost: t\r\nUpgrade: websocket\r\n` +
+      `Connection: Upgrade\r\nSec-WebSocket-Key: ${key}\r\nSec-WebSocket-Version: 13\r\n\r\n`,
+  );
+  const queue = [];
+  const waiters = [];
+  const parse = makeFrameParser((m) => {
+    const w = waiters.shift();
+    if (w) w(m);
+    else queue.push(m);
+  });
+  let head = Buffer.alloc(0);
+  let upgraded = false;
+  await new Promise((resolve, reject) => {
+    sock.on("data", (d) => {
+      if (upgraded) return parse(d);
+      head = Buffer.concat([head, d]);
+      const end = head.indexOf("\r\n\r\n");
+      if (end < 0) return;
+      upgraded = true;
+      resolve();
+      parse(head.subarray(end + 4));
+    });
+    sock.on("error", reject);
+  });
+  return {
+    send: (obj) => sock.write(maskedTextFrame(JSON.stringify(obj))),
+    async next(timeoutMs = 5000) {
+      if (queue.length) return JSON.parse(queue.shift().payload.toString("utf8"));
+      const frame = await new Promise((resolve, reject) => {
+        const t = setTimeout(() => reject(new Error("timed out waiting for a ws message")), timeoutMs);
+        waiters.push((m) => { clearTimeout(t); resolve(m); });
+      });
+      return JSON.parse(frame.payload.toString("utf8"));
+    },
+    async nextStatus(timeoutMs = 10000) {
+      const deadline = Date.now() + timeoutMs;
+      for (;;) {
+        const msg = await this.next(Math.max(100, deadline - Date.now()));
+        if (msg.type === "status") return msg;
+      }
+    },
+    close: () => sock.destroy(),
+  };
+}
+
+// Collect delivered frames until `want` of them match the expected dims (or
+// timeout). Returns every frame seen, tagged with its decoded dimensions.
+async function collectFrames(client, { want, dims, timeoutMs = 15000 }) {
+  const frames = [];
+  const matches = () => frames.filter((f) => f.dims && f.dims.width === dims.width && f.dims.height === dims.height);
+  const deadline = Date.now() + timeoutMs;
+  while (matches().length < want && Date.now() < deadline) {
+    let msg;
+    try {
+      msg = await client.next(Math.max(100, deadline - Date.now()));
+    } catch {
+      break;
+    }
+    if (msg.type !== "frame") continue;
+    frames.push({ refinement: !!msg.refinement, metadata: msg.metadata, dims: jpegDims(msg.data) });
+  }
+  return frames;
+}
+
+// Frames may straddle a mode switch (a staged pre-switch frame can flush
+// late). The invariant is: once the first frame at the NEW dimensions
+// arrives, every later frame has exactly those dimensions.
+function assertStableAfterSwitch(frames, dims, label) {
+  const at = frames.findIndex((f) => f.dims && f.dims.width === dims.width && f.dims.height === dims.height);
+  const seen = frames.map((f) => (f.dims ? `${f.dims.width}x${f.dims.height}` : "?")).join(",");
+  assert.ok(at >= 0, `${label}: at least one ${dims.width}×${dims.height} frame arrived (saw: ${seen || "none"})`);
+  for (const f of frames.slice(at)) {
+    assert.deepEqual(
+      { width: f.dims.width, height: f.dims.height },
+      dims,
+      `${label}: no dimension flips after the switch (motion and refinement identical)`,
+    );
+  }
+}
+
+test(
+  "scaled stream against real Chrome: delivered pixels, override lifecycle, remeasured viewport",
+  { skip: patchrightAvailable ? false : "patchright/Chrome not installed" },
+  async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "stream-scale-live-"));
+    let ctx = null;
+    let stream = null;
+    let client = null;
+    try {
+      ctx = await launchContext({ profileDir: dir, headless: true });
+      const pageA = ctx.pages()[0] || (await ctx.newPage());
+      await pageA.goto(ANIMATED);
+      const state = { current: pageA, ctx, invalidateRefs() {} };
+      stream = await startStreamServer(state, {
+        log: () => {},
+        resize: (w, h) => resizeToViewport(ctx, state, w, h),
+      });
+      client = await connectStream(stream.port, stream.token);
+      await client.next(); // greeting
+
+      // ── scale 2: the delivered stream is viewport × 2, with no flips ──────
+      client.send({ type: "resize", width: 390, height: 844, scale: 2 });
+      let status;
+      for (;;) {
+        status = await client.nextStatus();
+        if (status.resized) break;
+      }
+      assert.deepEqual(status.resized, { width: 390, height: 844, scale: 2 });
+      // The broadcast is the page's POST-override truth. The window cannot
+      // shrink to 390 css px (Chrome's minimum window width is wider), so a
+      // pre-override measurement would report ~500×844 — only the override
+      // pins the viewport to the request. This assert fails without the
+      // remeasure.
+      assert.deepEqual(status.viewport, { width: 390, height: 844 });
+      assert.equal(await pageA.evaluate(() => devicePixelRatio), 2, "the override is live on the page");
+
+      const scaled = { width: 780, height: 1688 };
+      const motion = await collectFrames(client, { want: 4, dims: scaled });
+      assertStableAfterSwitch(motion, scaled, "scale-2 motion");
+      const anyScaled = motion.find((f) => f.dims && f.dims.width === scaled.width);
+      assert.equal(anyScaled.metadata.deviceWidth, 390, "metadata stays CSS px");
+      assert.equal(anyScaled.metadata.deviceHeight, 844, "metadata stays CSS px");
+
+      // Quiet page → the refinement path must produce the SAME dimensions.
+      await pageA.goto(STATIC);
+      const refined = await collectFrames(client, { want: 1, dims: scaled, timeoutMs: 10000 }).then(
+        async (frames) => {
+          // keep collecting until a refinement-flagged frame shows up
+          const deadline = Date.now() + 10000;
+          while (!frames.some((f) => f.refinement) && Date.now() < deadline) {
+            frames.push(...(await collectFrames(client, { want: 1, dims: scaled, timeoutMs: 2000 })));
+          }
+          return frames;
+        },
+      );
+      const refinement = refined.find((f) => f.refinement);
+      assert.ok(refinement, "a refinement frame arrived on the quiet page");
+      assert.deepEqual(refinement.dims, scaled, "refinement pixels match motion pixels exactly");
+
+      // ── tab switch: the override follows the cast to the new tab ─────────
+      const pageB = await ctx.newPage();
+      await pageB.goto(ANIMATED);
+      state.current = pageB;
+      // The retarget poll flips the cast on its own clock (~500ms) — wait for
+      // the override to land on the new tab before asserting around it.
+      let dprB = 1;
+      const retargetDeadline = Date.now() + 5000;
+      while (dprB !== 2 && Date.now() < retargetDeadline) {
+        await sleep(100);
+        dprB = await pageB.evaluate(() => devicePixelRatio);
+      }
+      assert.equal(dprB, 2, "the new tab gets the override");
+      assert.equal(await pageA.evaluate(() => devicePixelRatio), 1, "the old tab reverts (override died with its session)");
+      const afterSwitch = await collectFrames(client, { want: 3, dims: scaled });
+      assertStableAfterSwitch(afterSwitch, scaled, "post-retarget");
+
+      // ── back to 1×: override gone, delivered pixels match the viewport ───
+      client.send({ type: "resize", width: 390, height: 844 });
+      for (;;) {
+        status = await client.nextStatus();
+        if (status.resized) break;
+      }
+      assert.equal(status.resized.scale, 1);
+      assert.ok(status.viewport, "the 1× resize still reports a viewport");
+      assert.equal(await pageB.evaluate(() => devicePixelRatio), 1, "1× drops the override");
+      const flat = { width: status.viewport.width, height: status.viewport.height };
+      assert.notDeepEqual(flat, scaled, "the 1× viewport is not the scaled pixel size");
+      const flatFrames = await collectFrames(client, { want: 2, dims: flat });
+      assertStableAfterSwitch(flatFrames, flat, "back-to-1x");
+    } finally {
+      client?.close();
+      stream?.close();
+      if (ctx) await ctx.close().catch(() => {});
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    }
+  },
+);

--- a/tests/test-browser-stream-scale-live.mjs
+++ b/tests/test-browser-stream-scale-live.mjs
@@ -26,8 +26,13 @@ import fs from "node:fs/promises";
 import { once } from "node:events";
 
 import { resolvePatchright, launchContext } from "../plugins/agent-id-browser/lib/launch.mjs";
-import { startStreamServer, makeFrameParser } from "../plugins/agent-id-browser/lib/stream-server.mjs";
+import {
+  startStreamServer,
+  makeFrameParser,
+  decodeFrameBinary,
+} from "../plugins/agent-id-browser/lib/stream-server.mjs";
 import { chromeCompensatedBounds } from "../plugins/agent-id-browser/lib/session-server.mjs";
+import { detectH264Encoder } from "../plugins/agent-id-browser/lib/stream-encoder.mjs";
 
 const patchrightAvailable = !!resolvePatchright();
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
@@ -101,12 +106,12 @@ function maskedTextFrame(payload) {
   return Buffer.concat([header, mask, masked]);
 }
 
-async function connectStream(port, token) {
+async function connectStream(port, token, params = "") {
   const sock = net.connect(port, "127.0.0.1");
   await once(sock, "connect");
   const key = crypto.randomBytes(16).toString("base64");
   sock.write(
-    `GET /?token=${token} HTTP/1.1\r\nHost: t\r\nUpgrade: websocket\r\n` +
+    `GET /?token=${token}${params} HTTP/1.1\r\nHost: t\r\nUpgrade: websocket\r\n` +
       `Connection: Upgrade\r\nSec-WebSocket-Key: ${key}\r\nSec-WebSocket-Version: 13\r\n\r\n`,
   );
   const queue = [];
@@ -132,12 +137,15 @@ async function connectStream(port, token) {
   });
   return {
     send: (obj) => sock.write(maskedTextFrame(JSON.stringify(obj))),
-    async next(timeoutMs = 5000) {
-      if (queue.length) return JSON.parse(queue.shift().payload.toString("utf8"));
-      const frame = await new Promise((resolve, reject) => {
+    async nextRaw(timeoutMs = 5000) {
+      if (queue.length) return queue.shift();
+      return new Promise((resolve, reject) => {
         const t = setTimeout(() => reject(new Error("timed out waiting for a ws message")), timeoutMs);
         waiters.push((m) => { clearTimeout(t); resolve(m); });
       });
+    },
+    async next(timeoutMs = 5000) {
+      const frame = await this.nextRaw(timeoutMs);
       return JSON.parse(frame.payload.toString("utf8"));
     },
     async nextStatus(timeoutMs = 10000) {
@@ -199,9 +207,13 @@ test(
       const pageA = ctx.pages()[0] || (await ctx.newPage());
       await pageA.goto(ANIMATED);
       const state = { current: pageA, ctx, invalidateRefs() {} };
+      // h264 is offered when this machine has a usable encoder, so the
+      // binary-envelope delivery path can be pinned at scale too.
+      const encoder = await detectH264Encoder();
       stream = await startStreamServer(state, {
         log: () => {},
         resize: (w, h) => resizeToViewport(ctx, state, w, h),
+        ...(encoder ? { h264Config: { ffmpegPath: process.env.AGENT_ID_FFMPEG || null, encoder } } : {}),
       });
       client = await connectStream(stream.port, stream.token);
       await client.next(); // greeting
@@ -244,6 +256,32 @@ test(
       const motion = await collectFrames(client, { want: 4, dims: scaled });
       assertStableAfterSwitch(motion, scaled, "scale-2 motion");
       cssOf(motion, scaled);
+
+      // ── h264 delivery at scale: every binary envelope carries CSS px ─────
+      // The h264 path builds its own frame envelopes; a probe caught it
+      // shipping device-pixel metadata (780×1688) on every chunk while the
+      // jpeg path was already normalized. Self-skips with no encoder.
+      if (encoder) {
+        const h264 = await connectStream(stream.port, stream.token, "&codec=h264");
+        let h264Frames = 0;
+        const h264Deadline = Date.now() + 15000;
+        while (h264Frames < 10 && Date.now() < h264Deadline) {
+          let m;
+          try {
+            m = await h264.nextRaw(Math.max(100, h264Deadline - Date.now()));
+          } catch {
+            break;
+          }
+          if (m.opcode !== 0x2) continue; // join/status text frames
+          const { header } = decodeFrameBinary(m.payload);
+          if (header.codec !== "h264") continue;
+          assert.equal(header.metadata.deviceWidth, 390, "h264 envelope metadata is CSS width");
+          assert.equal(header.metadata.deviceHeight, 844, "h264 envelope metadata is CSS height");
+          h264Frames++;
+        }
+        assert.ok(h264Frames >= 10, `h264 chunks flowed at scale (got ${h264Frames})`);
+        h264.close();
+      }
 
       // Quiet page → the refinement path must produce the SAME dimensions.
       await pageA.goto(STATIC);

--- a/tests/test-browser-stream.mjs
+++ b/tests/test-browser-stream.mjs
@@ -902,8 +902,11 @@ test("a scale change respawns the encoder with SPS/PPS/IDR at the scaled dimensi
   const path = await import("node:path");
   const fsSync = await import("node:fs");
   const dir = fsSync.mkdtempSync(path.join(os.tmpdir(), "stream-scale-"));
-  // The same nominal viewport at 1× (320×240) and at a viewer-requested 2×
-  // (640×480) — the dimension flip a HiDPI resize causes on the wire.
+  // The same nominal viewport at 1× (320×240 screencast frames) and at a
+  // viewer-requested 2× (640×480 device-pixel captures) — the dimension flip
+  // a HiDPI resize causes on the wire. In scaled mode the delivered frames
+  // come from captureScreenshot (the cast is only the damage tick), so the
+  // 2× pixels ride the screenshot fake.
   for (const size of ["320x240", "640x480"]) {
     execFileSync(process.env.AGENT_ID_FFMPEG || "ffmpeg", [
       "-hide_banner", "-loglevel", "error",
@@ -916,18 +919,20 @@ test("a scale change respawns the encoder with SPS/PPS/IDR at the scaled dimensi
   const small = framesAt("320x240");
   const big = framesAt("640x480");
 
-  const { state, server } = await startServer({
-    // The stream server owns the scale bookkeeping under test; the session
-    // side (device-metrics override) has its own fake-CDP coverage.
-    resize: async (w, h) => ({ width: w, height: h }),
-  });
+  const { state, server } = await startServer(
+    {
+      // The stream server owns all the scale bookkeeping under test; the
+      // override lifecycle has its own fake-CDP coverage.
+      resize: async (w, h) => ({ width: w, height: h }),
+    },
+    { screenshot: big[0] },
+  );
   const c = await connectStream(server.port, server.token, "&codec=h264");
   await c.nextJson(); // status (codec h264)
   await sleep(150); // screencast + encoder spawn settle
-  let feed = small;
   let n = 0;
   const feeder = setInterval(() => {
-    state.session.emitFrame(feed[n++ % feed.length]);
+    state.session.emitFrame(small[n++ % small.length]);
   }, 50);
   try {
     // Phase 1: the 1× stream flows.
@@ -941,8 +946,9 @@ test("a scale change respawns the encoder with SPS/PPS/IDR at the scaled dimensi
     }
     assert.ok(bytes >= 500, `1× h264 flowed before the resize (got ${bytes} bytes)`);
 
-    // Phase 2: the viewer asks for the HiDPI stream; the source flips to
-    // device-pixel frames. Everything after the `resized` broadcast must
+    // Phase 2: the viewer asks for the HiDPI stream; the delivered source
+    // flips to device-pixel captures (the cast keeps ticking at CSS size as
+    // the damage detector). Everything after the `resized` broadcast must
     // decode from scratch: fresh SPS/PPS + IDR, and the fresh SPS must code
     // the SCALED dimensions.
     c.sendJson({ type: "resize", width: 320, height: 240, scale: 2 });
@@ -957,7 +963,6 @@ test("a scale change respawns the encoder with SPS/PPS/IDR at the scaled dimensi
         if (msg.resized) {
           assert.equal(msg.resized.scale, 2);
           resized = true;
-          feed = big; // the page now renders 2× device pixels
         }
         continue;
       }

--- a/tests/test-browser-stream.mjs
+++ b/tests/test-browser-stream.mjs
@@ -821,3 +821,168 @@ test("a joining h264 viewer always restarts the screencast and encoder", async (
   server.close();
   fsSync.rmSync(dir, { recursive: true, force: true });
 });
+
+// Frame dimensions coded in an H.264 SPS (Annex-B, baseline/constrained-
+// baseline as our encoder emits). Minimal exp-Golomb walk — enough to prove
+// what resolution the encoder was (re)configured for.
+function spsDimensions(nal) {
+  const rbsp = [];
+  for (let i = 1; i < nal.length; i++) {
+    // Strip emulation-prevention bytes (00 00 03 xx → 00 00 xx).
+    if (nal[i] === 3 && nal[i - 1] === 0 && nal[i - 2] === 0) continue;
+    rbsp.push(nal[i]);
+  }
+  let bit = 0;
+  const u = (n) => {
+    let v = 0;
+    for (; n > 0; n--) v = (v << 1) | ((rbsp[bit >> 3] >> (7 - (bit & 7))) & 1), bit++;
+    return v;
+  };
+  const ue = () => {
+    let zeros = 0;
+    while (u(1) === 0) zeros++;
+    return (1 << zeros) - 1 + (zeros ? u(zeros) : 0);
+  };
+  const se = () => {
+    const k = ue();
+    return k & 1 ? (k + 1) / 2 : -(k / 2);
+  };
+  const profile = u(8);
+  u(16); // constraint flags + reserved + level
+  ue(); // sps id
+  if ([100, 110, 122, 244, 44, 83, 86, 118, 128, 138, 139, 134, 135].includes(profile)) {
+    throw new Error("high-profile SPS unexpected from the baseline encoder");
+  }
+  ue(); // log2_max_frame_num_minus4
+  const poc = ue();
+  if (poc === 0) ue();
+  else if (poc === 1) {
+    u(1);
+    se();
+    se();
+    const n = ue();
+    for (let i = 0; i < n; i++) se();
+  }
+  ue(); // max_num_ref_frames
+  u(1); // gaps_in_frame_num_value_allowed
+  const widthMbs = ue() + 1;
+  const heightMapUnits = ue() + 1;
+  const frameMbsOnly = u(1);
+  if (!frameMbsOnly) u(1);
+  u(1); // direct_8x8_inference
+  let width = widthMbs * 16;
+  let height = (2 - frameMbsOnly) * heightMapUnits * 16;
+  if (u(1)) {
+    // frame_cropping (4:2:0 crop units: 2px horizontal, 2px·(2-fmo) vertical)
+    const [l, r, t, b] = [ue(), ue(), ue(), ue()];
+    width -= (l + r) * 2;
+    height -= (t + b) * 2 * (2 - frameMbsOnly);
+  }
+  return { width, height };
+}
+
+// NAL payloads in stream order (start-code scan, 3- and 4-byte, deduped).
+function nalPayloads(stream) {
+  const starts = [];
+  for (let i = 0; i + 3 < stream.length; i++) {
+    if (stream[i] !== 0 || stream[i + 1] !== 0) continue;
+    let s = null;
+    if (stream[i + 2] === 1) s = i + 3;
+    else if (stream[i + 2] === 0 && stream[i + 3] === 1) s = i + 4;
+    if (s !== null && starts[starts.length - 1] !== s) starts.push(s);
+  }
+  return starts.map((s, k) => stream.subarray(s, k + 1 < starts.length ? starts[k + 1] - 3 : stream.length));
+}
+
+test("a scale change respawns the encoder with SPS/PPS/IDR at the scaled dimensions", async (t) => {
+  const { detectH264Encoder } = await import("../plugins/agent-id-browser/lib/stream-encoder.mjs");
+  if (!(await detectH264Encoder())) return t.skip("no ffmpeg h264 encoder on this machine");
+  const { execFileSync } = await import("node:child_process");
+  const os = await import("node:os");
+  const path = await import("node:path");
+  const fsSync = await import("node:fs");
+  const dir = fsSync.mkdtempSync(path.join(os.tmpdir(), "stream-scale-"));
+  // The same nominal viewport at 1× (320×240) and at a viewer-requested 2×
+  // (640×480) — the dimension flip a HiDPI resize causes on the wire.
+  for (const size of ["320x240", "640x480"]) {
+    execFileSync(process.env.AGENT_ID_FFMPEG || "ffmpeg", [
+      "-hide_banner", "-loglevel", "error",
+      "-f", "lavfi", "-i", `testsrc=size=${size}:rate=10`,
+      "-frames:v", "10", "-q:v", "5", path.join(dir, `${size}-f%02d.jpg`),
+    ]);
+  }
+  const framesAt = (size) => fsSync.readdirSync(dir).filter((f) => f.startsWith(`${size}-`)).sort()
+    .map((f) => fsSync.readFileSync(path.join(dir, f)).toString("base64"));
+  const small = framesAt("320x240");
+  const big = framesAt("640x480");
+
+  const { state, server } = await startServer({
+    // The stream server owns the scale bookkeeping under test; the session
+    // side (device-metrics override) has its own fake-CDP coverage.
+    resize: async (w, h) => ({ width: w, height: h }),
+  });
+  const c = await connectStream(server.port, server.token, "&codec=h264");
+  await c.nextJson(); // status (codec h264)
+  await sleep(150); // screencast + encoder spawn settle
+  let feed = small;
+  let n = 0;
+  const feeder = setInterval(() => {
+    state.session.emitFrame(feed[n++ % feed.length]);
+  }, 50);
+  try {
+    // Phase 1: the 1× stream flows.
+    let bytes = 0;
+    const warmup = Date.now() + 8000;
+    while (Date.now() < warmup && bytes < 500) {
+      const m = await c.next(3000);
+      if (m.opcode !== 0x2) continue;
+      const { header, payload } = decodeFrameBinary(m.payload);
+      if (header.codec === "h264") bytes += payload.length;
+    }
+    assert.ok(bytes >= 500, `1× h264 flowed before the resize (got ${bytes} bytes)`);
+
+    // Phase 2: the viewer asks for the HiDPI stream; the source flips to
+    // device-pixel frames. Everything after the `resized` broadcast must
+    // decode from scratch: fresh SPS/PPS + IDR, and the fresh SPS must code
+    // the SCALED dimensions.
+    c.sendJson({ type: "resize", width: 320, height: 240, scale: 2 });
+    let resized = false;
+    const post = [];
+    let dims = null;
+    const deadline = Date.now() + 10000;
+    while (Date.now() < deadline && !dims) {
+      const m = await c.next(3000);
+      if (m.opcode === 0x1) {
+        const msg = JSON.parse(m.payload.toString("utf8"));
+        if (msg.resized) {
+          assert.equal(msg.resized.scale, 2);
+          resized = true;
+          feed = big; // the page now renders 2× device pixels
+        }
+        continue;
+      }
+      if (m.opcode !== 0x2 || !resized) continue;
+      const { header, payload } = decodeFrameBinary(m.payload);
+      if (header.codec !== "h264") continue;
+      post.push(payload);
+      const stream = Buffer.concat(post);
+      const nals = nalPayloads(stream);
+      const sps = nals.find((nl) => (nl[0] & 0x1f) === 7);
+      if (!sps) continue;
+      // Decoder-priming order across the respawn, like on a join.
+      const order = nalTypesInOrder(stream);
+      const firstSlice = order.find((x) => x === 1 || x === 5);
+      assert.equal(firstSlice, 5, `post-resize stream leads with an IDR (got ${order.join(",")})`);
+      assert.ok(order.indexOf(7) < order.indexOf(5), "SPS precedes the IDR");
+      assert.ok(order.indexOf(8) < order.indexOf(5), "PPS precedes the IDR");
+      dims = spsDimensions(sps);
+    }
+    assert.ok(dims, "a fresh SPS arrived after the scaled resize");
+    assert.deepEqual(dims, { width: 640, height: 480 }, "the fresh SPS codes viewport × scale");
+  } finally {
+    clearInterval(feeder);
+  }
+  c.close();
+  server.close();
+  fsSync.rmSync(dir, { recursive: true, force: true });
+});

--- a/tests/test-browser-stream.mjs
+++ b/tests/test-browser-stream.mjs
@@ -969,6 +969,12 @@ test("a scale change respawns the encoder with SPS/PPS/IDR at the scaled dimensi
       if (m.opcode !== 0x2 || !resized) continue;
       const { header, payload } = decodeFrameBinary(m.payload);
       if (header.codec !== "h264") continue;
+      // EVERY post-resize h264 envelope must carry CSS geometry: the fake
+      // cast reports 640×480 (device-pixel-shaped) metadata, and the h264
+      // envelope builder used to pass it through raw — doubling scaled
+      // viewers' tap coordinates.
+      assert.equal(header.metadata.deviceWidth, 320, "h264 envelope metadata is CSS width");
+      assert.equal(header.metadata.deviceHeight, 240, "h264 envelope metadata is CSS height");
       post.push(payload);
       const stream = Buffer.concat(post);
       const nals = nalPayloads(stream);


### PR DESCRIPTION
## What

A phone watching the pair-browsing stream on a retina display gets a soft picture today: capture is clamped to CSS-viewport pixels, so a 390×844 stream is upscaled ~3× by the panel. This adds the smallest possible knob to fix that — an optional `scale` on the existing `resize` message:

```jsonc
{ "type": "resize", "width": 390, "height": 844, "scale": 2 }
```

`scale` is rounded to the nearest integer and clamped **1–3**; missing/garbage means 1, and clients that only ever send width/height keep their exact current behavior (pinned by test: zero Emulation traffic, no cast restart).

## How scaled capture works — measured against real Chrome, not assumed

Review probes of the first revision showed the obvious design doesn't work, so this one is built on delivered-pixel measurements (headless Chrome, viewport 390×844):

| Measurement | Result |
|---|---|
| Screencast frames under a `deviceScaleFactor: 2` override | **390×844 — the cast never delivers above 1×** (`maxWidth/maxHeight` are caps, not upsampling) |
| `captureScreenshot`, `clip.scale: 1`, under the same override | **780×1688** (device pixels; no-clip identical) |
| `captureScreenshot`, `clip.scale: 2`, under the override | 1560×3376 — multiplying by the scale again double-scales |
| One 2× phone-viewport capture | **~20 ms** |
| Override after its CDP session detaches | **reverts** — an override applied on a short-lived session never sticks |
| New tab while another tab holds an override | DPR 1 — overrides are per-target |
| Fractional `maxWidth` (586.5) | protocol error, **cast stops** |
| `innerWidth/Height` before vs after the override | 500×844 vs 390×844 (the window cannot shrink to the request; only the override pins it) |

The landed design therefore:

- holds `Emulation.setDeviceMetricsOverride({width, height, deviceScaleFactor: scale, mobile: false})` on the **long-lived cast CDP session** — the override lives exactly as long as the capture, so tab retargeting applies it to the new tab and the old tab reverts automatically; `mobile: false` is deliberate (no touch, no mobile UA — the only page-visible change is `devicePixelRatio`);
- keeps the screencast running as a **damage detector only** at scale (its 1× frames are never delivered) and serves coalesced `captureScreenshot` motion frames — the **same capture call refinement uses**, so motion and refinement pixel dimensions are identical by construction (the encoder invariant). At ~20 ms per capture, scaled motion tops out around 30–50 fps and idle cost is unchanged (damage-driven);
- enforces budgets after multiplication: no scaled axis over 4096 device px, total at most one 4K frame (3840×2160); over-budget requests are served at the largest scale that fits;
- coerces every CDP pixel field to integers;
- re-measures the viewport **after** the override lands and broadcasts that in the `resized` status (the pre-override measurement is the window-clamped size);
- gates cast (re)starts while a resize is reshaping the window: a stale override applied mid-resize also resizes the headless platform window in a way its later removal does not undo (measured — the delivered stream degraded to 555×1200 letterboxed frames without the gate).

Deliberately **not** added: a context-level `deviceScaleFactor` (breaks the `viewport: null` launch design) and any launch-level `--force-device-scale-factor` (delivers 2× casts, but is fixed at launch — not per-viewer).

## Design question for the plugin owners

A scaled session exposes `devicePixelRatio = 2` (or 3) on a desktop-UA page. That is the most common desktop-retina configuration in the wild, and it only happens while a viewer explicitly asks — a session nobody watches (or watched at 1×) never sees an Emulation call, and the override drops when the viewer leaves scale. Still: **should any stealth-sensitive flow get a per-session opt-out** (e.g. a session flag that ignores `scale`), or is viewer-initiated DPR acceptable everywhere? One related page-visible side effect worth knowing: while scaled, the override pins the viewport to the requested size, and in headless the platform window follows it.

## Tests

- **Real Chrome (self-skipping, like the live UA tests)** — `tests/test-browser-stream-scale-live.mjs`: launches actual Chromium and asserts **delivered** pixel dimensions: at scale 2 every delivered frame (motion and refinement alike) is exactly 780×1688 with no dimension flips; `metadata` stays CSS (390×844); the broadcast viewport is the post-override truth (390×844, where the pre-override measurement reads 500×844); a tab switch moves the override (new tab DPR 2, old tab reverts to 1); returning to 1× drops the override and the delivered frames match the reported viewport again.
- **Fake-CDP** — `tests/test-browser-stream-resize.mjs`: override params (`mobile: false`) and ordering (before the cast starts), capture-sourced delivery (cast payloads never delivered at scale), `clip.scale` pinned to 1, integer caps, rounding + axis/pixel budgets, zero Emulation traffic and no cast restart for two-field resizes, retarget override lifecycle.
- **Real ffmpeg** — a scale change respawns the encoder and the fresh SPS codes the scaled dimensions (SPS exp-Golomb parse, 320×240 → 640×480), SPS/PPS before the first IDR.
- Full suite: **745 pass / 0 fail / 0 skipped** (real-encoder and real-Chrome tests ran). Mutation-checked: removing the override, re-adding the clip.scale multiplication, delivering cast frames at scale, dropping the budgets, or dropping the remeasure each turns dedicated tests red.


## Re-review round 2 — four findings, all measured and fixed

1. **Scaled metadata alternated 780×1688 / 390×844** — Chrome briefly reports the transitional surface size in cast metadata while an override settles; one device-pixel metadata frame doubles tap coordinates. Every scaled frame (motion *and* refinement) now carries metadata **normalized to the session's CSS geometry** (the override pins it authoritatively). The live test asserts CSS metadata on **all** delivered frames and is deterministic standalone (5× consecutive green).
2. **Over-budget requests broke the dimension invariant** (measured: 1253×1200 motion alternating with 2040×1953 refinement after `2040×2040 scale:2` fell back to scale 1). Two fixes: (a) completed budget policy in `budgetedResize` — axis clamps, then scale drops first (layout beats density), then the **base viewport shrinks proportionally** when it alone exceeds the 4K pixel budget (4096×4096 → 2880×2880); `resized` always broadcasts the achieved geometry. (b) The real cause of the divergence was the legacy fixed 1600×1200 cast caps silently downscaling big viewports out of agreement with refinement — caps now follow the **measured viewport**, and a resize beyond the running caps re-caps the cast. Live test covers the over-budget case end to end: all frames identical, equal to the broadcast viewport, CSS metadata.
3. **Concurrent joins raced `startScreencast`** (a delayed-attach probe left three live CDP sessions, each keeping overrides and captures alive). Start/stop now serialize behind one promise chain with an **epoch stamp**; an attach that loses its epoch (close/retarget/newer start) is detached and never installed. Fake-CDP race tests: overlapping joins settle to exactly one live session; a mid-attach tab flip discards the stale session before it ever casts.
4. **A stale in-flight capture could strand the new session's first damage tick** behind the global busy flag — the dirty flag is now re-dispatched to the live session when a capture exits having lost the cast.

**New measurement made while verifying:** an override whose session merely detaches leaves a dormant registration that **re-pins the viewport to the stale size on every later navigation** (a 2040×2040 window snapped back to 390×844 on `goto`, indefinitely). Stopping the cast now sends an explicit `Emulation.clearDeviceMetricsOverride` first — never-scaled sessions still see zero Emulation traffic.

Suite: **750 pass / 0 fail / 0 skipped**; live real-Chrome test stable standalone 5×. Mutation-checked: metadata normalization, base-viewport clamp, and epoch discard each turn dedicated tests red.


## Round 3 — h264 envelope metadata

`sendH264Chunk` builds its own binary envelope and was still stamping raw cast metadata — a Chrome+ffmpeg probe delivered 45/45 h264 frames reporting 780×1688 for a 390×844 CSS viewport. The envelope now applies the same authoritative CSS normalization as the jpeg path, and both delivery rails are pinned at scale: the real-ffmpeg scaled test asserts CSS metadata on every delivered h264 frame, and the real-Chrome live test gained an h264 phase (10+ binary chunks at scale 2, every envelope asserting 390×844 CSS). Mutation gate: reverting the envelope normalization turns both tests red. Suite 750/750, live test standalone-stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


