### PR TITLE
fix(browser): close a live session before sealing a login

### DIFF
--- a/.changeset/quiet-daemons-keep-logins.md
+++ b/.changeset/quiet-daemons-keep-logins.md
@@ -1,0 +1,27 @@
+---
+"@alien-id/agent-id-browser": patch
+---
+
+Sealing a login no longer loses it to a live session daemon
+
+`auto-login` (and headed `login`) sealed the new session into the vault while a
+daemon opened earlier on the same profile kept running. That daemon holds the
+copy it unsealed at `open` time, so the next `open` reused it and showed the
+login form, and its eventual close re-sealed that stale, logged-out copy over
+the fresh login. Seen end to end: auto-login reported `logged-in`, `open main`
+was still logged out, and the login was gone after the close.
+
+Both commands now close a live session on the target profile first and wait for
+its re-seal to finish (`closeLiveSession`). The success payload carries
+`closedLiveSession` so the caller knows to open the profile again.
+
+Also:
+
+- `classifyLogin` recognizes Russian rejection copy («Пользователь не найден или
+  неверный пароль», «Неверный логин или пароль», «Ошибка авторизации»). A
+  rejection it could not read degraded to `unknown` every round, and the login
+  ended as `timeout` / `owner_must_drive` — the owner was sent to the browser
+  for a wrong password.
+- `AUTO_LOGIN_FAILED` carries `trace` (what the engine saw each round: password
+  field present or gone, challenge widget, URL) and `pageError` (the page's
+  visible error copy), so a failure is diagnosable from the payload alone.

--- a/plugins/agent-id-browser/bin/cli.mjs
+++ b/plugins/agent-id-browser/bin/cli.mjs
@@ -56,7 +56,7 @@ import { installCodecs, loadCodecConfig } from "../lib/stream-encoder.mjs";
 import { escalationFor } from "../lib/escalation.mjs";
 import { autoLogin } from "../lib/auto-login.mjs";
 import { looksLoggedOut } from "../lib/session.mjs";
-import { runSession, callSession, pruneDeadSessions } from "../lib/session-server.mjs";
+import { runSession, callSession, closeLiveSession, pruneDeadSessions } from "../lib/session-server.mjs";
 import { hasOwnerApproval, unlockViaOwnerApproval } from "../lib/unlock.mjs";
 import {
   ACCESS_LEVELS,
@@ -290,6 +290,10 @@ async function cmdLogin(flags) {
       // one cookie jar — sign into Google once and every "Sign in with Google" site
       // reuses it. `--fresh` discards the existing session and starts clean.
       const existing = vault.get(name);
+      // Same hazard as auto-login: a live daemon would re-seal its stale copy
+      // over this login on close. Close it first (and wait for its reseal) so
+      // the profile we unseal below is the latest one.
+      await closeLiveSession(stateDir, name, { log: stderr });
       const resuming =
         flags.fresh !== true &&
         existing &&
@@ -456,13 +460,29 @@ async function cmdAutoLogin(flags) {
     const dek = reuse ? reuse.dek : newDek();
     const headless = resolveHeadless(flags) ?? true;
 
+    // A live daemon on the target profile would keep serving its pre-login
+    // copy and re-seal it over ours on close. See closeLiveSession.
+    const closedLiveSession = await closeLiveSession(stateDir, targetProfile, { log: stderr });
+
     const work = await fs.mkdtemp(path.join(os.tmpdir(), "agentid-autologin-"));
     try {
       const ctx = await launchContext({ profileDir: work, headless });
       let result;
+      // What the engine saw, round by round — the failure report carries it so
+      // a wrong password is distinguishable from a changed form or a redirect
+      // that was never awaited. Never includes a secret.
+      const trace = [];
       try {
         const page = ctx.pages()[0] || (await ctx.newPage());
-        result = await autoLogin({ page, cred, env: process.env, log: (m) => stderr(m) });
+        result = await autoLogin({
+          page,
+          cred,
+          env: process.env,
+          log: (m) => {
+            stderr(m);
+            trace.push(m);
+          },
+        });
       } finally {
         // Close so the context flushes cookies/storage to the work dir before sealing.
         await ctx.close().catch(() => {});
@@ -485,6 +505,8 @@ async function cmdAutoLogin(flags) {
           reason,
           profile: targetProfile,
           finalUrl: result ? result.finalUrl : null,
+          ...(result && result.errorText ? { pageError: result.errorText } : {}),
+          trace,
           message,
         });
         process.exitCode = 1;
@@ -520,7 +542,12 @@ async function cmdAutoLogin(flags) {
         finalUrl: result.finalUrl,
         access: sessionAccess,
         sealedBytes: bytes,
-        message: `Logged in and sealed session '${targetProfile}'. Reuse it: \`read --name ${targetProfile} --url …\`.`,
+        closedLiveSession,
+        message:
+          `Logged in and sealed session '${targetProfile}'. Reuse it: \`read --name ${targetProfile} --url …\`.` +
+          (closedLiveSession
+            ? ` The '${targetProfile}' session that was open has been closed; open it again to use the new login.`
+            : ""),
       });
     } finally {
       await fs.rm(work, { recursive: true, force: true });

--- a/plugins/agent-id-browser/lib/auto-login.mjs
+++ b/plugins/agent-id-browser/lib/auto-login.mjs
@@ -253,8 +253,27 @@ async function detectPageState(page) {
     // Language-independent block signal: a visible challenge widget. Fed to
     // classifyLogin via its `blocked` input so it wins over "logged-in".
     const blocked = all(challengeSel).some(visible);
-    return { hasPasswordField, hasOtpField, otpFieldNames, bodyText, blocked };
+    // The page's own error/alert copy, surfaced verbatim in a failure report so
+    // a rejection the classifier cannot read is still visible to the caller.
+    const errorText =
+      all('[role="alert"], [aria-live="assertive"], [class*="error" i], [class*="alert" i], [class*="invalid" i]')
+        .filter(visible)
+        .map((e) => (e.innerText || "").trim())
+        .filter(Boolean)
+        .join(" | ")
+        .slice(0, 300) || null;
+    return { hasPasswordField, hasOtpField, otpFieldNames, bodyText, blocked, errorText };
   }, CHALLENGE_WIDGET_SEL);
+}
+
+// One line of page state for the trace: what the classifier saw, never any
+// secret (field values are not read).
+function describeState(s) {
+  const bits = [`pw=${s.hasPasswordField ? "visible" : "gone"}`];
+  if (s.hasOtpField) bits.push("otp-field");
+  if (s.blocked) bits.push("challenge-widget");
+  if (s.errorText) bits.push(`error="${s.errorText.slice(0, 120)}"`);
+  return bits.join(" ");
 }
 
 // Best-effort fill of the OTP field, then submit.
@@ -474,12 +493,15 @@ export async function autoLogin({
   }
   await page.waitForTimeout(settleMs);
 
+  let errorText = null;
   for (let round = 0; round < maxRounds; round++) {
-    const outcome = classifyLogin(await detectPageState(page));
-    log(`auto-login: ${outcome}`);
+    const state = await detectPageState(page);
+    const outcome = classifyLogin(state);
+    errorText = state.errorText || errorText;
+    log(`auto-login: round ${round + 1}/${maxRounds} ${outcome} (${describeState(state)}) at ${page.url()}`);
     // A bot-block / human-verification wall never clears by waiting — stop and
     // report it (the caller advises a headed login, which a human can clear).
-    if (outcome === "blocked") return { ok: false, outcome: "blocked", finalUrl: page.url() };
+    if (outcome === "blocked") return { ok: false, outcome: "blocked", finalUrl: page.url(), errorText };
     if (outcome === "logged-in") {
       // Positive confirmation: the form is gone AND we've left the login page.
       // Without this, a vanished password field on a block/challenge or SPA
@@ -489,7 +511,7 @@ export async function autoLogin({
       }
       log("auto-login: form cleared but still on the login page — awaiting redirect");
     } else if (outcome === "failed") {
-      return { ok: false, outcome, finalUrl: page.url() };
+      return { ok: false, outcome, finalUrl: page.url(), errorText };
     } else if (outcome === "confirm-on-device") {
       // Nothing to type: the owner approves on their own device and the page
       // advances by itself. Tell them once, then poll until it does. This is
@@ -514,5 +536,5 @@ export async function autoLogin({
     }
     await page.waitForTimeout(settleMs); // unknown / unconfirmed — settle, re-check
   }
-  return { ok: false, outcome: "timeout", finalUrl: page.url() };
+  return { ok: false, outcome: "timeout", finalUrl: page.url(), errorText };
 }

--- a/plugins/agent-id-browser/lib/escalation.mjs
+++ b/plugins/agent-id-browser/lib/escalation.mjs
@@ -84,8 +84,10 @@ export function escalationFor(outcome, { credName = "", profile = "" } = {}) {
         message:
           `Auto-login for '${credName}' did not complete (${outcome}). This is common for ` +
           "big-IdP sign-in (Google, Microsoft), which refuses automated credential entry. " +
-          `Ask the owner to sign in once in the browser view for profile '${profile}'; the ` +
-          "session then seals and later visits are headless.",
+          "Read `trace` and `pageError` first: a rejection message there means the stored " +
+          "credential is wrong (fix it), not that a human is needed. Otherwise ask the owner " +
+          `to sign in once in the browser view for profile '${profile}'; the session then ` +
+          "seals and later visits are headless.",
       };
   }
 }

--- a/plugins/agent-id-browser/lib/login-detect.mjs
+++ b/plugins/agent-id-browser/lib/login-detect.mjs
@@ -47,9 +47,14 @@ const OTP_BODY_RE =
 const CONFIRM_BODY_RE =
   /(check your phone|tap (?:yes|\d{1,3})\b|approve (?:this |the )?sign[- ]?in|sent a (?:notification|prompt) to|open the .{0,24}app on your|confirm (?:it.?s|its) you on your|2-step verification.*(?:notification|prompt))/i;
 
-// Body / inline text that signals the credentials were rejected.
+// Body / inline text that signals the credentials were rejected. English plus
+// Russian: a datacenter-hosted browser gets the page in the site's language,
+// and a rejection it cannot read degrades to `unknown` → `timeout` →
+// `owner_must_drive`, which sends the owner to a browser for what is really a
+// wrong password (seen on lk.eneva.ru: «Пользователь не найден или неверный
+// пароль»). Keep each phrase specific to a failed sign-in.
 const ERROR_RE =
-  /(incorrect|invalid|wrong password|that password|couldn.?t (?:sign|log) ?you in|try again|doesn.?t match|not recognized|too many attempts|account.*lock)/i;
+  /(incorrect|invalid|wrong password|that password|couldn.?t (?:sign|log) ?you in|try again|doesn.?t match|not recognized|too many attempts|account.*lock|неверн[а-яё]*\s+(?:логин|парол|имя|номер|данные|код)|неправильн[а-яё]*\s+(?:логин|парол|имя|номер|данные)|пользователь не найден|не найден или неверн|ошибка (?:входа|авторизации|аутентификации)|попробуйте (?:ещё|еще) раз|слишком много попыток|учетн[а-яё]* запись заблокирована)/i;
 
 // Bot-block / human-verification interstitial copy. DISTINCT from ERROR_RE: these
 // describe an anti-automation wall (network-security block, CAPTCHA, rate limit),

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -1852,6 +1852,58 @@ export async function runSession({
   return { port };
 }
 
+// Close a live session daemon for `name` (if any) and wait until it has
+// re-sealed its profile and exited. Returns true when a session was closed,
+// false when none was open.
+//
+// Every command that SEALS a profile (`login`, `auto-login`) must call this
+// first. A daemon holds an unsealed copy of the profile taken at `open` time,
+// and `finalize()` re-seals that copy on close — so sealing a fresh login
+// underneath a live daemon is lost twice over: the next `open` reuses the
+// running daemon (never re-reading the vault), and its eventual close writes
+// the stale, logged-out copy back over the new session. Observed end to end:
+// auto-login reported `logged-in`, `open` of the same profile showed the login
+// form, and the sealed login was gone after the close.
+//
+// Waiting for the session FILE to disappear is what makes this safe: finalize()
+// removes it only after the reseal, so once it is gone the profile file is
+// stable and ours to overwrite. A stale file (daemon died without finalize) is
+// removed so the next open does not keep trying to reach it.
+export async function closeLiveSession(stateDir, name, { log = () => {}, timeoutMs = 30000 } = {}) {
+  const file = sessionFilePath(stateDir, name);
+  let info = null;
+  try {
+    info = JSON.parse(await fs.readFile(file, "utf8"));
+  } catch {
+    return false;
+  }
+  log(`Closing the open '${name}' session (pid ${info.pid ?? "?"}) so the new login is not overwritten by its stale copy.`);
+  try {
+    await callSession(stateDir, name, "close", {}, timeoutMs);
+  } catch (err) {
+    if (err && err.code === "NO_SESSION") {
+      await fs.rm(file, { force: true }).catch(() => {});
+      return false;
+    }
+    throw err;
+  }
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      await fs.access(file);
+    } catch {
+      return true;
+    }
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  const e = new Error(
+    `session '${name}' did not finish closing within ${Math.round(timeoutMs / 1000)}s — ` +
+      "its re-seal would race the new login; retry once it is gone (`sessions` lists it)",
+  );
+  e.code = "SESSION_BUSY";
+  throw e;
+}
+
 // Client: send one action to a running session, return its JSON reply.
 export async function callSession(stateDir, name, action, params = {}, timeoutMs = 35000) {
   let info = null;

--- a/plugins/agent-id-browser/skills/agent-id-browser/SKILL.md
+++ b/plugins/agent-id-browser/skills/agent-id-browser/SKILL.md
@@ -145,6 +145,17 @@ decides what you do next. There are exactly three:
 Never answer `owner_must_drive` by asking for a password. An account created
 through "Sign in with Google" has none, so the owner cannot give you one.
 
+A failure also carries `trace` (what the engine saw each round: password field
+present or gone, challenge widget, URL) and `pageError` (the page's own error
+copy). Read them before acting on `action`: a rejection message there means the
+credential is wrong, whatever the site's language.
+
+`auto-login` and `login` **close an open session on the target profile first**
+(the payload says `closedLiveSession: true`). A daemon opened earlier keeps the
+copy it unsealed at `open` time and re-seals it on close, so sealing a new login
+underneath it would be lost. After a successful auto-login, `open` the profile
+again to use the new session.
+
 **Domain allowlist (security):** a `login` credential is only typed into hosts on
 its `domains` list (default-deny, the same control the proxy enforces); a foreign
 origin is **refused**, and a sealed in-vault-generated secret can never be typed

--- a/tests/test-browser-close-live-session.mjs
+++ b/tests/test-browser-close-live-session.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+// closeLiveSession (lib/session-server.mjs): the guard every profile-sealing
+// command runs first. A fake daemon stands in for the real one — a TCP server
+// that answers `close` and then removes its session file the way finalize()
+// does after re-sealing — so the ordering contract is tested without a browser.
+//
+// Run: node --test tests/test-browser-close-live-session.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import net from "node:net";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { closeLiveSession, sessionFilePath } from "../plugins/agent-id-browser/lib/session-server.mjs";
+
+async function tmpStateDir() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "aib-close-live-"));
+  await fs.mkdir(path.join(dir, "browser-sessions"), { recursive: true });
+  return dir;
+}
+
+// A daemon that acknowledges `close`, then (after `resealMs`) removes its
+// session file — the observable end of finalize()'s reseal.
+async function fakeDaemon(stateDir, name, { resealMs = 300 } = {}) {
+  const token = "t0k";
+  const received = [];
+  const server = net.createServer((sock) => {
+    let buf = "";
+    sock.on("data", (d) => {
+      buf += d.toString("utf8");
+      const nl = buf.indexOf("\n");
+      if (nl < 0) return;
+      const msg = JSON.parse(buf.slice(0, nl));
+      received.push(msg);
+      if (msg.token !== token) {
+        sock.end(JSON.stringify({ ok: false, error: "bad token" }) + "\n");
+        return;
+      }
+      sock.end(JSON.stringify({ ok: true, closed: true }) + "\n");
+      setTimeout(() => {
+        fs.rm(sessionFilePath(stateDir, name), { force: true }).then(() => server.close());
+      }, resealMs).unref();
+    });
+  });
+  await new Promise((r) => server.listen(0, "127.0.0.1", r));
+  const { port } = server.address();
+  await fs.writeFile(
+    sessionFilePath(stateDir, name),
+    JSON.stringify({ port, token, pid: process.pid, headless: true, startedAt: 1 }),
+  );
+  return { received, server };
+}
+
+test("closeLiveSession: no session file → false, nothing to do", async () => {
+  const stateDir = await tmpStateDir();
+  assert.equal(await closeLiveSession(stateDir, "main"), false);
+});
+
+test("closeLiveSession: sends close and returns only after the session file is gone", async () => {
+  const stateDir = await tmpStateDir();
+  const daemon = await fakeDaemon(stateDir, "main", { resealMs: 400 });
+  const logs = [];
+  const t0 = Date.now();
+  const closed = await closeLiveSession(stateDir, "main", { log: (m) => logs.push(m) });
+  assert.equal(closed, true);
+  assert.equal(daemon.received.length, 1);
+  assert.equal(daemon.received[0].action, "close");
+  // Returned after the file was removed (the reseal), not on the ack.
+  assert.ok(Date.now() - t0 >= 350, "waited for the daemon's reseal to finish");
+  await assert.rejects(fs.access(sessionFilePath(stateDir, "main")));
+  assert.ok(logs.some((m) => m.includes("Closing the open 'main' session")));
+});
+
+test("closeLiveSession: a stale session file (daemon gone) is removed and reports false", async () => {
+  const stateDir = await tmpStateDir();
+  // Grab a port that nothing listens on.
+  const probe = net.createServer();
+  await new Promise((r) => probe.listen(0, "127.0.0.1", r));
+  const { port } = probe.address();
+  await new Promise((r) => probe.close(r));
+  await fs.writeFile(
+    sessionFilePath(stateDir, "main"),
+    JSON.stringify({ port, token: "x", pid: 1, headless: true, startedAt: 1 }),
+  );
+  assert.equal(await closeLiveSession(stateDir, "main"), false);
+  await assert.rejects(fs.access(sessionFilePath(stateDir, "main")));
+});
+
+test("closeLiveSession: a daemon that never finishes closing is an error, not a silent race", async () => {
+  const stateDir = await tmpStateDir();
+  const daemon = await fakeDaemon(stateDir, "main", { resealMs: 60_000 });
+  await assert.rejects(closeLiveSession(stateDir, "main", { timeoutMs: 600 }), (err) => err.code === "SESSION_BUSY");
+  daemon.server.close();
+});

--- a/tests/test-login-detect.mjs
+++ b/tests/test-login-detect.mjs
@@ -184,3 +184,31 @@ test("blocked outranks a device prompt", () => {
     "blocked",
   );
 });
+
+test("failed: a Russian rejection is read as a bad credential, not `unknown`", () => {
+  // lk.eneva.ru — without this the password field stays, every round is
+  // `unknown`, and the result is a `timeout` blamed on the owner.
+  assert.equal(
+    classifyLogin({
+      hasPasswordField: true,
+      bodyText: "Вход в Личный кабинет\nПользователь не найден или неверный пароль\nВойти",
+    }),
+    "failed",
+  );
+  assert.equal(
+    classifyLogin({ hasPasswordField: true, errorText: "Неверный логин или пароль" }),
+    "failed",
+  );
+  assert.equal(
+    classifyLogin({ hasPasswordField: true, bodyText: "Ошибка авторизации. Попробуйте ещё раз." }),
+    "failed",
+  );
+});
+
+test("Russian body copy without a rejection does not trip the error match", () => {
+  assert.equal(
+    classifyLogin({ hasPasswordField: true, bodyText: "Вход в Личный кабинет\nНомер договора\nПароль\nВойти" }),
+    "unknown",
+  );
+  assert.equal(classifyLogin({ hasPasswordField: false, bodyText: "Добро пожаловать, Иван" }), "logged-in");
+});


### PR DESCRIPTION
## Problem

`auto-login` (and headed `login`) seal the new session into the vault while a daemon opened earlier on the **same profile** keeps running. That daemon holds the copy it unsealed at `open` time, so:

1. the next `open` reuses the running daemon (the host's `spawn_daemon_ready` returns `reused:true`) and never re-reads the vault → the login form is still there;
2. the daemon's `finalize()` re-seals its stale, logged-out copy over the fresh login when it eventually closes.

Seen end to end on `lk.eneva.ru` (develop, 2026-08-26 UTC): `open main` 16:47:25 → `vault_add` → `auto-login --name main` 16:50:40 **ok, `logged-in`** → `open main` 16:50:53 (2 s, no spawn — the `session=main` stream counters never stopped) → login form.

A second, independent issue made the first attempt undiagnosable: a wrong password produced `AUTO_LOGIN_FAILED: timeout` / `owner_must_drive`. The site's rejection copy is Russian («Пользователь не найден или неверный пароль»), `ERROR_RE` is English-only, so every round classified as `unknown`, and the CLI's stderr diagnostics are discarded by the host once stdout parses as JSON.

## Fix

- **`closeLiveSession(stateDir, name)`** (`lib/session-server.mjs`): send `close` to a live daemon and wait until its session file is gone — `finalize()` removes it only after the reseal, so the profile file is stable before we overwrite it. A stale file (daemon gone) is removed; a daemon that won't finish is a `SESSION_BUSY` error, not a silent race. `auto-login` and `login` call it first; the success payload carries `closedLiveSession` so the caller knows to `open` again.
- **`classifyLogin`** recognizes Russian rejection copy → `failed` / `fix_credential`. (`\w` is ASCII-only in JS regexes; the Cyrillic stems use an explicit class.)
- **`AUTO_LOGIN_FAILED`** carries `trace` (per round: outcome, password field visible/gone, challenge widget, URL) and `pageError` (the page's visible alert/error copy). The `timeout` escalation message points the agent at them before it sends the owner to a browser.
- `SKILL.md` documents both behaviours; changeset: patch for `@alien-id/agent-id-browser`.

## Tests

- New `tests/test-browser-close-live-session.mjs`: fake daemon — returns only after the "reseal" (file removal), stale-file cleanup, busy timeout.
- `tests/test-login-detect.mjs`: Russian rejections → `failed`; Russian non-error copy stays `unknown` / `logged-in`.
- Full suite: 614/615. The one failure, `vault migration v4 → v5` (`test-vault-migrate.mjs`), fails identically on a clean `main` worktree — pre-existing, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
