### PR TITLE
docs(browser): changeset for the HiDPI capture scale

### DIFF
--- a/.changeset/stream-hidpi-scale.md
+++ b/.changeset/stream-hidpi-scale.md
@@ -1,0 +1,24 @@
+---
+"@alien-id/agent-id-browser": minor
+---
+
+The viewport stream's `resize` message takes an optional `scale` (1–3, default
+1), so a viewer on a high-density screen can ask for a HiDPI capture instead of
+a 1× stream upscaled on the device. A scaled session applies
+`Emulation.setDeviceMetricsOverride` with that `deviceScaleFactor` (`mobile:
+false` — no touch capability, no mobile UA), and the capture path switches from
+screencast to coalesced `captureScreenshot` calls: the screencast's `maxWidth`/
+`maxHeight` are caps, not upsampling requests, so it can never deliver more than
+1×, while a screenshot under the override already does. Motion and refinement
+frames therefore come from the same call and are dimension-identical by
+construction, which the encoder requires — a dimension flip between them
+respawns it. Frame metadata stays CSS pixels at every scale, so viewer input
+mapping is unchanged.
+
+The override rides the long-lived capture session (overrides die with the
+session that set them) and is re-applied per target on retarget, so a new tab
+inherits the scale and the old one reverts. Scale is clamped, rounded to an
+integer at every CDP boundary, and budgeted against per-axis and total-pixel
+limits — an over-budget request is served at the largest scale that fits, and
+the achieved geometry is broadcast in the `resized` status. Omitting `scale`, or
+sending it to a build without support, behaves exactly as before.


### PR DESCRIPTION
The optional `scale` on the viewport stream's `resize` message (#108) merged without a changeset, so it is currently queued to reach npm in 7.12.0 with no changelog entry — the capability would ship discoverable only by reading the diff.

This adds the missing changeset (minor, matching the feature's shape). Opening it now, before the pending Version PR is merged, so the entry lands in the release the code actually ships in rather than a later one.

No code change; `bun run ci:detect` still reports `hasChangesets=true shouldPublish=false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)