### PR TITLE
Fix what a live sign-in found wrong with the code card

### DIFF
--- a/.changeset/passwordless-login-and-recipe-allowlist.md
+++ b/.changeset/passwordless-login-and-recipe-allowlist.md
@@ -33,14 +33,29 @@ could not be filled truthfully.
   redirects through once it has been driven, and the alternative was remove +
   re-add, which asks the owner for the secret again.
 - One run answers a code challenge twice at most, then reports `otp-rejected`.
-  A six-digit code read off a phone under a thirty-second clock is mistyped or
-  outrun often enough that one shot is the wrong budget; the retry card is a
-  short one (2 min) and says the previous code was refused, so the owner reads
-  the current one instead of retyping. For a stored seed the retry waits out the
-  time window first — within one period the seed produces the same digits, so an
-  immediate retry resubmits exactly what was just refused. Re-asking a human for a code the site has already
-  refused is both useless and unaffordable: the card waits ten minutes and the
-  host kills the process at sixteen.
+  A code is mistyped or outrun often enough that one shot is the wrong budget;
+  the retry card says the previous code was refused, so the owner reads the
+  current one instead of retyping. For a stored seed the retry waits out the time
+  window first — within one period the seed produces the same digits, so an
+  immediate retry resubmits exactly what was just refused. Re-asking a human for
+  a code the site has already refused is both useless and unaffordable: the first
+  card waits ten minutes and the host kills the process at sixteen.
+- The retry card is sized by where the code comes from. A generated one is read
+  off a device the owner is already holding, so its retry is a glance (2 min); a
+  mailed one sends them back to the mailbox, and two minutes expired on a live
+  sign-in with the owner still fetching it (4 min). Neither can be a second
+  full-length card — the host's sixteen-minute ceiling covers the whole run, page
+  work included.
+- An unanswered code card is reported as an `otp-timeout` outcome instead of
+  throwing. The error used to travel straight out of auto-login, so the caller
+  learned nothing about where the browser stopped — and it had stopped somewhere
+  useful, on the code screen, where a fresh code still finishes the job. The
+  escalation says as much: the credential is fine, and no password is missing.
+- The code field is not masked. Every other value this vault collects is, and for
+  a password or a token that is right — it is long-lived, reusable, and the owner
+  already knows what they typed. A code is none of those: single-use, dead in
+  minutes, and copied by hand out of a mail client, which is exactly the
+  transcription whose slips the dots would hide.
 - `login` no longer falls back to `domains: ["*"]`. `"*"` is a not-applicable
   placeholder that matches no host, so that default minted credentials which
   could never be typed anywhere.

--- a/plugins/agent-id-browser/lib/auto-login.mjs
+++ b/plugins/agent-id-browser/lib/auto-login.mjs
@@ -258,12 +258,26 @@ export async function runRecipe(
 // factor, not a second one — a card headed "2FA code" would be telling the owner
 // something untrue about the account they are signing into. Pure; exported so the
 // wording is testable without standing up a prompt provider.
-// The first card waits for someone who may be away from the screen; the retry does
-// not, because it only ever follows a card they just answered. Sized so both fit
-// under the host's own ceiling: 10 + 2 is under lethe's 16-minute HUMAN_TIMEOUT,
-// where 10 + 10 is not — which is the whole reason a retry is affordable at all.
+// The first card waits for someone who may be away from the screen. What the retry
+// waits for depends on where the code comes from, and the two are not comparable:
+// a generated code is read off a device the owner is already holding, so the retry
+// is a glance, while a mailed one sends them back to the mailbox for a second trip.
+// Measured on a live Booking.com run, where a two-minute retry expired with the
+// owner still fetching the mail.
+//
+// Both budgets are bounded by the same thing — lethe's 16-minute HUMAN_TIMEOUT
+// (`src/agent_id/cli.rs`) kills the whole auto-login subprocess, cards, navigation
+// and settles included. That is what rules out a second full-length card: 10 + 4
+// leaves room for the page work either side, where 10 + 10 does not.
 const OTP_CARD_MS = 10 * 60 * 1000;
-const OTP_RETRY_CARD_MS = 2 * 60 * 1000;
+const OTP_GLANCE_RETRY_CARD_MS = 2 * 60 * 1000;
+const OTP_MAILBOX_RETRY_CARD_MS = 4 * 60 * 1000;
+
+export function otpCardBudgetMs(cred, { retry = false } = {}) {
+  if (!retry) return OTP_CARD_MS;
+
+  return cred.otp === "totp" ? OTP_GLANCE_RETRY_CARD_MS : OTP_MAILBOX_RETRY_CARD_MS;
+}
 
 export function otpPromptWording(cred, { retry = false } = {}) {
   const host = cred.loginUrl ? hostOf(cred.loginUrl) : "";
@@ -319,7 +333,7 @@ export async function resolveOtp(cred, { env = process.env, log = () => {}, now,
       fields: [{ name: "otp", label: wording.label }],
       label: wording.ask,
       security: "Used once to complete sign-in; never stored or shown to the agent.",
-      timeoutMs: retry ? OTP_RETRY_CARD_MS : OTP_CARD_MS,
+      timeoutMs: otpCardBudgetMs(cred, { retry }),
     },
     { env },
   );

--- a/plugins/agent-id-browser/lib/auto-login.mjs
+++ b/plugins/agent-id-browser/lib/auto-login.mjs
@@ -671,13 +671,16 @@ export async function autoLogin({
   // spending them here would report a timeout while the owner is still walking
   // to the desk.
   confirmWaitMs = 180000,
+  // Injected the same way runRecipe takes `driver`: the code card is a ten-minute
+  // wait on a human, which no test can afford to take literally.
+  resolveOtpFn = resolveOtp,
 }) {
   if (!cred.loginUrl) throw new Error(`login '${cred.name}': loginUrl is required for auto-login`);
   // The whole run — warmup, the login page, every recipe step — happens on the
   // credential's own origins. Checked once here so a loginUrl pointing off the
   // allowlist fails before a browser goes anywhere, not after.
   assertHostAllowed(hostOf(cred.loginUrl), cred.domains, "loginUrl: refusing");
-  const getOtp = (retry) => resolveOtp(cred, { env, log, retry });
+  const getOtp = (retry) => resolveOtpFn(cred, { env, log, retry });
   // One run answers a code challenge twice at most, and the second attempt is
   // deliberately cheap.
   //
@@ -718,13 +721,25 @@ export async function autoLogin({
   await page.goto(cred.loginUrl, { waitUntil: "domcontentloaded", timeout: 30000 });
   await page.waitForTimeout(settleMs);
 
+  let errorText = null;
+  // An unanswered code card is the owner walking away, not a broken sign-in: the
+  // site is waiting at a screen a fresh code can still clear. Reporting it as an
+  // outcome keeps the run's shape — a caller that gets an exception here learns
+  // nothing about where the browser stopped, and the profile is sealed anyway.
+  const otpTimedOut = () => ({ ok: false, outcome: "otp-timeout", finalUrl: page.url(), errorText });
+
   if (Array.isArray(cred.recipe) && cred.recipe.length) {
-    await runRecipe(page, cred.recipe, {
-      username: cred.username,
-      password: cred.password,
-      getOtp,
-      domains: cred.domains,
-    });
+    try {
+      await runRecipe(page, cred.recipe, {
+        username: cred.username,
+        password: cred.password,
+        getOtp,
+        domains: cred.domains,
+      });
+    } catch (err) {
+      if (err?.code !== "FORM_TIMEOUT") throw err;
+      return otpTimedOut();
+    }
   } else if (await detectMicrosoftFlow(page)) {
     // Microsoft ADFS / Entra: stable element IDs the heuristic can't drive.
     await microsoftLogin(page, cred, log);
@@ -733,7 +748,6 @@ export async function autoLogin({
   }
   await page.waitForTimeout(settleMs);
 
-  let errorText = null;
   for (let round = 0; round < maxRounds; round++) {
     const onLoginPage = stillOnLoginPage(page.url(), cred.loginUrl);
     const state = { ...(await detectPageState(page)), onLoginPage };
@@ -806,7 +820,12 @@ export async function autoLogin({
         await page.waitForTimeout(millisToNextTotpWindow(cred));
       }
       otpAsks += 1;
-      await typeOtp(page, await getOtp(retry));
+      try {
+        await typeOtp(page, await getOtp(retry));
+      } catch (err) {
+        if (err?.code !== "FORM_TIMEOUT") throw err;
+        return otpTimedOut();
+      }
       await page.waitForTimeout(settleMs);
       continue;
     }

--- a/plugins/agent-id-browser/lib/auto-login.mjs
+++ b/plugins/agent-id-browser/lib/auto-login.mjs
@@ -324,20 +324,34 @@ export async function resolveOtp(cred, { env = process.env, log = () => {}, now,
       ...(now != null ? { now } : {}),
     });
   }
-  const wording = otpPromptWording(cred, { retry });
-  log(`Waiting for the ${wording.label.toLowerCase()} via the secure prompt…`);
-  const { values } = await collectSecret(
-    {
-      title: wording.title,
-      description: wording.description,
-      fields: [{ name: "otp", label: wording.label }],
-      label: wording.ask,
-      security: "Used once to complete sign-in; never stored or shown to the agent.",
-      timeoutMs: otpCardBudgetMs(cred, { retry }),
-    },
-    { env },
-  );
+  const spec = otpCardSpec(cred, { retry });
+  log(`Waiting for the ${spec.fields[0].label.toLowerCase()} via the secure prompt…`);
+  const { values } = await collectSecret(spec, { env });
+
   return String(values.otp || "").trim();
+}
+
+// The whole card an interactive code is asked for through, as a value. Pure, and
+// exported for the same reason `otpPromptWording` is: what the owner is shown is
+// worth asserting without standing up a prompt provider, and this is the one card
+// both auto-login and `fill_otp` raise.
+export function otpCardSpec(cred, { retry = false } = {}) {
+  const wording = otpPromptWording(cred, { retry });
+
+  return {
+    title: wording.title,
+    description: wording.description,
+    // Not masked, unlike every other value this vault collects. A code is
+    // single-use and dead within minutes, so there is no lasting secret for the
+    // dots to protect — and it is being copied by hand out of a mail client,
+    // which is exactly the transcription whose slips the dots would hide. A wrong
+    // code costs another round trip to the mailbox; watching it being typed
+    // costs nothing.
+    fields: [{ name: "otp", label: wording.label, secret: false }],
+    label: wording.ask,
+    security: "Used once to complete sign-in; never stored or shown to the agent.",
+    timeoutMs: otpCardBudgetMs(cred, { retry }),
+  };
 }
 
 // A visible CAPTCHA / anti-automation challenge WIDGET, matched by well-known

--- a/plugins/agent-id-browser/lib/escalation.mjs
+++ b/plugins/agent-id-browser/lib/escalation.mjs
@@ -102,6 +102,19 @@ export function escalationFor(outcome, { credName = "", profile = "" } = {}) {
           "Either way the password is FINE: do not re-check it and do not ask for one. " +
           "Run auto-login again once the cause is addressed.",
       };
+    // The code card expired unanswered — the owner was away, not the sign-in
+    // broken. The page is still sitting on the code screen, so the fix is a fresh
+    // code, and nothing about the credential is in doubt.
+    case "otp-timeout":
+      return {
+        action: OWNER_MUST_CONFIRM,
+        reason: "otp_not_entered",
+        message:
+          `Nobody entered the sign-in code for '${credName}' before the secure card expired. ` +
+          "The credential is FINE — do not re-add it, do not ask for a password, and do not " +
+          "assume the site refused anything. The code that was mailed has probably expired too, " +
+          "so ask the owner to be ready, then run auto-login again to have a fresh one sent.",
+      };
     // A code was demanded that the credential says it does not have. This is also
     // where a passwordless site lands when it was stored as an ordinary login, so
     // the message has to name that possibility: the agent is here precisely

--- a/tests/test-auto-login.mjs
+++ b/tests/test-auto-login.mjs
@@ -22,6 +22,7 @@ import {
   stillOnLoginPage,
   originOf,
   isDeepLoginUrl,
+  otpCardBudgetMs,
 } from "../plugins/agent-id-browser/lib/auto-login.mjs";
 import { generateTotp } from "../plugins/agent-id-core/lib/totp.mjs";
 
@@ -489,4 +490,28 @@ test("autoLogin does not dress every OTP failure up as a timeout", async () => {
     }),
     /totpSecret/,
   );
+});
+
+test("the retry card is sized by where the code comes from, not by the fact of retrying", () => {
+  const mailed = { name: "booking", otp: "interactive", passwordless: true };
+  const generated = { name: "gh", otp: "totp", totpSecret: "x" };
+
+  // A first card is the same either way: nobody knows whether the owner is there.
+  assert.equal(otpCardBudgetMs(mailed), otpCardBudgetMs(generated));
+
+  // A mailed code sends the owner back to the mailbox, so its retry cannot be
+  // sized like a glance at an authenticator already in their hand.
+  assert.ok(
+    otpCardBudgetMs(mailed, { retry: true }) > otpCardBudgetMs(generated, { retry: true }),
+    "a mailbox trip must outlast a glance",
+  );
+
+  // Both retries stay under lethe's 16-minute HUMAN_TIMEOUT once the first card
+  // has spent its own budget — that ceiling covers the whole subprocess, so a
+  // second full-length card would have the host kill the run mid-answer.
+  const HUMAN_TIMEOUT_MS = 16 * 60 * 1000;
+  for (const cred of [mailed, generated]) {
+    const total = otpCardBudgetMs(cred) + otpCardBudgetMs(cred, { retry: true });
+    assert.ok(total < HUMAN_TIMEOUT_MS, `${cred.otp}: ${total}ms leaves nothing for the page`);
+  }
 });

--- a/tests/test-auto-login.mjs
+++ b/tests/test-auto-login.mjs
@@ -23,6 +23,7 @@ import {
   originOf,
   isDeepLoginUrl,
   otpCardBudgetMs,
+  otpCardSpec,
 } from "../plugins/agent-id-browser/lib/auto-login.mjs";
 import { generateTotp } from "../plugins/agent-id-core/lib/totp.mjs";
 
@@ -514,4 +515,24 @@ test("the retry card is sized by where the code comes from, not by the fact of r
     const total = otpCardBudgetMs(cred) + otpCardBudgetMs(cred, { retry: true });
     assert.ok(total < HUMAN_TIMEOUT_MS, `${cred.otp}: ${total}ms leaves nothing for the page`);
   }
+});
+
+test("the code card does not mask what it asks for", () => {
+  const mailed = otpCardSpec({ name: "booking", otp: "interactive", loginUrl: "https://x.test/in" });
+  const generated = otpCardSpec({ name: "gh", otp: "interactive", loginUrl: "https://gh.test/in" }, { retry: true });
+
+  // Every other value this vault collects is masked by default — the code is the
+  // one that must opt out, and it has to hold on the retry card too, which is
+  // where a mistyped code lands in the first place.
+  for (const spec of [mailed, generated]) {
+    assert.equal(spec.fields.length, 1);
+    assert.equal(spec.fields[0].name, "otp");
+    assert.equal(spec.fields[0].secret, false, "a single-use code is not a lasting secret");
+  }
+});
+
+test("the code card never says '2FA' to someone who has no first factor", () => {
+  const passwordless = otpCardSpec({ name: "booking", otp: "interactive", passwordless: true, loginUrl: "https://x.test/in" });
+  assert.ok(!/2fa|two-factor/i.test(JSON.stringify(passwordless)), "this code IS the sign-in, not a second step");
+  assert.match(passwordless.fields[0].label, /sign-in code/i);
 });

--- a/tests/test-auto-login.mjs
+++ b/tests/test-auto-login.mjs
@@ -439,3 +439,54 @@ test("the retry card says the code was refused, so the owner reads a fresh one",
     /not accepted/,
   );
 });
+
+// ── An unanswered code card ends the run as an outcome, not an exception ─────────
+
+function formTimeout() {
+  const err = new Error("timed out waiting for the secure form to be submitted");
+  err.code = "FORM_TIMEOUT";
+  return err;
+}
+
+function recipePage(url) {
+  return { url: () => url, goto: async () => {}, waitForTimeout: async () => {} };
+}
+
+const OTP_FIRST_RECIPE = [{ action: "fill", selector: "#code", value: "{otp}" }];
+const PWLESS_CRED = {
+  name: "booking",
+  username: "u@example.test",
+  passwordless: true,
+  otp: "interactive",
+  loginUrl: "https://x.test/sign-in",
+  domains: ["x.test"],
+  recipe: OTP_FIRST_RECIPE,
+};
+
+test("autoLogin reports an expired code card as an outcome, so the caller learns where it stopped", async () => {
+  const result = await autoLogin({
+    page: recipePage("https://x.test/otp"),
+    cred: PWLESS_CRED,
+    resolveOtpFn: async () => {
+      throw formTimeout();
+    },
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.outcome, "otp-timeout");
+  assert.equal(result.finalUrl, "https://x.test/otp");
+});
+
+test("autoLogin does not dress every OTP failure up as a timeout", async () => {
+  // Only an unanswered card is an outcome. A credential that cannot produce a
+  // code at all is a fault, and swallowing it would report "nobody typed it".
+  await assert.rejects(
+    autoLogin({
+      page: recipePage("https://x.test/otp"),
+      cred: PWLESS_CRED,
+      resolveOtpFn: async () => {
+        throw new Error("login 'booking': otp=totp but no totpSecret stored");
+      },
+    }),
+    /totpSecret/,
+  );
+});

--- a/tests/test-escalation.mjs
+++ b/tests/test-escalation.mjs
@@ -107,3 +107,18 @@ test("qr-sign-in sends the owner to the browser view, because that is where the 
   assert.match(message, /browser view for profile 'telegram'/);
   assert.ok(!/Google, Microsoft/.test(message));
 });
+
+test("otp-timeout blames nobody's credential — the owner simply was not at the screen", () => {
+  const { action, reason, message } = escalationFor("otp-timeout", {
+    credName: "booking",
+    profile: "booking",
+  });
+  assert.equal(action, OWNER_MUST_CONFIRM);
+  assert.equal(reason, "otp_not_entered");
+  // The three wrong turns an agent takes from here: re-adding the credential,
+  // asking for a password a passwordless site does not have, and reading the
+  // silence as the site refusing the code.
+  assert.match(message, /do not re-add it/i);
+  assert.match(message, /do not ask for a password/i);
+  assert.match(message, /run auto-login again/i);
+});


### PR DESCRIPTION
Three fixes to the code card, all found by driving a real Booking.com sign-in end to end rather than by reading the code. The passwordless flow itself worked — one identifier card, the site mailed a code, one code card, `auth_success=1` — and these are what the run surfaced on the way.

**An unanswered card killed the run.** The card went unanswered for its ten minutes, secure-form rejected with `FORM_TIMEOUT`, and the error travelled straight out of `autoLogin`. The caller learned nothing about where the browser stopped — and it had stopped somewhere useful, on the code screen, where a fresh code still finishes the job. It is now an `otp-timeout` outcome. The catch stays narrow on purpose: a credential that cannot produce a code at all is a fault, and reporting that as "nobody typed it" sends the agent to reassure the owner instead of fixing the seed.

**The retry card was sized for the wrong person.** Two minutes was reasoned about as a glance — it only ever follows a card the owner just answered, so they are demonstrably at the screen. True for a code read off an authenticator already in their hand. Not true for a mailed one, where a wrong code means a second trip to the mailbox; that is exactly how it expired on the live run. Sized by source now (2 min generated, 4 min mailed), both still under the caller's own ceiling, which covers the whole run and is what rules out simply giving the retry a second full card.

**The code was masked.** Every other value this vault collects is, and for a password or a token that is right — long-lived, reusable, and the owner already knows what they typed. A code is none of those: single-use, dead in minutes, copied by hand out of a mail client. The dots protect nothing and hide the one thing worth seeing, which is whether the transcription is right. The live run mistyped a code under them.

## Notes for review

- `otpCardSpec` makes the card a value, exported for the same reason `otpPromptWording` already is: what the owner is shown is worth asserting without standing up a prompt provider. Both auto-login and `fill_otp` raise this one card, so the field decision holds for both.
- `resolveOtpFn` is injected into `autoLogin` the way `runRecipe` already takes `driver` — a ten-minute wait on a human is not something a test can take literally.
- The changeset edits the pending `passwordless-login-and-recipe-allowlist.md` rather than adding a new file: these belong to the same unreleased bump, and one of its bullets (the flat 2-minute retry) is what this PR revises. If the Version PR lands first, this becomes a new changeset file instead.
- Every test here was verified by breaking the code and watching it go red. Suite: 884 tests, 0 failures. `test-browser-stream-counters.mjs:644` flakes at roughly 50% independently of this work — measured on `dcb14d0`, the commit before #129 merged, and traced to a fixed 1400 ms wait that widening to 4000 ms clears.
