### PR TITLE
fix(browser): encode every frame instead of resampling to a fixed rate

### DIFF
--- a/.changeset/encoder-fps-passthrough.md
+++ b/.changeset/encoder-fps-passthrough.md
@@ -1,0 +1,7 @@
+---
+"@alien-id/agent-id-browser": patch
+---
+
+Encode every frame instead of resampling to a fixed rate — the demuxer's
+nominal 25 fps became a constant output rate and ffmpeg dropped every
+screencast frame that missed the grid (78 frames in, 2 encoded).

--- a/plugins/agent-id-browser/lib/stream-encoder.mjs
+++ b/plugins/agent-id-browser/lib/stream-encoder.mjs
@@ -211,6 +211,9 @@ export async function createH264Encoder({ onChunk, onExit, log = () => {}, rtp =
       // 0 bytes out). Dimensions come from the first JPEG's SOF either way.
       "-analyzeduration", "0", "-probesize", "32",
       "-f", "mjpeg", "-use_wallclock_as_timestamps", "1", "-i", "pipe:0",
+      // The demuxer's nominal 25 fps becomes a constant output rate, and a
+      // screencast repaints on no grid: measured 78 frames in, 2 encoded.
+      "-fps_mode", "passthrough",
       "-an", ...codecArgs(encoder), ...output,
     ],
     { stdio: ["pipe", rtp ? "ignore" : "pipe", "pipe"] },

--- a/tests/test-browser-stream-encoder-fps.mjs
+++ b/tests/test-browser-stream-encoder-fps.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+// The demuxer's nominal 25 fps becomes a constant output rate, so ffmpeg drops
+// every screencast frame that misses the grid — measured 78 frames in, 2
+// encoded, then silence. The argv is the contract: the drop is inside ffmpeg.
+//
+// Run: node --test tests/test-browser-stream-encoder-fps.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { createH264Encoder } from "../plugins/agent-id-browser/lib/stream-encoder.mjs";
+
+const FFMPEG_STUB = `#!/usr/bin/env node
+if (process.argv.includes("-encoders")) {
+  process.stdout.write(" V....D libx264 stub\\n");
+  process.exit(0);
+}
+require("node:fs").writeFileSync(process.env.ARGV_SINK, JSON.stringify(process.argv.slice(2)));
+process.stdin.resume();
+`;
+
+function stub(dir) {
+  const file = path.join(dir, "ffmpeg-stub.cjs");
+  fs.writeFileSync(file, FFMPEG_STUB, { mode: 0o755 });
+  return file;
+}
+
+test("the encoder passes frames through instead of resampling them to a fixed rate", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "agentid-fps-"));
+  const sink = path.join(dir, "argv.json");
+  process.env.ARGV_SINK = sink;
+  const enc = await createH264Encoder({ onChunk: () => {}, ffmpegPath: stub(dir) });
+  try {
+    for (let i = 0; i < 100 && !fs.existsSync(sink); i++) {
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    const argv = JSON.parse(fs.readFileSync(sink, "utf8"));
+    const mode = argv[argv.indexOf("-fps_mode") + 1];
+    assert.equal(mode, "passthrough", `frame-rate conversion is on: ${argv.join(" ")}`);
+    assert.ok(argv.indexOf("-fps_mode") > argv.indexOf("-i"), "must be an output option");
+  } finally {
+    enc.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
The mjpeg demuxer's nominal 25 fps became a constant output rate, so ffmpeg dropped every screencast frame that missed the grid. Feeding the real binary two JPEGs at ~3 fps, as the stream server does:

```
78 frames in:  frame=2   drop=70  →     31 330 bytes
with the fix:  frame=72  drop=0   →  1 001 388 bytes
```

H.264 viewers got the first frame and nothing after; JPEG was unaffected because it never passes through the encoder.

The test pins the argv — the drop happens inside ffmpeg.