### PR TITLE
fix(browser): align scaled-session pointer input by measuring the live displacement

### DIFF
--- a/.changeset/scaled-pointer-alignment.md
+++ b/.changeset/scaled-pointer-alignment.md
@@ -1,0 +1,15 @@
+---
+"@alien-id/agent-id-browser": patch
+---
+
+Align scaled-session pointer input with the captured frame. On some hosts an
+active device-metrics override (a `scale ≥ 2` viewer) leaves CDP-dispatched
+pointer coordinates in a different space than the picture: the frame is
+correct, wheel and keyboard work, but a click lands at roughly 1/scale of the
+intended point — on nothing, or on the wrong element. The displacement is
+host-specific (headless mac and Linux Chromium dispatch cleanly through the
+same override), so the stream server now measures it on the live page instead
+of deriving it from platform assumptions: one probe mousemove per cast epoch
+reports where the page actually saw the pointer, and every subsequent pointer
+coordinate is pre-scaled by the inverse. On aligned hosts the probe measures
+identity and the correction disables itself.

--- a/plugins/agent-id-browser/lib/stream-server.mjs
+++ b/plugins/agent-id-browser/lib/stream-server.mjs
@@ -263,6 +263,71 @@ export function parseStreamParams(url) {
 
 const KEY_ALIASES = { " ": "Space" };
 
+// ── Pointer alignment for scaled sessions ────────────────────────────────────
+//
+// A host has been observed where, with the scaled session's device-metrics
+// override active, CDP-dispatched pointer coordinates land in a DIFFERENT
+// space than the captured frame: the picture is correct, wheel and keyboard
+// work (they are position-insensitive), but a press/release pair lands at
+// roughly 1/scale of the intended point — so taps click nothing, or the
+// wrong element. The displacement does not reproduce on every host (headless
+// mac and Linux Chromium dispatch cleanly through the same override), so the
+// transform is MEASURED on the live page rather than derived from platform
+// assumptions: one probe mousemove reports where the page actually saw it,
+// and every subsequent pointer coordinate is pre-scaled by the inverse.
+// Identity within tolerance disables the correction — on a well-behaved host
+// this is a no-op beyond the single probe.
+//
+// The probe is a plain mousemove (the same event class every pan already
+// emits), sent once per cast epoch and only while a scale override is
+// active; hover side effects are the same as any viewer moving their finger.
+
+const CAL_PROBE_PX = 64;
+const CAL_TOLERANCE = 0.02;
+
+// Exported for tests: measure where the page sees a probe mousemove.
+// Returns {fx, fy} when the pointer space is displaced, null for identity
+// (or when the page cannot run the probe — no correction is safer than a
+// guessed one).
+export async function calibratePointer(page) {
+  try {
+    await page.evaluate(() => {
+      window.__aibPtrCal = null;
+      window.addEventListener(
+        "mousemove",
+        (e) => {
+          window.__aibPtrCal = { x: e.clientX, y: e.clientY };
+        },
+        { capture: true, once: true },
+      );
+    });
+    await page.mouse.move(CAL_PROBE_PX, CAL_PROBE_PX);
+    let seen = null;
+    for (let attempt = 0; attempt < 10 && !seen; attempt++) {
+      seen = await page.evaluate(() => window.__aibPtrCal);
+      if (!seen) await new Promise((r) => setTimeout(r, 30));
+    }
+    await page.evaluate(() => {
+      delete window.__aibPtrCal;
+    });
+    if (!seen || !(seen.x > 0) || !(seen.y > 0)) return null;
+    const fx = seen.x / CAL_PROBE_PX;
+    const fy = seen.y / CAL_PROBE_PX;
+    if (Math.abs(fx - 1) <= CAL_TOLERANCE && Math.abs(fy - 1) <= CAL_TOLERANCE) return null;
+    return { fx, fy };
+  } catch {
+    return null;
+  }
+}
+
+// Exported for tests: pre-scale a pointer message by the inverse of the
+// measured displacement so it lands where the viewer aimed. Wheel deltas are
+// scroll amounts, not positions — only x/y are corrected.
+export function withPointerCal(msg, cal) {
+  if (!cal || msg.type !== "input_mouse") return msg;
+  return { ...msg, x: Number(msg.x) / cal.fx, y: Number(msg.y) / cal.fy };
+}
+
 // Exported for tests: the input contract is only observable here.
 export async function applyInput(page, msg) {
   if (msg.type === "input_mouse") {
@@ -925,6 +990,11 @@ export async function startStreamServer(
   let castChain = Promise.resolve();
   let castEpoch = 0;
   let castOverride = false; // the CURRENT cast session applied a device-metrics override
+  // Pointer-space calibration, keyed to the cast epoch: the override (and any
+  // displacement it brings) lives exactly as long as the cast session, so a
+  // retarget/resize/restart naturally re-measures.
+  let pointerCal = null;
+  let pointerCalEpoch = -1;
 
   function stopScreencast() {
     castChain = castChain.then(stopScreencastNow).catch(() => {});
@@ -1322,10 +1392,18 @@ export async function startStreamServer(
       // Queue, don't fire-and-forget: the suspend/page checks re-run at apply
       // time so a fill starting mid-queue still blacks out the queued tail.
       inputChain = inputChain
-        .then(() => {
+        .then(async () => {
           if (suspended > 0) return;
           const page = state.current;
           if (!page || page.isClosed?.()) return;
+          if (msg.type === "input_mouse" && castOverride) {
+            if (pointerCalEpoch !== castEpoch) {
+              // Stamp first: a probe that fails must not re-run per event.
+              pointerCalEpoch = castEpoch;
+              pointerCal = await calibratePointer(page);
+            }
+            msg = withPointerCal(msg, pointerCal);
+          }
           return applyInput(page, msg);
         })
         // Malformed input used to disappear here: the viewer sent something

--- a/plugins/agent-id-browser/lib/stream-server.mjs
+++ b/plugins/agent-id-browser/lib/stream-server.mjs
@@ -1406,6 +1406,14 @@ export async function startStreamServer(
               // Stamp first: a probe that fails must not re-run per event.
               pointerCalEpoch = castEpoch;
               pointerCal = await calibratePointer(page);
+              // The measured factor is the one fact that decides whether every
+              // subsequent click is corrected — a host where it silently
+              // measures wrong would look exactly like the original bug.
+              log(
+                pointerCal
+                  ? `stream: pointer calibration measured fx=${pointerCal.fx.toFixed(4)} fy=${pointerCal.fy.toFixed(4)}, correcting input`
+                  : "stream: pointer calibration measured identity, no correction",
+              );
             }
             msg = withPointerCal(msg, pointerCal);
           }

--- a/plugins/agent-id-browser/lib/stream-server.mjs
+++ b/plugins/agent-id-browser/lib/stream-server.mjs
@@ -293,12 +293,17 @@ export async function calibratePointer(page) {
   try {
     await page.evaluate(() => {
       window.__aibPtrCal = null;
+      // isTrusted only: a page could dispatch a synthetic mousemove at a
+      // chosen position to poison the calibration and redirect the viewer's
+      // clicks. CDP-dispatched input is trusted; page JS can never be.
       window.addEventListener(
         "mousemove",
-        (e) => {
+        function probe(e) {
+          if (!e.isTrusted) return;
           window.__aibPtrCal = { x: e.clientX, y: e.clientY };
+          window.removeEventListener("mousemove", probe, true);
         },
-        { capture: true, once: true },
+        { capture: true },
       );
     });
     await page.mouse.move(CAL_PROBE_PX, CAL_PROBE_PX);

--- a/tests/test-stream-input-cal.mjs
+++ b/tests/test-stream-input-cal.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+
+// Tests for the scaled-session pointer calibration: the probe measurement
+// (calibratePointer) and the inverse correction (withPointerCal). Driven
+// against a stub page — the displacement itself is host-specific, so what is
+// testable here is the contract: a displaced probe produces the inverse
+// transform, an identity probe produces no correction, and a page that
+// cannot run the probe degrades to no correction rather than a guessed one.
+//
+// Run: node --test tests/test-stream-input-cal.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { calibratePointer, withPointerCal } from "../plugins/agent-id-browser/lib/stream-server.mjs";
+
+// A stub page whose pointer space is displaced by `factor`: the page "sees"
+// every dispatched move at dispatched×factor, the way the affected host
+// delivers them. evaluate() is called by the calibrator three ways —
+// install listener, read the captured point, clean up — modeled by call
+// order, which is exactly how the real page experiences it.
+function stubPage(factor) {
+  let moved = null;
+  let calls = 0;
+  return {
+    moves: [],
+    mouse: {
+      move(x, y) {
+        moved = { x, y };
+        return Promise.resolve();
+      },
+      down() {
+        return Promise.resolve();
+      },
+      up() {
+        return Promise.resolve();
+      },
+    },
+    evaluate() {
+      calls++;
+      if (calls === 1) return Promise.resolve(undefined); // listener install
+      if (moved && calls >= 2 && this.__cleaned !== true) {
+        return Promise.resolve({ x: moved.x * factor, y: moved.y * factor });
+      }
+      return Promise.resolve(undefined);
+    },
+  };
+}
+
+test("a displaced pointer space yields the measured factors", async () => {
+  const cal = await calibratePointer(stubPage(0.5));
+  assert.ok(cal, "displacement must be detected");
+  assert.ok(Math.abs(cal.fx - 0.5) < 1e-9 && Math.abs(cal.fy - 0.5) < 1e-9, `got ${JSON.stringify(cal)}`);
+});
+
+test("an aligned pointer space yields no correction", async () => {
+  assert.equal(await calibratePointer(stubPage(1)), null);
+});
+
+test("a page that cannot run the probe yields no correction", async () => {
+  const hostile = {
+    mouse: { move: () => Promise.resolve() },
+    evaluate() {
+      return Promise.reject(new Error("Execution context was destroyed"));
+    },
+  };
+  assert.equal(await calibratePointer(hostile), null);
+});
+
+test("withPointerCal pre-scales pointer coordinates by the inverse", () => {
+  const cal = { fx: 0.5, fy: 0.5 };
+  const out = withPointerCal({ type: "input_mouse", eventType: "mousePressed", x: 100, y: 200 }, cal);
+  assert.equal(out.x, 200);
+  assert.equal(out.y, 400);
+  assert.equal(out.eventType, "mousePressed");
+});
+
+test("withPointerCal leaves non-pointer messages and identity untouched", () => {
+  const key = { type: "input_keyboard", eventType: "char", text: "a" };
+  assert.equal(withPointerCal(key, { fx: 0.5, fy: 0.5 }), key);
+  const mouse = { type: "input_mouse", eventType: "mouseMoved", x: 10, y: 20 };
+  assert.equal(withPointerCal(mouse, null), mouse);
+});
+
+test("wheel deltas survive correction untouched — only the position moves", () => {
+  const wheel = { type: "input_mouse", eventType: "mouseWheel", x: 100, y: 100, deltaX: 3, deltaY: -24 };
+  const out = withPointerCal(wheel, { fx: 0.5, fy: 0.5 });
+  assert.equal(out.x, 200);
+  assert.equal(out.y, 200);
+  assert.equal(out.deltaX, 3);
+  assert.equal(out.deltaY, -24);
+});


### PR DESCRIPTION
Closes #121.

## What

On some hosts, the scaled session's device-metrics override leaves CDP-dispatched pointer coordinates in a different space than the captured frame: the picture is right, wheel and keyboard work (position-insensitive), but clicks land at ~1/scale of the aimed point — on nothing, or on the wrong element. Details and the A/B evidence: #121.

The stream server now **measures** the displacement on the live page instead of assuming any platform behavior:

- `calibratePointer(page)` — once per cast epoch, while a scale override is active: installs a one-shot `mousemove` listener, dispatches one probe move through the same `page.mouse` path every real event uses, and reads back where the page actually saw it. Identity within 2% → `null` (no correction). A page that cannot run the probe (mid-navigation, JS-hostile) also yields `null` — no correction is safer than a guessed one.
- `withPointerCal(msg, cal)` — pre-scales pointer `x`/`y` by the inverse of the measured factors. Wheel **deltas** are scroll amounts, not positions, and stay untouched.
- The input chain applies both only for `input_mouse` while `castOverride` is active, keyed to the cast epoch — a retarget, resize or cast restart naturally re-measures. The calibration stamp is written before the probe so a failing probe never re-runs per event.

## Why measure instead of derive

The displacement reproduces on the affected host and on none of the controlled testbeds (mac headless; Linux headed under Xvfb incl. undersized screens; the faithful launch→resize→override sequence — full list in #121). A derived platform-conditional correction would be wrong somewhere; a measured one is identity exactly where the host is well-behaved, so the risk on healthy hosts is one extra mousemove per cast epoch — the same event class every viewer pan already emits.

## Tests

`tests/test-stream-input-cal.mjs` (6): a displaced stub page yields the measured factors; an aligned page yields no correction; a probe-hostile page yields no correction; the inverse pre-scaling on pointer coordinates; non-pointer messages and identity untouched; wheel deltas survive with only the position corrected. Mutation-checked: inverting the correction direction turns the suite red.

Full `npm test`: 782/783 — the one failure is `the refinement's flush copy is the same frame, not another input`, which is flaky on pristine `origin/main` too (fails ~1 run in 3 both there and here; timing-driven, unrelated to this change).

## Verification on the affected host

Pending a release: the affected host runs the published package, so the calibration's live factor can only be confirmed after this ships. On every controlled testbed the probe measures identity and the change is a no-op.