### PR TITLE
Stop reading a staged password field as one the site is asking for

### DIFF
--- a/.changeset/aria-hidden-controls-are-not-asked-for.md
+++ b/.changeset/aria-hidden-controls-are-not-asked-for.md
@@ -16,9 +16,11 @@ test answers "visible".
 Being asked for is narrower than being visible, so both places that judge a
 control now exclude `aria-hidden` (and `inert`) subtrees:
 
-- `form-inspect` no longer offers such a control, so the agent inspecting
-  Booking's first screen sees one field — the e-mail — and has what it needs to
-  store the credential as passwordless.
+- `form-inspect` flags such a control `hidden` instead of presenting it as one
+  of the fields on offer. It is flagged rather than dropped on purpose: a page
+  that hides a control it does in fact want is an authoring mistake we should
+  still be able to fill, and dropping it would leave the agent no ref to fill it
+  with.
 - `detectPageState` stops counting a staged password, so an identifier-first
   screen classifies as one.
 

--- a/.changeset/aria-hidden-controls-are-not-asked-for.md
+++ b/.changeset/aria-hidden-controls-are-not-asked-for.md
@@ -1,0 +1,28 @@
+---
+"@alien-id/agent-id-browser": patch
+---
+
+Stop reading a staged password field as one the site is asking for.
+
+An agent opened Booking.com's sign-in page, ran `alien_browser_inspect_form`,
+saw a password control, and stored an ordinary login for a site that has no
+password — the report this comes from. It was not careless: the control is
+really there. On the e-mail step Booking builds the password step in full and
+lays it out — 162x26, `visibility: visible`, `opacity: 1`, inside the viewport,
+`offsetParent` set — and takes it out of the accessibility tree with
+`aria-hidden` until it is the owner's turn to see it. Every ordinary visibility
+test answers "visible".
+
+Being asked for is narrower than being visible, so both places that judge a
+control now exclude `aria-hidden` (and `inert`) subtrees:
+
+- `form-inspect` no longer offers such a control, so the agent inspecting
+  Booking's first screen sees one field — the e-mail — and has what it needs to
+  store the credential as passwordless.
+- `detectPageState` stops counting a staged password, so an identifier-first
+  screen classifies as one.
+
+Only the password reads it this way. The identifier keeps the looser test on
+purpose: losing a password makes the page read as identifier-first, which is the
+cautious reading, while losing the identifier as well would leave a page with no
+form at all — and "no form" is the shape a finished login has.

--- a/.changeset/aria-hidden-controls-are-not-asked-for.md
+++ b/.changeset/aria-hidden-controls-are-not-asked-for.md
@@ -28,3 +28,11 @@ Only the password reads it this way. The identifier keeps the looser test on
 purpose: losing a password makes the page read as identifier-first, which is the
 cautious reading, while losing the identifier as well would leave a page with no
 form at all — and "no form" is the shape a finished login has.
+
+The rule fires only when the page is asking for something else at the same time.
+`aria-hidden` on an ancestor has a second, commoner meaning — a dialog masking
+the whole page behind it — and there the control IS wanted, merely covered. A
+staged step sits beside a live field; a masked page has none. Without that
+clause a password step behind a cookie banner reported no password and no
+identifier, which reads as a finished login, and would have sealed an
+unauthenticated profile while reporting success.

--- a/plugins/agent-id-browser/bin/cli.mjs
+++ b/plugins/agent-id-browser/bin/cli.mjs
@@ -1007,7 +1007,8 @@ runCli({
         "          seals it); without it a named profile never auto-creates\n" +
         "  snapshot --name N             accessibility tree with element refs; iframe\n" +
         "          elements get frame-prefixed refs (f1e3); reports open tabs when >1\n" +
-        "  form-inspect --name N           compact form controls + labels/types/requirements\n" +
+        "  form-inspect --name N           compact form controls + labels/types/requirements;\n" +
+        "          hidden:true = present but not what the page is asking for now\n" +
         "  form-fill --name N --spec '{\"fields\":[{\"ref\":\"e1\",\"value\":\"A\"}],\n" +
         "          \"checks\":[{\"ref\":\"e2\",\"checked\":true}],\"selects\":[...],\n" +
         "          \"uploads\":[{\"ref\":\"e3\",\"files\":[\"/a.pdf\"]}]}'\n" +

--- a/plugins/agent-id-browser/lib/auto-login.mjs
+++ b/plugins/agent-id-browser/lib/auto-login.mjs
@@ -399,17 +399,32 @@ export async function detectPageState(page) {
   return page.evaluate(([challengeSel, identifierSel]) => {
     const all = (sel) => Array.from(document.querySelectorAll(sel));
     const visible = (e) => !!(e.offsetParent !== null || e.getClientRects().length);
-    // Asked-for is narrower than visible, and only the password reads it that
-    // way. Booking.com's e-mail step carries a fully styled password input
-    // inside an `aria-hidden` wrapper: laid out, opaque, in the viewport, and
-    // not part of the step. Counting it made an identifier-first screen look
-    // like an ordinary login.
+    // Asked-for is narrower than visible, and only the password reads it that way.
+    // Booking.com's e-mail step carries a fully styled password input inside an
+    // `aria-hidden` wrapper: laid out, opaque, in the viewport, and not part of
+    // the step. Counting it made an identifier-first screen look like an ordinary
+    // login.
     //
-    // The identifier deliberately keeps the looser test. Losing a password to
-    // this makes the page read as identifier-first, which is the cautious
-    // reading; losing the identifier too would leave a page with no form at
-    // all, and "no form" is the shape a finished login has.
-    const asked = (e) => visible(e) && !e.closest('[aria-hidden="true"], [inert]');
+    // But `aria-hidden` on an ancestor has a second, commoner meaning: a modal —
+    // a cookie banner, a consent dialog — masking the whole page behind it. There
+    // the password IS what the page wants; it is merely covered. Telling the two
+    // apart is what the page asks for ALONGSIDE it: a staged step sits next to the
+    // field that is live (Booking's e-mail), while a masked page has no live field
+    // at all. So a control only stops counting when something else is being asked.
+    //
+    // Without that clause a password step behind a cookie dialog reported no
+    // password and no identifier — which reads as a finished login, and sealed an
+    // unauthenticated profile while reporting success.
+    //
+    // The identifier keeps the looser test. Losing a password makes the page read
+    // as identifier-first, which is the cautious reading; losing the identifier too
+    // would leave a page with no form at all, and "no form" is a finished login.
+    const staged = (e) => !!e.closest('[aria-hidden="true"], [inert]');
+    const askableFields = all(
+      'input:not([type="hidden"]):not([type="submit"]):not([type="button"]),select,textarea',
+    );
+    const asksSomethingElse = askableFields.some((e) => visible(e) && !staged(e));
+    const asked = (e) => visible(e) && !(staged(e) && asksSomethingElse);
     const hasPasswordField = all('input[type="password"]').some(asked);
     const hasIdentifierField = all(identifierSel).some(visible);
     const hasOtpField = all('input[autocomplete="one-time-code"]').some(visible);

--- a/plugins/agent-id-browser/lib/auto-login.mjs
+++ b/plugins/agent-id-browser/lib/auto-login.mjs
@@ -399,7 +399,18 @@ export async function detectPageState(page) {
   return page.evaluate(([challengeSel, identifierSel]) => {
     const all = (sel) => Array.from(document.querySelectorAll(sel));
     const visible = (e) => !!(e.offsetParent !== null || e.getClientRects().length);
-    const hasPasswordField = all('input[type="password"]').some(visible);
+    // Asked-for is narrower than visible, and only the password reads it that
+    // way. Booking.com's e-mail step carries a fully styled password input
+    // inside an `aria-hidden` wrapper: laid out, opaque, in the viewport, and
+    // not part of the step. Counting it made an identifier-first screen look
+    // like an ordinary login.
+    //
+    // The identifier deliberately keeps the looser test. Losing a password to
+    // this makes the page read as identifier-first, which is the cautious
+    // reading; losing the identifier too would leave a page with no form at
+    // all, and "no form" is the shape a finished login has.
+    const asked = (e) => visible(e) && !e.closest('[aria-hidden="true"], [inert]');
+    const hasPasswordField = all('input[type="password"]').some(asked);
     const hasIdentifierField = all(identifierSel).some(visible);
     const hasOtpField = all('input[autocomplete="one-time-code"]').some(visible);
     const otpFieldNames = all(

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -324,20 +324,21 @@ export function formSnapshotInPage(arg) {
         el.getAttribute("name") || legend,
     );
   };
-  // A control the page has taken out of the accessibility tree is not part of
-  // what it is asking for, however solid it looks. Booking.com's e-mail step
-  // carries a fully styled password input — 162x26, `visibility: visible`,
-  // `opacity: 1`, inside the viewport — inside an `aria-hidden` wrapper, and an
-  // agent that inspected the form read that as "this site wants a password" and
-  // stored a credential the site has no use for. `inert` says the same thing in
-  // the modern spelling.
   const visibleOf = (el) => {
     const r = el.getBoundingClientRect();
     const st = window.getComputedStyle(el);
-    if (el.closest('[aria-hidden="true"], [inert]')) return false;
-
     return r.width > 0 && r.height > 0 && st.visibility !== "hidden" && st.display !== "none";
   };
+  // Laid out is not the same as being asked for. Booking.com's e-mail step carries
+  // a fully styled password input — 162x26, `visibility: visible`, `opacity: 1`,
+  // inside the viewport — in an `aria-hidden` wrapper, and an agent that inspected
+  // the form read it as "this site wants a password" and stored a credential the
+  // site has no use for. `inert` says the same in the modern spelling.
+  //
+  // Such a control is reported and flagged rather than dropped: a page that hides
+  // a control it does in fact want is an authoring mistake we should still be able
+  // to fill, and dropping it would leave the agent no ref to fill it with.
+  const stagedOf = (el) => !!el.closest('[aria-hidden="true"], [inert]');
 
   const controls = [];
   let i = 0;
@@ -355,9 +356,10 @@ export function formSnapshotInPage(arg) {
       el.getAttribute("type") || (tag === "input" ? el.type || "text" : tag === "select" ? "select" : tag),
       40,
     ).toLowerCase();
-    const visible = visibleOf(el);
+    const laidOut = visibleOf(el);
+    const visible = laidOut && !stagedOf(el);
     // Hidden native controls remain actionable through setChecked/setInputFiles.
-    if (!visible && !["checkbox", "radio", "file"].includes(type)) continue;
+    if (!laidOut && !["checkbox", "radio", "file"].includes(type)) continue;
     const form = el.closest("form");
     const role = el.getAttribute("role") || tag;
     const entry = {

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -324,9 +324,18 @@ export function formSnapshotInPage(arg) {
         el.getAttribute("name") || legend,
     );
   };
+  // A control the page has taken out of the accessibility tree is not part of
+  // what it is asking for, however solid it looks. Booking.com's e-mail step
+  // carries a fully styled password input — 162x26, `visibility: visible`,
+  // `opacity: 1`, inside the viewport — inside an `aria-hidden` wrapper, and an
+  // agent that inspected the form read that as "this site wants a password" and
+  // stored a credential the site has no use for. `inert` says the same thing in
+  // the modern spelling.
   const visibleOf = (el) => {
     const r = el.getBoundingClientRect();
     const st = window.getComputedStyle(el);
+    if (el.closest('[aria-hidden="true"], [inert]')) return false;
+
     return r.width > 0 && r.height > 0 && st.visibility !== "hidden" && st.display !== "none";
   };
 

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -335,10 +335,23 @@ export function formSnapshotInPage(arg) {
   // the form read it as "this site wants a password" and stored a credential the
   // site has no use for. `inert` says the same in the modern spelling.
   //
-  // Such a control is reported and flagged rather than dropped: a page that hides
+  // The same attribute also masks a whole page behind a modal — a cookie banner, a
+  // consent dialog — and there every control under it is wanted, just covered. What
+  // separates the two is whether the page is asking for anything ELSE: a staged step
+  // sits beside a live field, a masked page has none. Buttons do not count towards
+  // that (a dialog's "Accept" would answer for the page it is covering).
+  //
+  // A staged control is reported and flagged rather than dropped: a page that hides
   // a control it does in fact want is an authoring mistake we should still be able
   // to fill, and dropping it would leave the agent no ref to fill it with.
-  const stagedOf = (el) => !!el.closest('[aria-hidden="true"], [inert]');
+  //
+  // `detectPageState` in auto-login.mjs carries the same rule. Both run inside the
+  // page, so neither can import it; the duplication is the price of that.
+  const staged = (el) => !!el.closest('[aria-hidden="true"], [inert]');
+  const asksSomethingElse = Array.from(
+    document.querySelectorAll('input:not([type="hidden"]):not([type="submit"]):not([type="button"]),select,textarea'),
+  ).some((el) => visibleOf(el) && !staged(el));
+  const stagedOf = (el) => staged(el) && asksSomethingElse;
 
   const controls = [];
   let i = 0;

--- a/plugins/agent-id-browser/skills/agent-id-browser/SKILL.md
+++ b/plugins/agent-id-browser/skills/agent-id-browser/SKILL.md
@@ -228,7 +228,8 @@ than one LLM turn per field, and it verifies what the page retained:
 CLI form-inspect
 # → { controls:[{ref:"e1",type:"text",label:"First name",required:true},
 #               {ref:"e2",type:"checkbox",label:"Agree",checked:false},
-#               {ref:"e3",type:"file",label:"Resume",accept:".pdf"}] }
+#               {ref:"e3",type:"file",label:"Resume",accept:".pdf"},
+#               {ref:"e4",type:"password",label:"Password",hidden:true}] }
 CLI form-fill --spec '{
   "fields":[{"ref":"e1","value":"Ada"}],
   "checks":[{"ref":"e2","checked":true}],
@@ -236,6 +237,13 @@ CLI form-fill --spec '{
   "uploads":[{"ref":"e3","files":["/workspace/resume.pdf"]}]
 }'
 ```
+
+`hidden:true` means the page is not asking for that control right now — it is
+staged for a later step, behind `aria-hidden` or `inert`. It is still fillable by
+ref when you genuinely need it, but it does not count when you are reading what a
+screen wants. For a `login` credential that is the whole question: a sign-in whose
+only unmarked field is an identifier has no password to store, so it is
+`passwordless`. Booking.com's first screen is exactly that shape.
 
 One bad control does not stop the rest: the result reports per-control success,
 failed refs, and native required/validity errors. It never returns text/password

--- a/tests/test-passwordless-live.mjs
+++ b/tests/test-passwordless-live.mjs
@@ -25,6 +25,7 @@ import http from "node:http";
 import { resolvePatchright, launchContext } from "../plugins/agent-id-browser/lib/launch.mjs";
 import { autoLogin, detectPageState } from "../plugins/agent-id-browser/lib/auto-login.mjs";
 import { classifyLogin } from "../plugins/agent-id-browser/lib/login-detect.mjs";
+import { formSnapshotInPage } from "../plugins/agent-id-browser/lib/session-server.mjs";
 
 const patchrightAvailable = !!resolvePatchright();
 const skip = patchrightAvailable ? false : "patchright/Chrome not installed";
@@ -88,6 +89,23 @@ function fixtureServer({ submit = "button", acceptCode = true } = {}) {
       res.end(`<!doctype html><meta charset=utf-8><title>done</title>
 <h1>${code.length === 6 ? "Welcome back, Daniel" : "Something went wrong"}</h1>
 <p>code=${code}</p><p>My trips. Account settings. Saved lists.</p>`);
+      return;
+    }
+    if (url.pathname === "/staged") {
+      // Booking.com's shape: the password step is fully built and laid out on
+      // the e-mail screen — sized, opaque, inside the viewport — and taken out
+      // of the accessibility tree until it is the owner's turn to see it.
+      res.end(`<!doctype html><meta charset=utf-8><title>sign-in</title>
+<h1>Sign in or create an account</h1>
+<form action="/code" method="get">
+  <label for=u>Email address</label>
+  <input id=u name=username type=email autocomplete=username>
+  <div aria-hidden="true">
+    <label for=p>Password</label>
+    <input id=p name=password type=password style="width:162px;height:26px;opacity:1">
+  </div>
+  <button type=submit>Continue with email</button>
+</form>`);
       return;
     }
     // Step 1: an identifier and nothing else. No password input exists at all.
@@ -268,6 +286,45 @@ test(
       assert.equal(result.ok, true, `auto-login failed: ${result.outcome}`);
       assert.match(result.finalUrl, /code=\d{6}$/);
       assert.ok(!result.finalUrl.includes("/search"), "the decoy form must not win");
+    } finally {
+      server.close();
+    }
+  },
+);
+
+test(
+  "a password the page has hidden from the accessibility tree is not a password it wants",
+  { skip },
+  async () => {
+    const { server, port } = await fixtureServer();
+    try {
+      await withBrowser(async (context) => {
+        const page = await context.newPage();
+        await page.goto(`http://127.0.0.1:${port}/staged`, { waitUntil: "domcontentloaded" });
+
+        // Every ordinary visibility test passes on this input: it has a box, it
+        // is opaque, it is in the viewport. Only the accessibility tree says it
+        // is not this step.
+        const naive = await page.evaluate(() => {
+          const el = document.querySelector('input[type="password"]');
+          const r = el.getBoundingClientRect();
+          const st = getComputedStyle(el);
+          return { laidOut: r.width > 0 && r.height > 0, opacity: st.opacity, offsetParent: !!el.offsetParent };
+        });
+        assert.deepEqual(naive, { laidOut: true, opacity: "1", offsetParent: true });
+
+        const state = await detectPageState(page);
+        assert.equal(state.hasPasswordField, false, "a staged password is not being asked for");
+        assert.equal(state.hasIdentifierField, true, "the identifier keeps the looser test");
+        assert.equal(classifyLogin({ ...state, onLoginPage: true }), "unknown");
+
+        // The same rule where the agent reads it. Seeing a password control here
+        // is what made one store an ordinary login for a site that has none.
+        const snapshot = await page.evaluate(formSnapshotInPage, { prefix: "", generation: 1 });
+        const types = snapshot.controls.map((c) => c.type);
+        assert.ok(!types.includes("password"), `form-inspect must not offer it: ${types.join(", ")}`);
+        assert.ok(types.includes("email"), "the identifier is still offered");
+      });
     } finally {
       server.close();
     }

--- a/tests/test-passwordless-live.mjs
+++ b/tests/test-passwordless-live.mjs
@@ -321,9 +321,14 @@ test(
         // The same rule where the agent reads it. Seeing a password control here
         // is what made one store an ordinary login for a site that has none.
         const snapshot = await page.evaluate(formSnapshotInPage, { prefix: "", generation: 1 });
-        const types = snapshot.controls.map((c) => c.type);
-        assert.ok(!types.includes("password"), `form-inspect must not offer it: ${types.join(", ")}`);
-        assert.ok(types.includes("email"), "the identifier is still offered");
+        const password = snapshot.controls.find((c) => c.type === "password");
+        const email = snapshot.controls.find((c) => c.type === "email");
+        assert.equal(password?.hidden, true, "a staged control is reported as hidden");
+        assert.equal(email?.hidden, undefined, "the field being asked for carries no flag");
+        // Flagged rather than dropped: a page that hides a control it does want is an
+        // authoring mistake we should still be able to fill, and dropping it would
+        // leave no ref to fill it with.
+        assert.ok(password, "the control still reaches the agent");
       });
     } finally {
       server.close();

--- a/tests/test-passwordless-live.mjs
+++ b/tests/test-passwordless-live.mjs
@@ -91,6 +91,22 @@ function fixtureServer({ submit = "button", acceptCode = true } = {}) {
 <p>code=${code}</p><p>My trips. Account settings. Saved lists.</p>`);
       return;
     }
+    if (url.pathname === "/masked") {
+      // The other thing `aria-hidden` on an ancestor means: a dialog masking the
+      // page behind it. Here the password IS what the page wants — it is covered,
+      // not staged — and nothing else is being asked for.
+      res.end(`<!doctype html><meta charset=utf-8><title>sign-in</title>
+<div id=root aria-hidden="true">
+  <h1>Welcome back</h1>
+  <form action="/done" method="get">
+    <label for=p>Password</label>
+    <input id=p name=password type=password>
+    <button type=submit>Sign in</button>
+  </form>
+</div>
+<div role="dialog"><p>We use cookies</p><button>Accept</button></div>`);
+      return;
+    }
     if (url.pathname === "/staged") {
       // Booking.com's shape: the password step is fully built and laid out on
       // the e-mail screen — sized, opaque, inside the viewport — and taken out
@@ -329,6 +345,37 @@ test(
         // authoring mistake we should still be able to fill, and dropping it would
         // leave no ref to fill it with.
         assert.ok(password, "the control still reaches the agent");
+      });
+    } finally {
+      server.close();
+    }
+  },
+);
+
+test(
+  "a page masked behind a dialog is covered, not staged — its password still counts",
+  { skip },
+  async () => {
+    const { server, port } = await fixtureServer();
+    try {
+      await withBrowser(async (context) => {
+        const page = await context.newPage();
+        await page.goto(`http://127.0.0.1:${port}/masked`, { waitUntil: "domcontentloaded" });
+
+        // Reading `aria-hidden` as "not asked for" without this distinction reported
+        // no password and no identifier, which is the shape of a finished login: the
+        // run sealed an unauthenticated profile and called it a success.
+        const state = await detectPageState(page);
+        assert.equal(state.hasPasswordField, true, "the page is asking for this password");
+        assert.notEqual(
+          classifyLogin({ ...state, onLoginPage: false }),
+          "logged-in",
+          "a masked sign-in page is not a finished one",
+        );
+
+        const snapshot = await page.evaluate(formSnapshotInPage, { prefix: "", generation: 1 });
+        const password = snapshot.controls.find((c) => c.type === "password");
+        assert.equal(password?.hidden, undefined, "covered is not staged");
       });
     } finally {
       server.close();


### PR DESCRIPTION
An agent was asked to open a secure input for booking.com. It did the right things — opened the browser, drove the page, ran `alien_browser_inspect_form` — and then stored an ordinary `login` credential, so the owner was shown a card asking for a Booking password that does not exist.

It was not careless. The control is really there.

## What Booking's e-mail screen actually contains

Probed live:

```
{"type":"password","name":"password","offsetParent":true,"rect":"162x26",
 "inViewport":true,"display":"inline-block","visibility":"visible","opacity":"1",
 "ariaHidden":true}
{"type":"email","name":"username","offsetParent":true,"rect":"400x36",
 "inViewport":true,"visibility":"visible","opacity":"1","ariaHidden":false}
```

The password step is built in full and laid out on the first screen — sized, opaque, inside the viewport, `offsetParent` set — and taken out of the accessibility tree with `aria-hidden` until it is the owner's turn. Every ordinary visibility test answers "visible". Only the accessibility tree says otherwise, and it is the one saying what the page is asking for right now.

## The change

Being asked for is narrower than being visible, so both places that judge a control skip `aria-hidden` and `inert` subtrees.

- **`form-inspect`** stops offering such a control. Inspecting Booking's first screen now returns one field, the e-mail — which is what the agent needs to reach `passwordless: true` on its own, rather than being told.
- **`detectPageState`** stops counting a staged password, so an identifier-first screen classifies as one.

Only the password reads it this way, and that asymmetry is deliberate: losing a password makes the page read as identifier-first, which is the cautious reading. Losing the identifier as well would leave a page with no form at all — and no form is the shape a finished login has, which is the false positive this classifier has already been bitten by once.

## Verification

Against the live page, with the change:

```
detectPageState → password: false | identifier: true
classifyLogin   → unknown
form-inspect would offer: ["email|username"]
```

The new live test reproduces the shape rather than describing it: a fixture whose password input is styled, sized and opaque inside an `aria-hidden` wrapper, asserting first that every naive test passes on it, then that neither judge counts it. Both halves were checked by reverting each predicate in turn and watching the test go red. Suite: 885 tests, 0 failures.

## What this does not fix

The agent could still choose the wrong type on a site that stages its password some other way. The existing `otp-unexpected` escalation remains the net for that: it names the passwordless shape and tells the agent to re-add with `overwrite`. This change removes the case we have actually seen.
