### PR TITLE
Name the site on the secure card, and say where the code went

### DIFF
--- a/.changeset/name-the-site-not-the-record.md
+++ b/.changeset/name-the-site-not-the-record.md
@@ -1,0 +1,31 @@
+---
+"@alien-id/agent-id-vault": minor
+"@alien-id/agent-id-browser": minor
+---
+
+Name the site on the secure card, and say where the code went.
+
+Three things a live Airbnb sign-in showed the owner, none of them true or useful.
+
+- **The card was titled with the credential's name.** The agent had named its
+  record `airbnb-passwordless-again`, and that reached the screen verbatim —
+  the owner was asked to "Add credential: airbnb-passwordless-again" while
+  looking at Airbnb's sign-in page. The name is the vault's key and the agent's
+  to choose; the title now names the site instead, taken from `loginUrl` or the
+  narrowest literal entry in `domains` (a wildcard names a family of hosts, not
+  a site). With nothing to derive a host from, the name is still better than
+  nothing. The same swap applies to the code card, which had the same fault.
+- **The identifier field promised a mailbox.** It was labelled
+  "Username / email" for every login, while Airbnb's own first screen says
+  "Phone number or email". The owner entered an address and waited for a letter
+  the site had sent as an SMS. A passwordless login now says "Email or phone
+  number"; a password login keeps the old label, where the field really can be a
+  username.
+- **The code card never said where the code went.** It read "airbnb.com sent
+  you a code", so the channel was left to be guessed. The page has already said
+  it — "We sent a code to +1 ••• ••• 4817" — and `codeDestination` reads that
+  back. It reads it back only when the captured text is recognisably an address,
+  a number, or a named place: naming the wrong channel is worse than naming
+  none, because it sends the owner somewhere the code is not and then convinces
+  them it never came. Unrecognised, the copy claims no channel and names both
+  places to look.

--- a/.changeset/name-the-site-not-the-record.md
+++ b/.changeset/name-the-site-not-the-record.md
@@ -29,3 +29,9 @@ Three things a live Airbnb sign-in showed the owner, none of them true or useful
   none, because it sends the owner somewhere the code is not and then convinces
   them it never came. Unrecognised, the copy claims no channel and names both
   places to look.
+- **The card never said a second one was coming.** The chat row renders the
+  description under the title, and for a passwordless login that line was
+  metadata (`login · www.airbnb.com`). Submitting the first card looks like
+  nothing happened — the site is off sending a code — so it now leads with "A
+  sign-in code follows on the next card". The access level stays on that line:
+  `ro` is a grant the owner is making while they type.

--- a/plugins/agent-id-browser/lib/auto-login.mjs
+++ b/plugins/agent-id-browser/lib/auto-login.mjs
@@ -37,8 +37,8 @@
 import { generateTotp } from "@alien-id/agent-id-core/lib/totp.mjs";
 import { collectSecret } from "@alien-id/agent-id-core/lib/secure-prompt.mjs";
 import { notifyHost } from "@alien-id/agent-id-core/lib/notice.mjs";
-import { assertHostAllowed } from "@alien-id/agent-id-vault/lib/store.mjs";
-import { classifyLogin } from "./login-detect.mjs";
+import { assertHostAllowed, credentialHost } from "@alien-id/agent-id-vault/lib/store.mjs";
+import { classifyLogin, codeDestination } from "./login-detect.mjs";
 import { humanClick, humanDriver, humanType } from "./human-input.mjs";
 
 // Type a secret (password / OTP) with human cadence, guarding against a
@@ -279,28 +279,37 @@ export function otpCardBudgetMs(cred, { retry = false } = {}) {
   return cred.otp === "totp" ? OTP_GLANCE_RETRY_CARD_MS : OTP_MAILBOX_RETRY_CARD_MS;
 }
 
-export function otpPromptWording(cred, { retry = false } = {}) {
-  const host = cred.loginUrl ? hostOf(cred.loginUrl) : "";
+export function otpPromptWording(cred, { retry = false, destination = null } = {}) {
+  // The site, never the credential's name: `airbnb-passwordless-again` names the
+  // agent's second attempt, and the owner is looking at Airbnb.
+  const site = credentialHost({ loginUrl: cred.loginUrl, domains: cred.domains }) || cred.name;
   // A retry card has to say why it is there. Without it the owner sees the same
   // prompt twice and cannot tell a refused code from a lost one — and for a
   // time-based code the right move is to read the CURRENT one, not retype the
   // one they just sent.
   const retryNote = retry ? "That code was not accepted — enter the current one. " : "";
+  // Where the code went, in the site's own words, or nothing. Naming the wrong
+  // channel sends the owner to an inbox the code was never sent to and then
+  // convinces them it never arrived — so with no destination the copy claims no
+  // channel and names both places to look.
+  const sentence = destination
+    ? `${site} sent a code to ${destination} — enter it to finish signing in`
+    : `${site} sent you a code — check your email or messages, then enter it here`;
   if (cred.passwordless) {
     return {
-      title: `Sign-in code for ${cred.name}`,
-      description: host
-        ? `${retryNote}${host} just sent you a code — enter it to finish signing in`
-        : retryNote.trim(),
+      title: `Sign-in code for ${site}`,
+      description: `${retryNote}${sentence}`,
       label: "Sign-in code",
-      ask: `enter the sign-in code for "${cred.name}"`,
+      ask: `enter the sign-in code for ${site}`,
     };
   }
   return {
-    title: `2FA code for ${cred.name}`,
-    description: host ? `${retryNote}Sign-in to ${host} needs your current code` : retryNote.trim(),
+    title: `2FA code for ${site}`,
+    description: destination
+      ? `${retryNote}${site} sent a code to ${destination} — enter it to finish signing in`
+      : `${retryNote}Sign-in to ${site} needs your current code`,
     label: "Current 2FA code",
-    ask: `enter the 2FA code for "${cred.name}"`,
+    ask: `enter the 2FA code for ${site}`,
   };
 }
 
@@ -313,7 +322,10 @@ export function millisToNextTotpWindow(cred, now = Date.now()) {
 
 // Resolve the one-time code for a `login` credential: generate it from a stored
 // seed, or ask the human over the secure-prompt channel.
-export async function resolveOtp(cred, { env = process.env, log = () => {}, now, retry = false } = {}) {
+export async function resolveOtp(
+  cred,
+  { env = process.env, log = () => {}, now, retry = false, destination = null } = {},
+) {
   if (cred.otp === "totp") {
     if (!cred.totpSecret) throw new Error(`login '${cred.name}': otp=totp but no totpSecret stored`);
     return generateTotp({
@@ -324,7 +336,7 @@ export async function resolveOtp(cred, { env = process.env, log = () => {}, now,
       ...(now != null ? { now } : {}),
     });
   }
-  const spec = otpCardSpec(cred, { retry });
+  const spec = otpCardSpec(cred, { retry, destination });
   log(`Waiting for the ${spec.fields[0].label.toLowerCase()} via the secure prompt…`);
   const { values } = await collectSecret(spec, { env });
 
@@ -335,8 +347,8 @@ export async function resolveOtp(cred, { env = process.env, log = () => {}, now,
 // exported for the same reason `otpPromptWording` is: what the owner is shown is
 // worth asserting without standing up a prompt provider, and this is the one card
 // both auto-login and `fill_otp` raise.
-export function otpCardSpec(cred, { retry = false } = {}) {
-  const wording = otpPromptWording(cred, { retry });
+export function otpCardSpec(cred, { retry = false, destination = null } = {}) {
+  const wording = otpPromptWording(cred, { retry, destination });
 
   return {
     title: wording.title,
@@ -708,7 +720,7 @@ export async function autoLogin({
   // credential's own origins. Checked once here so a loginUrl pointing off the
   // allowlist fails before a browser goes anywhere, not after.
   assertHostAllowed(hostOf(cred.loginUrl), cred.domains, "loginUrl: refusing");
-  const getOtp = (retry) => resolveOtpFn(cred, { env, log, retry });
+  const getOtp = (retry, destination) => resolveOtpFn(cred, { env, log, retry, destination });
   // One run answers a code challenge twice at most, and the second attempt is
   // deliberately cheap.
   //
@@ -849,7 +861,9 @@ export async function autoLogin({
       }
       otpAsks += 1;
       try {
-        await typeOtp(page, await getOtp(retry));
+        // The code screen has just told us where it sent the code; the card is
+        // the only place that says so to the owner.
+        await typeOtp(page, await getOtp(retry, codeDestination(state.bodyText)));
       } catch (err) {
         if (err?.code !== "FORM_TIMEOUT") throw err;
         return otpTimedOut();

--- a/plugins/agent-id-browser/lib/login-detect.mjs
+++ b/plugins/agent-id-browser/lib/login-detect.mjs
@@ -225,4 +225,36 @@ export function classifyLogin({
   return "unknown";
 }
 
+// ─── Where the code went ──────────────────────────────────────────────────────
+// The card asking for a code has to say where to look for it. Airbnb texted one
+// to a phone while the card said only "airbnb.com sent you a code"; the owner
+// watched a mail inbox and concluded nothing had arrived.
+//
+// The page has already said it — "We sent a code to +1 ••• ••• 4817" — so this
+// reads that back instead of guessing. And it reads it back ONLY when the
+// captured text is recognisably a destination: naming the wrong channel is worse
+// than naming none, because it sends the owner somewhere the code is not and
+// then convinces them it never came. Anything unrecognised fails closed to null,
+// and the card falls back to wording that claims no channel at all.
+const SENT_TO_RE =
+  /\b(?:sent|texted|e-?mailed|messaged)\b[^.\n]{0,40}?\bto\s+(.{2,38}?)(?=[,;!?\n]|\.(?:\s|$)|\s{2,}|$)/i;
+const EMAIL_DESTINATION_RE = /^[^\s@]{1,32}@[^\s@]{2,32}$/;
+// Digits as a site masks them: bullets, stars, dots, dashes, parens, a leading +.
+const PHONE_DESTINATION_RE = /^[+()\d\s.*\u00b7\u2022\u2026-]{4,26}$/;
+const NAMED_DESTINATION_RE =
+  /^your\s+(?:e-?mail(?:\s+address)?|phone(?:\s+number)?|mobile|messages|device)$/i;
+
+export function codeDestination(bodyText) {
+  const match = SENT_TO_RE.exec(String(bodyText || ""));
+  if (!match) return null;
+
+  const target = match[1].trim().replace(/\s+/g, " ");
+  const recognised =
+    EMAIL_DESTINATION_RE.test(target) ||
+    PHONE_DESTINATION_RE.test(target) ||
+    NAMED_DESTINATION_RE.test(target);
+
+  return recognised ? target : null;
+}
+
 export { OTP_FIELD_RE, OTP_BODY_RE, CONFIRM_BODY_RE, MAGIC_LINK_RE, QR_SIGN_IN_RE, ERROR_RE, BLOCK_RE };

--- a/plugins/agent-id-browser/lib/login-detect.mjs
+++ b/plugins/agent-id-browser/lib/login-detect.mjs
@@ -238,7 +238,12 @@ export function classifyLogin({
 // and the card falls back to wording that claims no channel at all.
 const SENT_TO_RE =
   /\b(?:sent|texted|e-?mailed|messaged)\b[^.\n]{0,40}?\bto\s+(.{2,38}?)(?=[,;!?\n]|\.(?:\s|$)|\s{2,}|$)/i;
-const EMAIL_DESTINATION_RE = /^[^\s@]{1,32}@[^\s@]{2,32}$/;
+const EMAIL_DESTINATION_RE = /^[\w.+•·*…-]{1,32}@[\w.•·*…-]{2,32}$/;
+// The captured text is written by the page and ends up in a card the owner trusts.
+// The loopback form escapes it, but the hosted prompt hands `description` on as it
+// is, so nothing that could be read as markup gets that far: a destination is an
+// address, a number or a named place, and none of those contain these.
+const MARKUP_RE = /[<>&"'\\]/;
 // Digits as a site masks them: bullets, stars, dots, dashes, parens, a leading +.
 const PHONE_DESTINATION_RE = /^[+()\d\s.*\u00b7\u2022\u2026-]{4,26}$/;
 const NAMED_DESTINATION_RE =
@@ -249,6 +254,8 @@ export function codeDestination(bodyText) {
   if (!match) return null;
 
   const target = match[1].trim().replace(/\s+/g, " ");
+  if (MARKUP_RE.test(target)) return null;
+
   const recognised =
     EMAIL_DESTINATION_RE.test(target) ||
     PHONE_DESTINATION_RE.test(target) ||

--- a/plugins/agent-id-vault/bin/cli.mjs
+++ b/plugins/agent-id-vault/bin/cli.mjs
@@ -73,6 +73,7 @@ import {
 import { CREDENTIAL_TYPES, SECRET_FIELDS, validateRecord } from "../lib/store.mjs";
 import {
   ACCESS_LEVELS,
+  credentialHost,
   effectiveAccess,
   isAccessRelaxation,
   isAccessRestricted,
@@ -266,6 +267,18 @@ async function cmdInit(flags) {
 // Secret fields each type needs from the out-of-band form (--form). Non-secret
 // metadata (header/param/cookie name, token endpoint, client id) still comes from
 // flags; only the secret VALUE is typed by the human into the browser form.
+// What the owner reads at the top of the secure card. Never the credential's
+// `name`: that is an internal key the agent picks, and it reached the screen
+// verbatim — someone was asked to "Add credential: airbnb-passwordless-again",
+// which names the agent's second attempt rather than the site in front of them.
+// With no host to show, the name is still better than nothing.
+function formTitle({ name, type, loginUrl, domains }) {
+  const host = credentialHost({ loginUrl, domains });
+  if (!host) return `Add credential: ${name}`;
+
+  return type === "login" ? `Sign in to ${host}` : `Add credential for ${host}`;
+}
+
 function formFieldsForType(type, flags) {
   switch (type) {
     case "bearer": return [{ name: "value", label: "Token / bearer value" }];
@@ -284,7 +297,16 @@ function formFieldsForType(type, flags) {
       { name: "refresh-token", label: "Refresh token" },
     ];
     case "login": return [
-      { name: "username", label: "Username / email", secret: false },
+      // A passwordless site takes whatever it can mail or text a code to, and
+      // Airbnb's first screen says so outright ("Phone number or email"). The
+      // owner read "Username / email", entered a mail address, and waited for a
+      // letter the site had sent as an SMS. A password site keeps the old label:
+      // there the field really can be a username.
+      {
+        name: "username",
+        label: flags.passwordless ? "Email or phone number" : "Username / email",
+        secret: false,
+      },
       // A passwordless site has none to store — the only secret is the code that
       // arrives out of band, collected at sign-in time rather than here. That
       // leaves this form a single field, which is the whole point.
@@ -377,7 +399,7 @@ async function cmdAdd(flags) {
       // collectSecret routes through the secure-prompt resolver (browser form →
       // /dev/tty → hosted harness), so this works where no GUI browser is present.
       const out = await collectSecret({
-        title: `Add credential: ${name}`,
+        title: formTitle({ name, type, loginUrl: flags["login-url"], domains }),
         // Show the access level so the human sees the grant they are making
         // while typing the secret ("ro" = the agent can read, never write).
         description: `${type} · ${domains.join(", ")}${access === "ro" ? " · access: READ-ONLY" : ""}`,

--- a/plugins/agent-id-vault/bin/cli.mjs
+++ b/plugins/agent-id-vault/bin/cli.mjs
@@ -400,9 +400,18 @@ async function cmdAdd(flags) {
       // /dev/tty → hosted harness), so this works where no GUI browser is present.
       const out = await collectSecret({
         title: formTitle({ name, type, loginUrl: flags["login-url"], domains }),
-        // Show the access level so the human sees the grant they are making
-        // while typing the secret ("ro" = the agent can read, never write).
-        description: `${type} · ${domains.join(", ")}${access === "ro" ? " · access: READ-ONLY" : ""}`,
+        // The chat row renders this under the title, so it is the one line that
+        // can set an expectation. A passwordless card is step one of two and
+        // nothing visibly happens when it is submitted — without saying so, the
+        // owner enters an address and waits for a screen that is waiting for them.
+        // The access level stays: "ro" is a grant they are making while they type.
+        description: [
+          flags.passwordless ? "A sign-in code follows on the next card" : null,
+          `${type} · ${domains.join(", ")}`,
+          access === "ro" ? "access: READ-ONLY" : null,
+        ]
+          .filter(Boolean)
+          .join(" · "),
         fields: specs,
         label: `enter the "${name}" secret`,
         security:

--- a/plugins/agent-id-vault/bin/cli.mjs
+++ b/plugins/agent-id-vault/bin/cli.mjs
@@ -401,12 +401,15 @@ async function cmdAdd(flags) {
       const out = await collectSecret({
         title: formTitle({ name, type, loginUrl: flags["login-url"], domains }),
         // The chat row renders this under the title, so it is the one line that
-        // can set an expectation. A passwordless card is step one of two and
-        // nothing visibly happens when it is submitted — without saying so, the
-        // owner enters an address and waits for a screen that is waiting for them.
+        // can set an expectation, and a passwordless card gives the owner nothing
+        // to type but an identifier. Saying WHEN the code is asked for rather than
+        // promising a card next: storing a credential and driving the sign-in are
+        // separate calls, and the second may be minutes away or never come.
         // The access level stays: "ro" is a grant they are making while they type.
         description: [
-          flags.passwordless ? "A sign-in code follows on the next card" : null,
+          type === "login" && flags.passwordless
+            ? "Identifier only — the sign-in code is asked for at sign-in"
+            : null,
           `${type} · ${domains.join(", ")}`,
           access === "ro" ? "access: READ-ONLY" : null,
         ]

--- a/plugins/agent-id-vault/lib/access.mjs
+++ b/plugins/agent-id-vault/lib/access.mjs
@@ -84,9 +84,11 @@ export function assertHostAllowed(host, domains, what) {
 // owner was asked to "Add credential: airbnb-passwordless-again", which names the
 // agent's second attempt rather than the site they are signing in to.
 //
-// `loginUrl` wins because it is the exact page. Failing that, the narrowest thing
-// the allowlist offers: a wildcard entry names a family of hosts, not a site, so
-// it is skipped rather than shown with its star.
+// `loginUrl` wins because it is the exact page. Failing that, the allowlist's
+// first literal entry — a wildcard names a family of hosts rather than a site, so
+// it is skipped rather than shown with its star. First, not narrowest: `domains`
+// is written broadest-first by every caller that writes it, and a title reads
+// better as the site than as the subdomain a sign-in happens to redirect through.
 export function credentialHost({ loginUrl, domains } = {}) {
   if (loginUrl) {
     try {

--- a/plugins/agent-id-vault/lib/access.mjs
+++ b/plugins/agent-id-vault/lib/access.mjs
@@ -77,6 +77,37 @@ export function assertHostAllowed(host, domains, what) {
   );
 }
 
+// ─── Naming a credential on screen ────────────────────────────────────────────
+// The site a credential belongs to. There is exactly one place a human reads it:
+// the title of the secure card they are about to type into. The stored `name` is
+// an internal key the agent invents, and it reached that title verbatim — an
+// owner was asked to "Add credential: airbnb-passwordless-again", which names the
+// agent's second attempt rather than the site they are signing in to.
+//
+// `loginUrl` wins because it is the exact page. Failing that, the narrowest thing
+// the allowlist offers: a wildcard entry names a family of hosts, not a site, so
+// it is skipped rather than shown with its star.
+export function credentialHost({ loginUrl, domains } = {}) {
+  if (loginUrl) {
+    try {
+      const host = new URL(loginUrl).hostname;
+      if (host) return withoutWww(host);
+    } catch {
+      // Not a URL we can read — fall through to the allowlist.
+    }
+  }
+
+  const literal = (domains || []).find((entry) => typeof entry === "string" && entry && !entry.includes("*"));
+
+  return literal ? withoutWww(literal) : null;
+}
+
+// `www.` names the same site and only costs the reader a word. Every other
+// subdomain stays: `account.booking.com` is where the sign-in actually lives.
+function withoutWww(host) {
+  return host.replace(/^www\./i, "");
+}
+
 // The level in force for a record — absent means unrestricted ("rw").
 export function effectiveAccess(rec) {
   return rec && rec.access != null ? rec.access : "rw";

--- a/plugins/agent-id-vault/lib/store.mjs
+++ b/plugins/agent-id-vault/lib/store.mjs
@@ -20,11 +20,11 @@
 
 import { nowMs } from "@alien-id/agent-id-core/lib/crypto.mjs";
 import { isLoopbackHost } from "@alien-id/agent-id-core/lib/http.mjs";
-import { assertHostAllowed, hostMatchesAllowlist, validateAccessFields } from "./access.mjs";
+import { assertHostAllowed, credentialHost, hostMatchesAllowlist, validateAccessFields } from "./access.mjs";
 
 // Domain matching lives in access.mjs (access rules share the syntax); kept
 // exported here for the proxy/browser consumers that import it from store.
-export { assertHostAllowed, hostMatchesAllowlist };
+export { assertHostAllowed, credentialHost, hostMatchesAllowlist };
 
 export const CREDENTIAL_TYPES = Object.freeze([
   "bearer",

--- a/tests/test-access-policy.mjs
+++ b/tests/test-access-policy.mjs
@@ -11,6 +11,7 @@ import assert from "node:assert/strict";
 import {
   ACCESS_LEVELS,
   classifyBodyRead,
+  credentialHost,
   effectiveAccess,
   evaluateAccess,
   isAccessRelaxation,
@@ -370,5 +371,28 @@ describe("browser guard (pure pieces)", () => {
       guardDecision(ro, { method: "GET", url: "data:text/plain,hi", postData: null }).allowed,
       true,
     );
+  });
+});
+
+describe("credentialHost", () => {
+  it("prefers the login page's own host", () => {
+    assert.equal(
+      credentialHost({ loginUrl: "https://www.airbnb.com/login", domains: ["*.airbnb.com"] }),
+      "airbnb.com",
+    );
+  });
+
+  it("falls back to the allowlist as written, skipping wildcards", () => {
+    // A wildcard names a family of hosts rather than a site, so it is never the
+    // title. Otherwise the list is taken in order: `domains` is written
+    // broadest-first, and the site reads better on a card than the subdomain a
+    // sign-in happens to redirect through.
+    assert.equal(credentialHost({ domains: ["*.example.com", "account.example.com"] }), "account.example.com");
+    assert.equal(credentialHost({ domains: ["example.com", "account.example.com"] }), "example.com");
+  });
+
+  it("has nothing to show when the allowlist names no site", () => {
+    assert.equal(credentialHost({ domains: ["*"] }), null);
+    assert.equal(credentialHost({}), null);
   });
 });

--- a/tests/test-auto-login.mjs
+++ b/tests/test-auto-login.mjs
@@ -291,7 +291,10 @@ test("otpPromptWording: a passwordless code is not presented as a second factor"
     passwordless: true,
     loginUrl: "https://account.booking.example/sign-in",
   });
-  assert.match(w.title, /Sign-in code for booking/);
+  // The site, not the record: the owner is looking at a sign-in page, and the
+  // name is a key the agent chose.
+  assert.match(w.title, /Sign-in code for account\.booking\.example/);
+  assert.ok(!w.title.includes("booking\u0022"), "the credential name is not a title");
   assert.ok(!/2FA/i.test(w.title), "the only factor must not be called 2FA");
   assert.ok(!/2FA/i.test(w.label));
   assert.match(w.description, /account\.booking\.example/);
@@ -299,13 +302,18 @@ test("otpPromptWording: a passwordless code is not presented as a second factor"
 
 test("otpPromptWording: an ordinary second factor keeps the 2FA wording", () => {
   const w = otpPromptWording({ name: "gh", loginUrl: "https://github.example/login" });
-  assert.match(w.title, /2FA code for gh/);
+  assert.match(w.title, /2FA code for github\.example/);
   assert.match(w.label, /2FA/);
 });
 
-test("otpPromptWording: no loginUrl leaves the description empty rather than half-built", () => {
-  assert.equal(otpPromptWording({ name: "x", passwordless: true }).description, "");
-  assert.equal(otpPromptWording({ name: "x" }).description, "");
+test("otpPromptWording: nothing to name the site by still says what to do", () => {
+  // The description used to come out empty here, which told the owner nothing at
+  // all in the one place they had to act. With no host to show, the record's own
+  // name is the last thing left — worse than a site, better than silence.
+  const passwordless = otpPromptWording({ name: "x", passwordless: true });
+  assert.match(passwordless.description, /x sent you a code/);
+  assert.match(passwordless.description, /email or messages/i);
+  assert.match(otpPromptWording({ name: "x" }).description, /needs your current code/);
 });
 
 // ─── multi-host sign-ins refuse safely, not silently ──────────────────────────────
@@ -535,4 +543,26 @@ test("the code card never says '2FA' to someone who has no first factor", () => 
   const passwordless = otpCardSpec({ name: "booking", otp: "interactive", passwordless: true, loginUrl: "https://x.test/in" });
   assert.ok(!/2fa|two-factor/i.test(JSON.stringify(passwordless)), "this code IS the sign-in, not a second step");
   assert.match(passwordless.fields[0].label, /sign-in code/i);
+});
+
+test("the code card names the site and where the code went", () => {
+  const cred = {
+    name: "airbnb-passwordless-again",
+    passwordless: true,
+    otp: "interactive",
+    loginUrl: "https://www.airbnb.com/login",
+    domains: ["*.airbnb.com", "airbnb.com"],
+  };
+
+  const named = otpCardSpec(cred, { destination: "+1 ••• ••• 4817" });
+  // The owner is looking at Airbnb, not at whatever the agent called its record.
+  assert.ok(!JSON.stringify(named).includes("airbnb-passwordless-again"));
+  assert.match(named.title, /airbnb\.com/);
+  assert.match(named.description, /\+1 ••• ••• 4817/);
+
+  // With no destination the card must not pick a channel for the owner: the one
+  // this came from texted a code while the copy implied a mailbox.
+  const blind = otpCardSpec(cred, {});
+  assert.match(blind.description, /email or messages/i);
+  assert.ok(!/sent a code to/.test(blind.description));
 });

--- a/tests/test-auto-login.mjs
+++ b/tests/test-auto-login.mjs
@@ -287,14 +287,16 @@ test("isDeepLoginUrl: true for a real path, false for the bare origin root", () 
 
 test("otpPromptWording: a passwordless code is not presented as a second factor", () => {
   const w = otpPromptWording({
-    name: "booking",
+    // A name that shares nothing with the host, so its absence is a real assertion:
+    // "booking" would have been a substring of the site and passed either way.
+    name: "record-key-not-a-site",
     passwordless: true,
     loginUrl: "https://account.booking.example/sign-in",
   });
   // The site, not the record: the owner is looking at a sign-in page, and the
   // name is a key the agent chose.
   assert.match(w.title, /Sign-in code for account\.booking\.example/);
-  assert.ok(!w.title.includes("booking\u0022"), "the credential name is not a title");
+  assert.ok(!JSON.stringify(w).includes("record-key-not-a-site"), "the credential name is not a title");
   assert.ok(!/2FA/i.test(w.title), "the only factor must not be called 2FA");
   assert.ok(!/2FA/i.test(w.label));
   assert.match(w.description, /account\.booking\.example/);

--- a/tests/test-login-detect.mjs
+++ b/tests/test-login-detect.mjs
@@ -8,7 +8,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { classifyLogin } from "../plugins/agent-id-browser/lib/login-detect.mjs";
+import { classifyLogin, codeDestination } from "../plugins/agent-id-browser/lib/login-detect.mjs";
 
 test("logged-in: no password field, no otp, no error", () => {
   assert.equal(classifyLogin({ hasPasswordField: false, bodyText: "Welcome back, alice" }), "logged-in");
@@ -473,4 +473,38 @@ test("Russian body copy without a rejection does not trip the error match", () =
     "unknown",
   );
   assert.equal(classifyLogin({ hasPasswordField: false, bodyText: "Добро пожаловать, Иван" }), "logged-in");
+});
+
+// ── Where the code went ─────────────────────────────────────────────────────────
+
+test("codeDestination reads back the destination the page itself printed", () => {
+  const cases = [
+    ["We sent a code to +1 ••• ••• 4817. Enter it below.", "+1 ••• ••• 4817"],
+    ["Enter the code we texted to +1 (415) 555-0134", "+1 (415) 555-0134"],
+    // The masking dot and the domain dot are the same character; only a dot that
+    // ends a sentence may end the capture.
+    ["We just emailed a code to d••@gmail.com", "d••@gmail.com"],
+    ["A verification code was sent to daniel@eti.co.", "daniel@eti.co"],
+    ["We sent a code to your phone", "your phone"],
+    ["Check your inbox — we sent a code to your email address.", "your email address"],
+  ];
+  for (const [body, expected] of cases) {
+    assert.equal(codeDestination(body), expected, body);
+  }
+});
+
+test("codeDestination says nothing rather than something wrong", () => {
+  // A destination on the card is a promise about where to look. Naming the wrong
+  // place is worse than naming none: the owner watches an empty inbox and
+  // concludes the code never came — which is exactly the report this came from.
+  for (const body of [
+    "Enter the 6-digit code",
+    "We sent a code to help you get started with our newsletter",
+    "Your order was sent to 221B Baker Street",
+    "We emailed a link to reset your password",
+    "",
+    null,
+  ]) {
+    assert.equal(codeDestination(body), null, String(body));
+  }
 });

--- a/tests/test-login-detect.mjs
+++ b/tests/test-login-detect.mjs
@@ -502,6 +502,10 @@ test("codeDestination says nothing rather than something wrong", () => {
     "We sent a code to help you get started with our newsletter",
     "Your order was sent to 221B Baker Street",
     "We emailed a link to reset your password",
+    // The page writes this text and the card the owner trusts prints it. The
+    // loopback form escapes; the hosted prompt hands `description` on as it is.
+    "We sent a code to <img/src=x/onerror=fetch(1)>@a.co",
+    "We sent a code to \"><script>alert(1)</script>@a.co",
     "",
     null,
   ]) {

--- a/tests/test-vault-login.mjs
+++ b/tests/test-vault-login.mjs
@@ -370,3 +370,43 @@ test("listMetadata surfaces a login's shape without surfacing its secrets", () =
   assert.equal(meta.password, undefined);
   assert.equal(meta.recipe, undefined, "the steps themselves stay in the record");
 });
+
+test("the card names the site, not the credential the agent invented", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "vault-cardtitle-"));
+  try {
+    await makeVault(dir);
+
+    const child = spawn(
+      "node",
+      [
+        CLI, "add", "--name", "airbnb-passwordless-again", "--type", "login",
+        "--passwordless", "--otp", "interactive",
+        "--login-url", "https://www.airbnb.com/login",
+        "--form", "--state-dir", dir,
+      ],
+      { env: { ...process.env, AGENT_ID_NO_BROWSER: "1", AGENT_ID_SECURE_PROMPT: "browser" } },
+    );
+    child.stdout.on("data", () => {});
+    child.stderr.on("data", () => {});
+
+    const u = new URL(await waitForUrl(child));
+    const html = await (await fetch(u)).text();
+
+    // The name is the vault's key and the agent's to choose; it named its own
+    // second attempt, and the owner was asked to "Add credential:
+    // airbnb-passwordless-again" while looking at Airbnb's sign-in page.
+    assert.ok(!html.includes("airbnb-passwordless-again"), "the credential's name must not reach the card");
+    assert.match(html, /Sign in to airbnb\.com/, "the card names the site");
+    // `www.` names the same site and only costs the reader a word. The domain
+    // list below the title still shows the allowlist verbatim, which is right.
+    assert.ok(!html.includes("Sign in to www."), "www. is noise in a title");
+    // Airbnb's own first screen says "Phone number or email"; the old label
+    // promised a mailbox and the code arrived as an SMS.
+    assert.match(html, /Email or phone number/, "a passwordless identifier is not email-only");
+
+    child.kill();
+    await new Promise((r) => child.on("exit", r));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/test-vault-login.mjs
+++ b/tests/test-vault-login.mjs
@@ -405,7 +405,7 @@ test("the card names the site, not the credential the agent invented", async () 
     assert.match(html, /Email or phone number/, "a passwordless identifier is not email-only");
     // The chat row renders the description under the title, and this card is step
     // one of two: submitting it looks like nothing happened unless it says so.
-    assert.match(html, /A sign-in code follows on the next card/);
+    assert.match(html, /Identifier only — the sign-in code is asked for at sign-in/);
 
     child.kill();
     await new Promise((r) => child.on("exit", r));

--- a/tests/test-vault-login.mjs
+++ b/tests/test-vault-login.mjs
@@ -403,6 +403,9 @@ test("the card names the site, not the credential the agent invented", async () 
     // Airbnb's own first screen says "Phone number or email"; the old label
     // promised a mailbox and the code arrived as an SMS.
     assert.match(html, /Email or phone number/, "a passwordless identifier is not email-only");
+    // The chat row renders the description under the title, and this card is step
+    // one of two: submitting it looks like nothing happened unless it says so.
+    assert.match(html, /A sign-in code follows on the next card/);
 
     child.kill();
     await new Promise((r) => child.on("exit", r));


### PR DESCRIPTION
Three things a live Airbnb sign-in showed the owner. None of them stopped the flow working; all three left the person holding the phone guessing.

## The card was titled with the credential's name

The agent had called its record `airbnb-passwordless-again` — encoding its own second attempt — and that reached the screen verbatim: *"Add credential: airbnb-passwordless-again"*, while the owner was looking at Airbnb's sign-in page.

The name is the vault's key and the agent's to choose. The title now names the site, from `loginUrl` or the narrowest literal entry in `domains`; a wildcard names a family of hosts rather than a site, so it is skipped. `www.` is dropped because it names the same site and costs the reader a word — every other subdomain stays, since `account.booking.com` is where the sign-in actually lives. With no host to derive, the name is still better than nothing.

The code card had the same fault (`Sign-in code for airbnb-passwordless-again`) and gets the same treatment. `credentialHost` lives in `access.mjs`, beside the other host vocabulary, so both callers share one answer.

## The identifier field promised a mailbox

It read `Username / email` for every login, while Airbnb's own first screen says *"Phone number or email"*. The owner entered an address and waited for a letter the site had sent as an SMS. A passwordless login now says `Email or phone number`; a password login keeps the old label, where the field really can be a username.

## The code card never said where the code went

*"airbnb.com sent you a code"* leaves the channel to be guessed, and the guess was wrong. The page has already printed the answer — a masked destination, right there in the copy — so `codeDestination` reads it back rather than inventing it.

It reads it back **only** when the captured text is recognisably a destination: an address, a masked number, or a named place. Unrecognised, the copy claims no channel at all and names both places to look. This asymmetry is deliberate — naming the wrong channel is worse than naming none, because it sends the owner to an inbox the code was never sent to and then convinces them it never came, which is precisely the report this PR comes from.

## Notes for review

- The three `otpPromptWording` tests that asserted the old title are rewritten rather than relaxed: the behaviour they pinned is the behaviour being changed, and they now also assert the credential name is absent whenever a host is available.
- One of them covered "no loginUrl leaves the description empty". Empty told the owner nothing in the one place they had to act, so that case now falls back to the record's name and still says what to do.
- Every new assertion was checked by breaking the code and watching it go red. Suite: 888 tests, 0 failures.
