### PR TITLE
fix(browser): send one H.264 access unit per stream message so large frames stop freezing the viewport

### DIFF
--- a/.changeset/h264-access-unit-framing.md
+++ b/.changeset/h264-access-unit-framing.md
@@ -1,0 +1,19 @@
+---
+"@alien-id/agent-id-browser": patch
+---
+
+Stream H.264 one access unit per WebSocket message
+
+The viewport stream forwarded each encoder stdout chunk verbatim. A pipe read
+is capped at 64 KiB, so any access unit above that was split across messages
+and every message after the first carried no start code at all — a viewer that
+parses one access unit per message could only discard it. Because the keyframe
+is the largest access unit in the stream, it was the one most likely to be
+split, so a viewer waiting for a keyframe never got a usable one: on content
+that produces large frames the viewport froze or went black, while a static
+page looked fine.
+
+The stream is now framed on access unit delimiters and each unit is sent whole,
+however large. A unit is known-complete when the next one's delimiter arrives;
+when the encoder goes quiet, a 50 ms idle timer releases the last one, so an
+idle page still updates promptly.

--- a/plugins/agent-id-browser/lib/h264-framer.mjs
+++ b/plugins/agent-id-browser/lib/h264-framer.mjs
@@ -1,0 +1,109 @@
+// Access-unit framing for the Annex-B byte stream an encoder writes to stdout.
+//
+// A pipe read is capped at 64 KiB below Node (not tunable — raising
+// readableHighWaterMark changes nothing), so an access unit bigger than that
+// arrives split across chunks, and the tail chunk carries NO start code at all
+// (emulation prevention keeps 00 00 01 out of NAL bodies). A consumer that
+// parses one access unit per message therefore sees the tail as nothing,
+// resyncs, and waits for a keyframe — and since the IDR is the largest access
+// unit in the stream, the very frame that would clear that wait is the one
+// most likely to be split. The picture freezes or goes black.
+//
+// So the byte stream is buffered and cut on access unit delimiters (NAL type
+// 9, which the encoder inserts for exactly this purpose), and each complete
+// access unit is handed over whole, however large.
+//
+// An AUD marks the START of an access unit, so unit N is only known-complete
+// when unit N+1's AUD arrives — on a page that stops producing frames that
+// would hold the last unit indefinitely. An idle timer, reset by every chunk,
+// flushes it instead. The timer only fires when the encoder produced nothing
+// for the whole interval, and it is orders of magnitude longer than the gaps
+// inside one unit's writes (the writer refills the 64 KiB pipe buffer as fast
+// as this process drains it, and a timer cannot fire while the event loop is
+// too busy to drain), so it does not split a unit it is meant to deliver.
+
+const START_CODE = Buffer.from([0, 0, 1]);
+const NAL_AUD = 9;
+
+// Well above one frame interval at the encoder's frame rates, so a stream in
+// motion is framed by the next AUD and pays nothing; this is the ceiling on
+// how long the LAST unit of a burst waits.
+export const AU_FLUSH_MS = 50;
+
+// ~16s of video at the encoder's 4 Mbit/s cap: no real access unit comes near
+// it, so reaching it means the stream carries no delimiters and the buffer
+// would otherwise grow without bound.
+export const AU_MAX_PENDING = 8 * 1024 * 1024;
+
+/**
+ * Frame an Annex-B byte stream into access units. `push(chunk)` takes stdout
+ * chunks; `onAccessUnit(buf)` receives each complete unit, start code first.
+ * `close()` stops the timer and drops any partial unit — a replaced or dead
+ * encoder's tail belongs to no stream the next one will produce.
+ */
+export function createAccessUnitFramer({
+  onAccessUnit,
+  flushMs = AU_FLUSH_MS,
+  maxPending = AU_MAX_PENDING,
+  log = () => {},
+}) {
+  let buf = Buffer.alloc(0);
+  let searchFrom = 0;
+  let timer = null;
+
+  function emit(end) {
+    const au = buf.subarray(0, end);
+    buf = buf.subarray(end);
+    onAccessUnit(au);
+  }
+
+  function stopTimer() {
+    if (timer) clearTimeout(timer);
+    timer = null;
+  }
+
+  function armTimer() {
+    stopTimer();
+    timer = setTimeout(() => {
+      timer = null;
+      if (buf.length) emit(buf.length);
+    }, flushMs);
+    timer.unref?.();
+  }
+
+  return {
+    push(chunk) {
+      buf = buf.length ? Buffer.concat([buf, chunk]) : chunk;
+      let i = searchFrom;
+      for (;;) {
+        const at = buf.indexOf(START_CODE, i);
+        // Undecidable until the NAL type byte arrives: rescan next chunk.
+        if (at < 0 || at + 3 >= buf.length) break;
+        if ((buf[at + 3] & 0x1f) === NAL_AUD) {
+          // A 4-byte start code owns its leading zero, so cut before it —
+          // every emitted unit begins with a start code.
+          const cut = at > 0 && buf[at - 1] === 0 ? at - 1 : at;
+          if (cut > 0) {
+            emit(cut);
+            i = 1; // past the delimiter now sitting at the head
+            continue;
+          }
+        }
+        i = at + 3;
+      }
+      searchFrom = Math.max(0, buf.length - 3);
+      if (buf.length > maxPending) {
+        log("stream: no access unit delimiter within the frame buffer — resyncing");
+        buf = Buffer.alloc(0);
+        searchFrom = 0;
+      }
+      if (buf.length) armTimer();
+      else stopTimer();
+    },
+    close() {
+      stopTimer();
+      buf = Buffer.alloc(0);
+      searchFrom = 0;
+    },
+  };
+}

--- a/plugins/agent-id-browser/lib/stream-encoder.mjs
+++ b/plugins/agent-id-browser/lib/stream-encoder.mjs
@@ -23,6 +23,8 @@ import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 
+import { createAccessUnitFramer } from "./h264-framer.mjs";
+
 const execFileP = promisify(execFile);
 
 const FFMPEG = () => process.env.AGENT_ID_FFMPEG || "ffmpeg";
@@ -180,11 +182,12 @@ function codecArgs(encoder) {
 }
 
 /**
- * Spawn an encoder. `onChunk(Buffer)` receives Annex-B output; pass `rtp:
- * {port, payloadType, ssrc}` instead to emit RTP to loopback UDP (onChunk
- * unused). Returns { write(jpegBuffer) → bool, close() }; calls `onExit()`
- * once when the process dies for any reason. Throws when ffmpeg or an H.264
- * encoder is unavailable.
+ * Spawn an encoder. `onChunk(Buffer)` receives Annex-B output, one complete
+ * access unit per call (see h264-framer.mjs: stdout chunks are not unit
+ * boundaries); pass `rtp: {port, payloadType, ssrc}` instead to emit RTP to
+ * loopback UDP (onChunk unused). Returns { write(jpegBuffer) → bool,
+ * close() }; calls `onExit()` once when the process dies for any reason.
+ * Throws when ffmpeg or an H.264 encoder is unavailable.
  */
 export async function createH264Encoder({ onChunk, onExit, log = () => {}, rtp = null, ffmpegPath = null }) {
   const ffmpeg = ffmpegPath || FFMPEG();
@@ -222,7 +225,10 @@ export async function createH264Encoder({ onChunk, onExit, log = () => {}, rtp =
   proc.stderr.on("data", (d) => {
     stderrTail = (stderrTail + d.toString()).slice(-2048);
   });
-  if (!rtp) proc.stdout.on("data", (chunk) => onChunk?.(chunk));
+  const framer = rtp
+    ? null
+    : createAccessUnitFramer({ onAccessUnit: (au) => onChunk?.(au), log });
+  if (framer) proc.stdout.on("data", (chunk) => framer.push(chunk));
 
   let writable = true;
   let alive = true;
@@ -230,6 +236,7 @@ export async function createH264Encoder({ onChunk, onExit, log = () => {}, rtp =
   proc.stdin.on("error", () => {}); // EPIPE on teardown races
   proc.once("close", (code) => {
     alive = false;
+    framer?.close(); // a dead encoder's partial unit belongs to no stream
     if (code) log(`stream: h264 encoder (${encoder}) exited ${code}: ${stderrTail.trim()}`);
     onExit?.();
   });
@@ -243,6 +250,7 @@ export async function createH264Encoder({ onChunk, onExit, log = () => {}, rtp =
     },
     close() {
       alive = false;
+      framer?.close();
       try { proc.stdin.destroy(); } catch { /* already gone */ }
       try { proc.kill("SIGKILL"); } catch { /* already dead */ }
     },

--- a/plugins/agent-id-browser/lib/stream-server.mjs
+++ b/plugins/agent-id-browser/lib/stream-server.mjs
@@ -15,9 +15,10 @@
 //   ?binary=1         type:"frame" messages arrive as WS binary messages:
 //                     [u32 LE header length][JSON header][payload bytes]
 //                     (everything else stays a JSON text frame)
-//   ?codec=h264       payload is an H.264 Annex-B chunk from an ffmpeg
-//                     subprocess (implies binary=1; falls back to jpeg with a
-//                     status notice when no usable ffmpeg/encoder exists)
+//   ?codec=h264       payload is ONE complete H.264 Annex-B access unit from
+//                     an ffmpeg subprocess (implies binary=1; falls back to
+//                     jpeg with a status notice when no usable ffmpeg/encoder
+//                     exists)
 //   ?pacing=ack|push  ack: at most one frame in flight — the client releases
 //                     the next with {"type":"ack","seq":N}
 //   ?maxFps=<0-120>   per-client delivery cap (0 = uncapped)
@@ -35,11 +36,12 @@
 // newer frames overwrite whenever the client is slower than the feed (socket
 // backpressure, outstanding ack, fps cap), so a viewer always resumes at live
 // and the server never queues stale frames. H.264 is a temporally-dependent
-// byte stream, so chunks can't be dropped mid-GOP — a client whose socket
-// buffer exceeds a bound is disconnected instead (it reconnects at a fresh
-// keyframe). After ~600ms without a screencast frame the page has settled and
-// one high-quality Page.captureScreenshot "refinement" frame is pushed, so
-// text is sharp at rest while motion runs at aggressive JPEG quality.
+// byte stream, so access units can't be dropped mid-GOP — a client whose
+// socket buffer exceeds a bound is disconnected instead (it reconnects at a
+// fresh keyframe). After ~600ms without a screencast frame the page has
+// settled and one high-quality Page.captureScreenshot "refinement" frame is
+// pushed, so text is sharp at rest while motion runs at aggressive JPEG
+// quality.
 //
 // `resize` is our one extension beyond agent-browser's shapes (harmless there —
 // unknown types are ignored). width/height are the VIEWER's dimensions — the
@@ -596,7 +598,11 @@ export async function startStreamServer(
     }
   }
 
-  function sendH264Chunk(chunk) {
+  // One message per ACCESS UNIT, never per stdout chunk: the encoder's pipe
+  // splits a unit larger than 64 KiB across chunks, and the tail carries no
+  // start code, so a viewer parsing one unit per message would discard it
+  // (h264-framer.mjs does the framing).
+  function sendAccessUnit(au) {
     let msg = null;
     for (const client of clients) {
       if (client.codec !== "h264") continue;
@@ -612,13 +618,16 @@ export async function startStreamServer(
             codec: "h264",
             metadata: streamScale > 1 ? scaledMetadata() : lastMetadata,
           },
-          chunk,
+          au,
         ),
       );
       client.sock.write(msg);
-      // A temporally-dependent stream can't drop chunks; a viewer that can't
-      // keep up is cut instead of buffering without bound. It reconnects and
-      // the encoder restart gives it a fresh keyframe.
+      // A temporally-dependent stream can't drop access units; a viewer that
+      // can't keep up is cut instead of buffering without bound. It reconnects
+      // and the encoder restart gives it a fresh keyframe. Whole units are
+      // larger writes than the old per-chunk ones, but the bound still holds
+      // several of even the biggest measured unit (~440 KiB against 4 MiB),
+      // so only a genuinely stalled socket trips it.
       if (client.sock.writableLength > H264_MAX_BUFFERED) {
         log("stream: h264 viewer too slow — disconnecting");
         client.sock.destroy();
@@ -647,7 +656,7 @@ export async function startStreamServer(
     if (annexB) return;
     try {
       const enc = await createH264Encoder({
-        onChunk: sendH264Chunk,
+        onChunk: sendAccessUnit,
         log,
         ffmpegPath: h264Config?.ffmpegPath ?? null,
         onExit: () => {

--- a/tests/test-browser-stream-au-framing.mjs
+++ b/tests/test-browser-stream-au-framing.mjs
@@ -1,0 +1,319 @@
+#!/usr/bin/env node
+
+// Tests for the h264 wire framing: one WS binary message per ACCESS UNIT.
+//
+// The encoder writes an Annex-B byte stream to a pipe, and a pipe read is
+// capped at 64 KiB below Node — so an access unit bigger than that arrives in
+// several stdout chunks, and every chunk after the first carries no start
+// code at all (emulation prevention keeps 00 00 01 out of NAL bodies).
+// Forwarding chunks verbatim hands a viewer that parses one unit per message
+// a fragment it can only discard, and because the IDR is the largest unit in
+// the stream, the frame that clears a viewer's wait-for-keyframe state is the
+// one most likely to be split: the viewport freezes or goes black.
+//
+// Driven end-to-end over real sockets against a fake CDP session and a stub
+// encoder binary (no browser, no ffmpeg), so the byte stream under test is
+// exact and the test always runs.
+//
+// Run: node --test tests/test-browser-stream-au-framing.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { once } from "node:events";
+
+import {
+  startStreamServer,
+  decodeFrameBinary,
+  makeFrameParser,
+} from "../plugins/agent-id-browser/lib/stream-server.mjs";
+import { createAccessUnitFramer } from "../plugins/agent-id-browser/lib/h264-framer.mjs";
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ── synthetic Annex-B ────────────────────────────────────────────────────────
+// Only start codes and NAL types matter to the framer, so the payloads are
+// filler — but filler that never contains 00, which is what emulation
+// prevention guarantees about a real NAL body.
+
+function nal(type, bodyLen, startCodeBytes = 4) {
+  const start = startCodeBytes === 4 ? [0, 0, 0, 1] : [0, 0, 1];
+  const buf = Buffer.alloc(start.length + 1 + bodyLen);
+  buf.set(start);
+  buf[start.length] = 0x60 | type; // forbidden_zero=0, nal_ref_idc=3
+  for (let i = 0; i < bodyLen; i++) buf[start.length + 1 + i] = (i % 251) + 1;
+  return buf;
+}
+
+function accessUnit({ sliceBytes, idr = false, startCodeBytes = 4 }) {
+  const parts = [nal(9, 1, startCodeBytes)];
+  if (idr) parts.push(nal(7, 24, startCodeBytes), nal(8, 8, startCodeBytes));
+  parts.push(nal(idr ? 5 : 1, sliceBytes, startCodeBytes));
+  return Buffer.concat(parts);
+}
+
+/** NAL types in stream order. A 4-byte start code matches once, at its tail. */
+function nalTypes(buf) {
+  const out = [];
+  for (let i = 0; i + 3 < buf.length; ) {
+    if (buf[i] === 0 && buf[i + 1] === 0 && buf[i + 2] === 1) {
+      out.push(buf[i + 3] & 0x1f);
+      i += 4;
+    } else i++;
+  }
+  return out;
+}
+
+const startsWithStartCode = (b) =>
+  b.length >= 4 && b[0] === 0 && b[1] === 0 && (b[2] === 1 || (b[2] === 0 && b[3] === 1));
+
+// ── fakes ────────────────────────────────────────────────────────────────────
+
+function makeFakeSession(screenshotData) {
+  const handlers = new Map();
+  const session = {
+    detached: false,
+    on: (event, fn) => handlers.set(event, fn),
+    async send(method) {
+      if (method === "Page.captureScreenshot") return { data: screenshotData };
+      return {};
+    },
+    async detach() { session.detached = true; },
+    emitFrame(data, metadata = { deviceWidth: 640, deviceHeight: 480, timestamp: Date.now() }) {
+      handlers.get("Page.screencastFrame")?.({ data, metadata, sessionId: 1 });
+    },
+  };
+  return session;
+}
+
+function makeFakeState({ screenshot } = {}) {
+  let session = makeFakeSession(screenshot);
+  const page = {
+    isClosed: () => false,
+    viewportSize: () => ({ width: 640, height: 480 }),
+    mouse: { move: async () => {}, down: async () => {}, up: async () => {}, wheel: async () => {} },
+    keyboard: { down: async () => {}, up: async () => {}, insertText: async () => {} },
+  };
+  return {
+    current: page,
+    invalidateRefs() {},
+    ctx: {
+      newCDPSession: async () => {
+        if (session.detached) session = makeFakeSession(screenshot);
+        return session;
+      },
+    },
+    get session() { return session; },
+  };
+}
+
+// Stands in for ffmpeg: answers the encoder probe, then writes a canned
+// Annex-B stream to stdout in one go — the pipe does the 64 KiB chunking, the
+// same way a real encoder's output is chunked.
+function writeFfmpegStub(stream) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "stream-au-stub-"));
+  const streamFile = path.join(dir, "stream.h264");
+  fs.writeFileSync(streamFile, stream);
+  const stub = path.join(dir, "ffmpeg-stub.mjs");
+  fs.writeFileSync(
+    stub,
+    `#!/usr/bin/env node
+import fs from "node:fs";
+if (process.argv.includes("-encoders")) {
+  process.stdout.write(" V....D libx264 stub\\n");
+  process.exit(0);
+}
+setTimeout(() => process.stdout.write(fs.readFileSync(${JSON.stringify(streamFile)})), 150);
+setInterval(() => {}, 60000); // outlive the write; the server kills us
+`,
+    { mode: 0o755 },
+  );
+  return { dir, stub };
+}
+
+// ── minimal WS client (receive-only) ─────────────────────────────────────────
+
+async function connectStream(port, token, params = "") {
+  const sock = net.connect(port, "127.0.0.1");
+  await once(sock, "connect");
+  const key = crypto.randomBytes(16).toString("base64");
+  sock.write(
+    `GET /?token=${token}${params} HTTP/1.1\r\nHost: t\r\nUpgrade: websocket\r\n` +
+      `Connection: Upgrade\r\nSec-WebSocket-Key: ${key}\r\nSec-WebSocket-Version: 13\r\n\r\n`,
+  );
+  const queue = [];
+  const waiters = [];
+  const parse = makeFrameParser((m) => {
+    const w = waiters.shift();
+    if (w) w(m);
+    else queue.push(m);
+  });
+  let head = Buffer.alloc(0);
+  let upgraded = false;
+  await new Promise((resolve, reject) => {
+    sock.on("data", (d) => {
+      if (upgraded) return parse(d);
+      head = Buffer.concat([head, d]);
+      const end = head.indexOf("\r\n\r\n");
+      if (end < 0) return;
+      upgraded = true;
+      resolve();
+      parse(head.subarray(end + 4));
+    });
+    sock.on("error", reject);
+  });
+  return {
+    next(timeout = 2000) {
+      if (queue.length) return Promise.resolve(queue.shift());
+      return new Promise((resolve, reject) => {
+        const waiter = (m) => { clearTimeout(t); resolve(m); };
+        const t = setTimeout(() => {
+          const i = waiters.indexOf(waiter);
+          if (i >= 0) waiters.splice(i, 1);
+          reject(new Error("timeout waiting for ws message"));
+        }, timeout);
+        waiters.push(waiter);
+      });
+    },
+    close() { sock.destroy(); },
+  };
+}
+
+// ── the regression ───────────────────────────────────────────────────────────
+
+test("every h264 message is one whole access unit, however large", async () => {
+  // The middle unit is far past the 64 KiB pipe read, so it can only reach a
+  // viewer intact if the server frames the stream rather than the chunks.
+  const units = [
+    accessUnit({ sliceBytes: 900, idr: false }),
+    accessUnit({ sliceBytes: 150_000, idr: true }),
+    accessUnit({ sliceBytes: 1_200, idr: false }),
+    accessUnit({ sliceBytes: 70_000, idr: false }),
+    accessUnit({ sliceBytes: 800, idr: false }),
+  ];
+  const stream = Buffer.concat(units);
+  const { dir, stub } = writeFfmpegStub(stream);
+  const state = makeFakeState({ screenshot: Buffer.from("jpeg").toString("base64") });
+  const server = await startStreamServer(state, {
+    log: () => {},
+    h264Config: { ffmpegPath: stub, encoder: "libx264" },
+  });
+  const c = await connectStream(server.port, server.token, "&codec=h264");
+
+  const payloads = [];
+  let got = 0;
+  const deadline = Date.now() + 10000;
+  while (Date.now() < deadline && got < stream.length) {
+    let m;
+    try { m = await c.next(2000); } catch { break; }
+    if (m.opcode !== 0x2) continue;
+    const { header, payload } = decodeFrameBinary(m.payload);
+    if (header.codec !== "h264") continue;
+    payloads.push(payload);
+    got += payload.length;
+  }
+  c.close();
+  server.close();
+  fs.rmSync(dir, { recursive: true, force: true });
+
+  assert.ok(payloads.length > 0, "the viewer received h264 messages");
+  for (const [i, p] of payloads.entries()) {
+    assert.ok(
+      startsWithStartCode(p),
+      `payload ${i} begins with a start code (got ${p.subarray(0, 4).toString("hex")}, ` +
+        `${p.length} bytes) — a mid-NAL fragment is undecodable`,
+    );
+    const types = nalTypes(p);
+    assert.equal(types[0], 9, `payload ${i} opens with an access unit delimiter (${types})`);
+    assert.equal(
+      types.filter((t) => t === 9).length,
+      1,
+      `payload ${i} carries exactly one access unit (${types})`,
+    );
+  }
+  // Whole units, in order, nothing added or lost.
+  assert.deepEqual(payloads.map((p) => p.length), units.map((u) => u.length));
+  assert.ok(Buffer.concat(payloads).equals(stream), "the byte stream is delivered intact");
+  assert.ok(
+    payloads.some((p) => p.length > 65536),
+    "a unit larger than one pipe read was delivered in a single message",
+  );
+});
+
+// ── framing edge cases (not observable through the socket) ───────────────────
+
+function frameAll(stream, chunker, opts = {}) {
+  const out = [];
+  const framer = createAccessUnitFramer({ onAccessUnit: (au) => out.push(Buffer.from(au)), ...opts });
+  for (const chunk of chunker(stream)) framer.push(chunk);
+  return { out, framer };
+}
+
+test("units survive any chunk split, including one byte at a time", () => {
+  const units = [
+    accessUnit({ sliceBytes: 40, idr: true }),
+    accessUnit({ sliceBytes: 70_000 }),
+    accessUnit({ sliceBytes: 30 }),
+  ];
+  const stream = Buffer.concat(units);
+  for (const size of [1, 2, 3, 4, 5, 7, 4096, 65536, stream.length]) {
+    const { out } = frameAll(stream, function* (s) {
+      for (let i = 0; i < s.length; i += size) yield s.subarray(i, i + size);
+    });
+    // The last unit waits for the next delimiter (or the idle flush).
+    assert.deepEqual(
+      out.map((u) => u.length),
+      units.slice(0, -1).map((u) => u.length),
+      `chunk size ${size}`,
+    );
+    assert.ok(Buffer.concat(out).equals(Buffer.concat(units.slice(0, -1))), `chunk size ${size}`);
+  }
+});
+
+test("3-byte start codes frame the same as 4-byte ones", () => {
+  const units = [
+    accessUnit({ sliceBytes: 100, startCodeBytes: 3 }),
+    accessUnit({ sliceBytes: 66_000, idr: true, startCodeBytes: 3 }),
+    accessUnit({ sliceBytes: 100, startCodeBytes: 3 }),
+  ];
+  const { out } = frameAll(Buffer.concat(units), function* (s) {
+    for (let i = 0; i < s.length; i += 65536) yield s.subarray(i, i + 65536);
+  });
+  assert.deepEqual(out.map((u) => u.length), units.slice(0, -1).map((u) => u.length));
+  for (const u of out) assert.ok(startsWithStartCode(u));
+});
+
+test("the idle flush releases the last unit, and close drops a partial one", async () => {
+  const unit = accessUnit({ sliceBytes: 200, idr: true });
+  const { out, framer } = frameAll(unit, (s) => [s], { flushMs: 20 });
+  assert.equal(out.length, 0, "held while the encoder might still be writing it");
+  await sleep(60);
+  assert.equal(out.length, 1, "released once the encoder went quiet");
+  assert.ok(out[0].equals(unit));
+
+  const late = [];
+  const f2 = createAccessUnitFramer({ onAccessUnit: (au) => late.push(au), flushMs: 20 });
+  f2.push(unit.subarray(0, 50));
+  f2.close();
+  await sleep(60);
+  assert.equal(late.length, 0, "a dead encoder's partial unit is never emitted");
+  framer.close();
+});
+
+test("a stream with no delimiters cannot grow the buffer without bound", () => {
+  const out = [];
+  const logged = [];
+  const framer = createAccessUnitFramer({
+    onAccessUnit: (au) => out.push(au),
+    maxPending: 4096,
+    log: (m) => logged.push(m),
+  });
+  for (let i = 0; i < 10; i++) framer.push(nal(1, 2000));
+  framer.close();
+  assert.equal(out.length, 0);
+  assert.ok(logged.length > 0, "the resync is reported");
+});


### PR DESCRIPTION
## The defect

`lib/stream-server.mjs` sent one WebSocket binary message per ffmpeg stdout
chunk. A chunk is not an access unit boundary: the pipe read below Node is
capped at 65536 bytes (not tunable — raising `readableHighWaterMark` to 8 MiB
was measured to change nothing), so any access unit larger than that is split,
and every chunk after the first carries **no start code at all** — emulation
prevention guarantees `00 00 01` never occurs inside a NAL body.

A viewer that parses one access unit per payload therefore reads the tail as
nothing, resyncs, and starts waiting for a keyframe. And the IDR access unit is
the **largest** unit in the stream, so it is the one most likely to be split:
it renders truncated, clears the wait, and its own tail immediately re-arms it.
The viewport freezes or goes black, with at most a corrupt one-frame flash per
GOP — while a static page, whose units all fit in one read, looks perfect.

Measured against the real encoder with the production arguments:

```
static 430x712    unit max=2357      chunks at the 65536 cap = 0
complex 430x712   unit max=66940     chunks at the 65536 cap = 2
complex 860x1424  unit max=206367    chunks at the 65536 cap = 6
```

## The fix

Emit **one message per complete access unit**. The encoder already inserts
access unit delimiters for exactly this purpose (`h264_metadata=aud=insert`),
so the boundaries are in the byte stream — they were just being ignored.

New `lib/h264-framer.mjs` buffers stdout and cuts it on AUD NALs (type 9),
handing each complete unit over whole, start code first, however large. It is
wired in `createH264Encoder` rather than at the send site, so the encoder's
existing lifecycle owns the buffer: a replaced or dead encoder drops its
partial unit instead of prefixing it to the next stream. `sendH264Chunk` is
renamed `sendAccessUnit` — its body is otherwise unchanged.

### Latency: how the last unit is bounded, and why 50 ms

An AUD marks the **start** of a unit, so unit *N* is only known-complete when
unit *N+1*'s AUD arrives. Holding it until then would stall an idle page
indefinitely — a freeze traded for a stall, which is no improvement. An idle
timer, **reset by every chunk**, flushes a buffered unit when the encoder
produced nothing for 50 ms.

Worst-case added latency is **50 ms**, and only for the last unit of a burst.
In motion the next unit's delimiter always arrives first, so the cost is
bounded by the frame interval instead (~33 ms at 30 fps) and the timer never
fires. Nothing else in the pipeline is delayed.

50 ms is chosen to sit far above the gaps *inside* one unit's writes, so the
timer cannot split a unit it is meant to deliver: the writer refills the 64 KiB
pipe buffer as fast as this process drains it (sub-millisecond gaps), and a
timer cannot fire while the event loop is too busy to drain — so a 50 ms
silence with the loop free means the encoder genuinely stopped. It is also
comfortably above one frame interval, which keeps steady motion on the
delimiter path rather than the timer path. The daemon's ~600 ms idle
refinement frame would also flush a pending unit, but it is not relied on: it
is armed by a screencast frame and does not fire in every state.

## Verification against the real encoder

Complex content at 860x1424 through the production encoder path: **38 units,
largest 438750 bytes, 4 above 64 KiB, 0 not start-code aligned, 0 carrying
anything but exactly one delimiter.**

## Tests

New `tests/test-browser-stream-au-framing.mjs`, driven end-to-end over real
sockets against a fake CDP session and a stub encoder binary (reusing the stub
pattern from #112, so it runs without ffmpeg on CI):

- **`every h264 message is one whole access unit, however large`** — the gate.
  A synthetic Annex-B stream whose second unit is ~150 KB (a keyframe: AUD +
  SPS + PPS + IDR) is written to the pipe, which chunks it exactly as a real
  encoder's output is chunked. Asserts every payload begins with a start code,
  opens with a delimiter, contains exactly one, that the reassembled bytes
  equal the source exactly, and that a unit above one pipe read arrived in a
  single message.
- Three framing unit tests for what the socket cannot show: identical output
  under every chunk split from 1 byte upward, 3-byte start codes, the idle
  flush releasing the last unit, `close()` dropping a partial one, and a
  delimiter-less stream resyncing instead of growing the buffer without bound.

**Verified the gate is real** — with the framing reverted to verbatim chunk
forwarding, the regression test goes red on the fragment:

```
✖ every h264 message is one whole access unit, however large
  AssertionError: payload 1 begins with a start code (got 42434445, 65536
  bytes) — a mid-NAL fragment is undecodable
```

(with the one-unit-per-payload assertion checked first, it fails one payload
earlier: `payload 0 carries exactly one access unit (9,1,9,7,8,5)`.)

Full suite: **755 pass, 0 fail.**

## Checked, not assumed

- **`seq`** now increments once per access unit instead of once per chunk,
  which is what the field was always meant to count. The counter itself is
  untouched — #112 owns that.
- **Backpressure.** `H264_MAX_BUFFERED` (4 MiB) and the `writableLength` check
  now see larger individual writes. The largest unit measured is ~440 KiB, so
  the bound still holds several whole units and a keeping-up viewer never
  approaches it; only a genuinely stalled socket trips it. Constant unchanged.
- **Memory.** The buffer is capped at 8 MiB (~16 s of video at the encoder's
  4 Mbit/s ceiling — no real unit comes near it). Exceeding it means the stream
  has no delimiters; the buffer is dropped and framing resyncs.
- **RTP path unaffected.** The framer is created only when `rtp` is absent, and
  the RTP spawn has no stdout at all (`stdio[1] = "ignore"`).
- Encoder arguments, the JPEG path, the resize path and the screencast
  lifecycle are untouched.

## Conflicts with #112

Both PRs edit the same message-builder block. #112 changes `seq: ++frameSeq` to
`seq: ++h264Seq`; this PR changes the payload argument five lines below it and
renames the enclosing function. Expect one small conflict in
`sendH264Chunk`/`sendAccessUnit` — take #112's counter line and this PR's
function name and `au` argument; there is no semantic disagreement.

One behavioural note for whichever lands second: #112's stub encoder emits NAL
type 5 with no delimiter, so under this framing its writes are released by the
idle flush rather than by a delimiter. Its tests write once and then await, so
they still see one message per write — adding `00 00 00 01 09` to that stub's
output would make that exact rather than incidental.
