### PR TITLE
fix(browser): number stream seq per codec so viewers stop seeing phantom frame loss

### DIFF
--- a/.changeset/stream-per-codec-seq.md
+++ b/.changeset/stream-per-codec-seq.md
@@ -1,0 +1,14 @@
+---
+"@alien-id/agent-id-browser": patch
+---
+
+Viewport stream: number `seq` per codec. The stream server drew every message
+from a single counter, so a JPEG frame delivery (which happens for each
+screencast frame whether or not a JPEG viewer is attached, and again for the
+idle refinement pass) consumed sequence numbers out of the H.264 stream. An
+H.264 viewer therefore saw its sequence advance in steps of two or three,
+read that as dropped frames, waited for a keyframe that was never missing,
+and redialed — a relay that reconnected every few seconds on an otherwise
+healthy stream. Each codec now has its own counter, so a viewer's sequence is
+contiguous and a real gap once again means real loss. No wire-format or
+client change: `seq` is still a monotonically increasing per-message ordinal.

--- a/plugins/agent-id-browser/lib/stream-server.mjs
+++ b/plugins/agent-id-browser/lib/stream-server.mjs
@@ -31,6 +31,8 @@
 //                     {"type":"resize","width":W,"height":H[,"scale":S]}
 //                     {"type":"webrtc_offer"|"webrtc_ice", ...}  (experimental)
 //
+// `seq` counts per codec, so each viewer sees its own stream contiguous.
+//
 // Delivery is latest-frame-wins: each JPEG client has ONE pending slot that
 // newer frames overwrite whenever the client is slower than the feed (socket
 // backpressure, outstanding ack, fps cap), so a viewer always resumes at live
@@ -374,7 +376,12 @@ export async function startStreamServer(
   let cdpPage = null;
   let suspended = 0; // depth-counted: nested fills keep it suspended
   let closed = false;
+  // Per-codec sequences: a client consumes exactly one codec, and each
+  // codec's subscribers must see their own stream contiguous. A shared
+  // counter made every jpeg delivery punch a hole in the h264 sequence,
+  // which viewers read as frame loss.
   let frameSeq = 0;
+  let h264Seq = 0;
   let lastFrameAt = 0;
   let lastMetadata = null;
   let refined = true; // no refinement until at least one screencast frame
@@ -608,7 +615,7 @@ export async function startStreamServer(
         encodeFrameBinary(
           {
             type: "frame",
-            seq: ++frameSeq,
+            seq: ++h264Seq,
             codec: "h264",
             metadata: streamScale > 1 ? scaledMetadata() : lastMetadata,
           },

--- a/tests/test-browser-stream-seq.mjs
+++ b/tests/test-browser-stream-seq.mjs
@@ -1,23 +1,24 @@
 #!/usr/bin/env node
 
-// Tests for the stream's `seq` numbering contract. seq is a per-session
-// stream-event counter shared across delivery paths (jpeg frame deliveries
-// and h264 chunk sends both draw from it), not a per-message ordinal: an
-// h264 viewer sees seq strictly increase but with holes, and that IS the
-// contract — a consumer detecting loss must use a gap threshold, never
-// `delta != 1`. A jpeg viewer that keeps up sees consecutive values because
-// nothing else burns the counter between its frames.
+// Tests for the stream's `seq` numbering contract. seq counts per codec: a
+// client consumes exactly one codec, and every message that codec's
+// subscribers receive is numbered consecutively, so a viewer can read a gap
+// as loss. A shared counter would let jpeg deliveries punch holes into the
+// h264 sequence, which viewers report as loss and answer with a reconnect.
 //
 // Driven end-to-end over real sockets against a FAKE CDP session (no
-// browser); the h264 test additionally needs a real ffmpeg and self-skips
-// without one.
+// browser). The contiguity tests drive a stub encoder binary so they always
+// run; the real-encoder test needs an ffmpeg and self-skips without one.
 //
 // Run: node --test tests/test-browser-stream-seq.mjs
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import crypto from "node:crypto";
+import fs from "node:fs";
 import net from "node:net";
+import os from "node:os";
+import path from "node:path";
 import { once } from "node:events";
 
 import {
@@ -135,7 +136,119 @@ async function startServer(opts = {}, stateOpts = {}) {
 
 // ── tests ────────────────────────────────────────────────────────────────────
 
-test("h264 seq increases monotonically with holes allowed", async (t) => {
+// Stands in for ffmpeg: answers the encoder probe, then emits one Annex-B
+// chunk per write it receives. Keeps these tests off a real encoder so they
+// always run and the chunk count follows the writes.
+const FFMPEG_STUB = `#!/usr/bin/env node
+if (process.argv.includes("-encoders")) {
+  process.stdout.write(" V....D libx264 stub\\n");
+  process.exit(0);
+}
+process.stdin.on("data", () => process.stdout.write(Buffer.from([0, 0, 0, 1, 0x65])));
+process.stdin.on("end", () => process.exit(0));
+`;
+
+function writeFfmpegStub() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "stream-seq-stub-"));
+  const stub = path.join(dir, "ffmpeg-stub.mjs");
+  fs.writeFileSync(stub, FFMPEG_STUB, { mode: 0o755 });
+  return { dir, stub };
+}
+
+// Next binary frame of `codec`, skipping the status text frames a viewer
+// also receives.
+async function nextSeq(c, codec, timeout = 4000) {
+  const deadline = Date.now() + timeout;
+  for (;;) {
+    const left = deadline - Date.now();
+    if (left <= 0) throw new Error(`timeout waiting for a ${codec} frame`);
+    const m = await c.next(left);
+    if (m.opcode !== 0x2) continue;
+    const { header } = decodeFrameBinary(m.payload);
+    if ((header.codec ?? "jpeg") === codec) return header.seq;
+  }
+}
+
+function assertConsecutive(seqs, what) {
+  for (let i = 1; i < seqs.length; i++) {
+    assert.equal(seqs[i] - seqs[i - 1], 1, `consecutive ${what} (got ${seqs.join(",")})`);
+  }
+}
+
+// The regression: with no jpeg viewer attached, every screencast frame still
+// runs a jpeg delivery, and the idle refinement adds one more plus a double
+// encoder write. None of that may number the h264 stream — a viewer reads
+// the resulting holes as frame loss and redials.
+test("h264 seq is contiguous while jpeg frames are delivered", async () => {
+  const { dir, stub } = writeFfmpegStub();
+  const jpeg = Buffer.from("jpeg-payload").toString("base64");
+  const { state, server } = await startServer(
+    { h264Config: { ffmpegPath: stub, encoder: "libx264" } },
+    { screenshot: jpeg },
+  );
+  const c = await connectStream(server.port, server.token, "&codec=h264");
+  await c.nextJson(); // join status — this is the only client on the server
+
+  const seqs = [];
+  // Motion phase. The stub encoder spawns asynchronously, so keep feeding
+  // until the first chunk comes back, then take a run of them.
+  const warmup = Date.now() + 10000;
+  while (seqs.length === 0 && Date.now() < warmup) {
+    state.session.emitFrame(jpeg);
+    try { seqs.push(await nextSeq(c, "h264", 300)); } catch { /* encoder not up yet */ }
+  }
+  assert.equal(seqs.length, 1, "the stub encoder produced a chunk");
+  for (let i = 0; i < 5; i++) {
+    state.session.emitFrame(jpeg);
+    seqs.push(await nextSeq(c, "h264"));
+  }
+  // Idle phase: silence past the refinement threshold arms one high-quality
+  // capture — a jpeg delivery plus two encoder writes.
+  seqs.push(await nextSeq(c, "h264", 4000));
+
+  assert.ok(seqs.length >= 7, `collected h264 chunks (got ${seqs.length})`);
+  assertConsecutive(seqs, "h264 chunks");
+  c.close();
+  server.close();
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+// Both codecs on one server: neither sequence may be disturbed by the other.
+test("jpeg and h264 viewers each get their own contiguous seq", async () => {
+  const { dir, stub } = writeFfmpegStub();
+  const jpeg = Buffer.from("jpeg-payload").toString("base64");
+  const { state, server } = await startServer(
+    { h264Config: { ffmpegPath: stub, encoder: "libx264" } },
+    { screenshot: jpeg },
+  );
+  const h = await connectStream(server.port, server.token, "&codec=h264");
+  await h.nextJson();
+  const j = await connectStream(server.port, server.token, "&binary=1");
+  await j.nextJson();
+
+  const h264 = [];
+  const jpegs = [];
+  const warmup = Date.now() + 10000;
+  while (h264.length === 0 && Date.now() < warmup) {
+    state.session.emitFrame(jpeg);
+    jpegs.push(await nextSeq(j, "jpeg"));
+    try { h264.push(await nextSeq(h, "h264", 300)); } catch { /* encoder not up yet */ }
+  }
+  assert.equal(h264.length, 1, "the stub encoder produced a chunk");
+  for (let i = 0; i < 5; i++) {
+    state.session.emitFrame(jpeg);
+    jpegs.push(await nextSeq(j, "jpeg"));
+    h264.push(await nextSeq(h, "h264"));
+  }
+  assertConsecutive(h264, "h264 chunks");
+  assertConsecutive(jpegs, "jpeg frames");
+  h.close();
+  j.close();
+  server.close();
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test("h264 seq stays contiguous under real encoding", async (t) => {
   const { detectH264Encoder } = await import("../plugins/agent-id-browser/lib/stream-encoder.mjs");
   if (!(await detectH264Encoder())) return t.skip("no ffmpeg h264 encoder on this machine");
   const { execFileSync } = await import("node:child_process");
@@ -158,8 +271,8 @@ test("h264 seq increases monotonically with holes allowed", async (t) => {
   await c.nextJson();
   await sleep(150);
   const seqs = [];
-  // Steady motion: every screencast frame burns a counter value of its own,
-  // so chunk-to-chunk deltas here are mostly ≥2 — the holes.
+  // Steady motion: each screencast frame is delivered as a jpeg frame AND
+  // fed to the encoder, and only the encoder's chunks number the h264 stream.
   let n = 0;
   const feeder = setInterval(() => {
     state.session.emitFrame(jpegs[n++ % jpegs.length]);
@@ -175,8 +288,7 @@ test("h264 seq increases monotonically with holes allowed", async (t) => {
     clearInterval(feeder);
   }
   assert.ok(seqs.length >= 8, `collected h264 chunks under motion (got ${seqs.length})`);
-  // Burst then silence: the encoder drains its backlog with nothing else
-  // burning the counter, so back-to-back chunks arrive with delta 1.
+  // Burst then silence: the encoder drains its backlog.
   await sleep(200);
   for (let i = 0; i < 30; i++) state.session.emitFrame(jpegs[i % jpegs.length]);
   const drainDeadline = Date.now() + 4000;
@@ -188,14 +300,9 @@ test("h264 seq increases monotonically with holes allowed", async (t) => {
       break; // drained
     }
   }
-  // Strictly increasing across the whole connection — which is also the
-  // no-reset guarantee.
-  for (let i = 1; i < seqs.length; i++) {
-    assert.ok(seqs[i] > seqs[i - 1], `seq strictly increases (${seqs[i - 1]} then ${seqs[i]})`);
-  }
-  const deltas = seqs.slice(1).map((s, i) => s - seqs[i]);
-  assert.ok(deltas.includes(1), `a delta of 1 occurs (deltas: ${deltas.join(",")})`);
-  assert.ok(deltas.some((d) => d >= 2), `a delta of ≥2 occurs (deltas: ${deltas.join(",")})`);
+  // Consecutive across the whole connection — which is also the no-reset
+  // guarantee.
+  assertConsecutive(seqs, "h264 chunks");
   c.close();
   server.close();
   fsSync.rmSync(dir, { recursive: true, force: true });
@@ -212,8 +319,8 @@ test("a jpeg viewer's seq increments by one per delivered frame", async () => {
     const { header } = await c.nextBinary();
     seqs.push(header.seq);
   }
-  // A keeping-up jpeg viewer sees consecutive values; holes appear only when
-  // another delivery path burns the shared counter in between.
+  // A keeping-up jpeg viewer sees consecutive values; a viewer that falls
+  // behind skips frames outright (latest-frame-wins), it does not see holes.
   for (let i = 1; i < seqs.length; i++) {
     assert.equal(seqs[i] - seqs[i - 1], 1, `consecutive frames (got ${seqs.join(",")})`);
   }


### PR DESCRIPTION
## The defect

`lib/stream-server.mjs` numbered every outgoing stream message from a single
counter. Both delivery paths drew from it:

- `deliverFrame()` incremented it for each JPEG frame — *before* the
  `client.codec !== "jpeg"` filter, so a screencast frame consumed a number
  even with zero JPEG viewers connected.
- `sendH264Chunk()` incremented the same counter per H.264 chunk.

So an H.264-only viewer received a sequence with structural holes: at least
one number per screencast frame, and three around the idle refinement pass
(which delivers a JPEG frame and then deliberately writes the capture to the
encoder twice to flush the MJPEG parser).

## Why it matters

`seq` is what a viewer uses to detect loss. Viewers tolerate a small delta,
then stop rendering and wait for a keyframe — and force a reconnect if none
arrives. With holes of two or three appearing routinely on a perfectly
healthy stream, viewers spuriously declared frame loss and redialed, so a
relay would open and close every few seconds.

## The fix

Give the H.264 flow its own counter. A client negotiates and consumes exactly
one codec, so per-codec numbering is both correct and sufficient — each
codec's subscribers see their own sequence contiguous.

```diff
   let frameSeq = 0;
+  let h264Seq = 0;
...
-            seq: ++frameSeq,
+            seq: ++h264Seq,
             codec: "h264",
```

Server-side only. No wire-format change, no client change, no viewer
tolerance touched: `seq` is still a monotonically increasing per-message
ordinal, it just no longer skips. Ack pacing (`client.awaitingAck =
frame.seq`) runs on the JPEG path and keeps the existing counter. Encoder
restarts still work — the H.264 counter is never reset, so the delta stays
positive and the epoch-reset path is not triggered by an ordinary restart.

## Tests

`tests/test-browser-stream-seq.mjs`:

- **`h264 seq is contiguous while jpeg frames are delivered`** — the
  regression test. One H.264 viewer, no JPEG viewer, driven over real
  sockets against a fake CDP session: a run of screencast frames, then
  silence long enough to arm the idle refinement. Asserts every chunk-to-chunk
  delta is exactly 1.
- **`jpeg and h264 viewers each get their own contiguous seq`** — both codecs
  on one server; asserts neither sequence is disturbed by the other.

Both drive a stub encoder binary instead of ffmpeg, so they always run rather
than self-skipping on a host without a codec.

Verified they catch the bug: with `++h264Seq` reverted to `++frameSeq`, both
go red —

```
AssertionError: consecutive h264 chunks (got 3,5,7,9,11,13,15)
  2 !== 1
```

The pre-existing real-ffmpeg test asserted the old behaviour as intentional
(`a delta of ≥2 occurs`, with a header comment declaring the shared counter
"IS the contract"). That contract is what this PR corrects, so the test and
its comment now assert contiguity; it fails too without the fix, with a gap
of 31 across the quiet stretch.

Full suite: 752 pass, 0 fail.

## Also included

A patch changeset for `@alien-id/agent-id-browser`.
