### PR TITLE
fix(browser): stop a closed H.264 encoder from delivering chunks

### DIFF
--- a/.changeset/encoder-close-stdout-listener.md
+++ b/.changeset/encoder-close-stdout-listener.md
@@ -1,0 +1,18 @@
+---
+"@alien-id/agent-id-browser": patch
+---
+
+Stop a closed H.264 encoder from writing into the next one's stream
+
+Closing an encoder destroyed its stdin and killed the process, but left the
+listener on its stdout attached — and neither of those stops delivery: what the
+kernel pipe already holds is still read out and handed to the caller after
+close returned (measured: ~17 KB in 9 chunks). Because an encoder is replaced by
+closing the old one and spawning a new one onto the same viewer sink, that tail
+was written to live viewers interleaved into the replacement's output, carrying
+slices that reference the previous encoder's parameter sets — which a decoder
+can only fail on. A replacement happens on every viewer join, retarget, resume
+and watchdog restart, so a viewport could go black right after reconnecting.
+
+Closing now detaches the output listener before killing the process, so a closed
+encoder delivers nothing, and repeated closes are a no-op.

--- a/plugins/agent-id-browser/lib/stream-encoder.mjs
+++ b/plugins/agent-id-browser/lib/stream-encoder.mjs
@@ -222,10 +222,12 @@ export async function createH264Encoder({ onChunk, onExit, log = () => {}, rtp =
   proc.stderr.on("data", (d) => {
     stderrTail = (stderrTail + d.toString()).slice(-2048);
   });
-  if (!rtp) proc.stdout.on("data", (chunk) => onChunk?.(chunk));
+  const onStdout = rtp ? null : (chunk) => onChunk?.(chunk);
+  if (onStdout) proc.stdout.on("data", onStdout);
 
   let writable = true;
   let alive = true;
+  let closed = false;
   proc.stdin.on("drain", () => (writable = true));
   proc.stdin.on("error", () => {}); // EPIPE on teardown races
   proc.once("close", (code) => {
@@ -242,7 +244,13 @@ export async function createH264Encoder({ onChunk, onExit, log = () => {}, rtp =
       return true;
     },
     close() {
+      if (closed) return;
+      closed = true;
       alive = false;
+      // Detach before the kill: whatever is already in the pipe is still
+      // delivered after it, and a replaced encoder's tail must never reach the
+      // sink its replacement writes to (it references the old parameter sets).
+      if (onStdout) proc.stdout.off("data", onStdout);
       try { proc.stdin.destroy(); } catch { /* already gone */ }
       try { proc.kill("SIGKILL"); } catch { /* already dead */ }
     },

--- a/tests/test-browser-stream-encoder-close.mjs
+++ b/tests/test-browser-stream-encoder-close.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+
+// A closed encoder must not deliver another byte.
+//
+// close() destroyed stdin and SIGKILLed the process but left the stdout
+// listener attached, and neither of those stops delivery: what the kernel
+// pipe already holds is still read out and handed to onChunk (measured:
+// ~17 KB in 9 chunks after close returned). The stream server replaces an
+// encoder by closing the old one and spawning a new one onto the SAME sink,
+// so that tail was written to live viewers interleaved into the replacement's
+// output — slices referencing the dead encoder's parameter sets, which a
+// decoder can only fail on. That replacement happens on every viewer join and
+// every restart, so a viewport could go black right after reconnecting.
+//
+// Driven by a stub encoder binary (no ffmpeg), flooding stdout at the moment
+// of close so there is always something in flight to leak.
+//
+// Run: node --test tests/test-browser-stream-encoder-close.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { createH264Encoder } from "../plugins/agent-id-browser/lib/stream-encoder.mjs";
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Stands in for ffmpeg: answers the encoder probe, then writes Annex-B access
+// units as fast as the pipe takes them, so the kernel pipe buffer is full when
+// the test closes the encoder.
+const FFMPEG_STUB = `#!/usr/bin/env node
+if (process.argv.includes("-encoders")) {
+  process.stdout.write(" V....D libx264 stub\\n");
+  process.exit(0);
+}
+const aud = Buffer.from([0, 0, 0, 1, 0x09, 0x10]);
+const slice = Buffer.concat([Buffer.from([0, 0, 0, 1, 0x65]), Buffer.alloc(8 * 1024, 0x41)]);
+const unit = Buffer.concat([aud, slice]);
+process.stdin.resume();
+process.stdout.on("error", () => process.exit(0));
+setInterval(() => { for (let i = 0; i < 8; i++) process.stdout.write(unit); }, 1);
+`;
+
+function writeFfmpegStub() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "stream-close-stub-"));
+  const stub = path.join(dir, "ffmpeg-stub.mjs");
+  fs.writeFileSync(stub, FFMPEG_STUB, { mode: 0o755 });
+  return { dir, stub };
+}
+
+test("no chunk reaches the caller after close() returns", async () => {
+  const { dir, stub } = writeFfmpegStub();
+  let closed = false;
+  const after = { chunks: 0, bytes: 0 };
+  let before = 0;
+
+  const enc = await createH264Encoder({
+    ffmpegPath: stub,
+    log: () => {},
+    onChunk: (chunk) => {
+      if (closed) {
+        after.chunks++;
+        after.bytes += chunk.length;
+      } else before++;
+    },
+  });
+
+  try {
+    // Feed it like the stream server does, and wait until output is flowing —
+    // the leak only exists while the encoder is mid-stream.
+    const deadline = Date.now() + 10000;
+    while (before === 0 && Date.now() < deadline) {
+      enc.write(Buffer.alloc(1024, 0xff));
+      await sleep(20);
+    }
+    assert.ok(before > 0, "the stub encoder is producing output at close time");
+
+    closed = true;
+    enc.close();
+
+    // Long enough for the pipe drain the old code kept delivering.
+    await sleep(500);
+    assert.equal(
+      after.chunks,
+      0,
+      `no onChunk after close (got ${after.chunks} chunks, ${after.bytes} bytes)`,
+    );
+
+    // Idempotent: a second close must not throw or resurrect delivery.
+    enc.close();
+    await sleep(100);
+    assert.equal(after.chunks, 0, "still nothing after a second close");
+  } finally {
+    enc.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## The defect

`createH264Encoder` attaches a `data` listener to the encoder process's stdout and forwards every chunk to `onChunk`. `close()` destroyed stdin and `SIGKILL`ed the process — but left that listener attached, and neither of those stops delivery: whatever the kernel pipe already holds is still read out and handed to `onChunk` after `close()` has returned.

Measured on a real encoder: **17,535 bytes in 9 chunks after `close()`**. The test in this PR, driven by a stub that is flooding stdout at the moment of close, measures **65,536 bytes in 1 chunk** on the unfixed code (a full pipe buffer).

## Why it matters

The stream server replaces an encoder by closing the old one and creating a replacement, with the **same** send closure as `onChunk` for both. So a dead encoder's trailing output is written to the same viewer sockets, interleaved into the replacement's stream, carrying slices that reference the *old* encoder's parameter sets. A decoder can only fail on those.

That replacement runs on every cast start — every viewer join, retarget, resume and watchdog restart — which makes it a prime suspect for a viewport that goes black immediately after a reconnect.

## The fix

`close()` detaches the stdout listener **before** killing the process, and is idempotent.

Deliberately unchanged:

- **`onExit` still fires after an explicit `close()`** (the process `close` event is untouched). Both call sites already ignore that callback for an encoder they replaced on purpose — the WS path guards with `if (annexB !== enc) return;`, the WebRTC path with `if (peers.get(client) !== peer || !peer.enc) return;` — so suppressing it would change nothing they rely on, and keeping it preserves the documented contract ("calls `onExit()` once when the process dies for any reason").
- **The RTP path is unaffected.** With `rtp` set, `stdio[1]` is `"ignore"`, so there is no stdout, no listener, and nothing to detach; the added code is `null` on that path.

## Test

`tests/test-browser-stream-encoder-close.mjs` — a stub encoder binary (no ffmpeg, always runs on CI, same pattern as the other stream tests) writes Annex-B access units as fast as the pipe accepts them. The test waits until output is flowing, calls `close()`, then asserts no `onChunk` call happens afterwards, and that a second `close()` is a no-op.

Verified as a gate — with the fix reverted:

```
✖ no chunk reaches the caller after close() returns (755.090291ms)
  AssertionError [ERR_ASSERTION]: no onChunk after close (got 1 chunks, 65536 bytes)
  1 !== 0
```

Full suite green with the fix: `751 pass, 0 fail`.

## Interaction with #113

#113 (`fix/h264-access-unit-framing`) edits the same two spots in `lib/stream-encoder.mjs`, so it conflicts textually. **#113 merges first**; resolve on this branch by keeping #113's framer and naming its push handler so it can be detached:

```js
const framer = rtp
  ? null
  : createAccessUnitFramer({ onAccessUnit: (au) => onChunk?.(au), log });
const onStdout = framer ? (chunk) => framer.push(chunk) : null;
if (onStdout) proc.stdout.on("data", onStdout);
```

and in `close()`:

```js
close() {
  if (closed) return;
  closed = true;
  alive = false;
  if (onStdout) proc.stdout.off("data", onStdout);
  framer?.close();
  try { proc.stdin.destroy(); } catch { /* already gone */ }
  try { proc.kill("SIGKILL"); } catch { /* already dead */ }
},
```

The two fixes are complementary rather than overlapping: #113's `framer.close()` drops a *partial* buffered unit, but with the listener still attached the post-close pipe drain would push *complete* units through the framer and out to the sink. Detaching the listener is what closes that path. #113's other files (`h264-framer.mjs`, `stream-server.mjs`, its test) do not conflict with anything here.

## Left alone

- The `alive`/`writable` input-side flags and the frame-dropping behaviour of `write()`.
- The `onExit` restart logic in the stream server and the WebRTC teardown path.
- The stdout stream itself is not destroyed — the process is killed and the listener detached, which is sufficient and keeps the diff minimal.
