### PR TITLE
Say what the page asks for, and write the card for the person reading it

### DIFF
--- a/.changeset/say-what-the-page-asks-for.md
+++ b/.changeset/say-what-the-page-asks-for.md
@@ -1,0 +1,45 @@
+---
+"@alien-id/agent-id-browser": minor
+"@alien-id/agent-id-vault": minor
+---
+
+Say what a sign-in page asks for, and write the card for the person reading it.
+
+Both halves are corrections to the previous release, which shipped and did not
+work.
+
+**The staged password came back as a flag, and the flag was read straight past.**
+`form-inspect` was reporting a control the page had taken out of the
+accessibility tree with `hidden: true` rather than leaving it out. An agent
+inspecting Booking.com's e-mail screen saw a password control, said as much —
+"I saw a technical password field in the markup" — and stored a credential the
+site has no use for. It is left out again, which is safe now that a control only
+counts as staged while the page is asking for something else: a page hiding its
+only form is not staged, so its controls still arrive and stay fillable.
+
+And the conclusion is stated rather than implied. On a page with an identifier
+field, `form-inspect` now answers with `signIn: { identifier, passwordAsked }`.
+A caller acts on a statement; a flag on one control among ten is something it
+has to interpret, and interpretation is what failed.
+
+**The card was written for the system, not the owner.** It read "Sign in to
+account.booking.com / Identifier only — the sign-in code is asked for at
+sign-in · login · *.booking.com / Sealed with AES-256-GCM (key via
+HKDF-SHA256)". The type and the domain allowlist are how an agent addresses a
+credential — `*.booking.com` reads to a person as a typo — and the cipher names
+told them nothing they could act on while reading as a warning label on a screen
+meant to reassure.
+
+The title now says what is being asked and the line below says what it is for:
+
+```
+Enter it securely
+Booking.com sign-in. You type it on a sealed screen. The code comes at sign-in.
+I never see it and it isn't saved anywhere
+```
+
+The site is named as the owner would name it: a sign-in subdomain is dropped
+from the front (`account.booking.com` → `Booking.com`), and only from the front,
+because working out the registrable domain needs a public-suffix list and
+guessing turns `example.co.uk` into `co.uk`. The access level survives the cut —
+`ro` is a grant being made in the moment of typing.

--- a/.changeset/say-what-the-page-asks-for.md
+++ b/.changeset/say-what-the-page-asks-for.md
@@ -1,5 +1,5 @@
 ---
-"@alien-id/agent-id-browser": minor
+"@alien-id/agent-id-browser": major
 "@alien-id/agent-id-vault": minor
 ---
 
@@ -8,17 +8,25 @@ Say what a sign-in page asks for, and write the card for the person reading it.
 Both halves are corrections to the previous release, which shipped and did not
 work.
 
+**`form-inspect`'s output shape changed**, which is why the browser package takes a
+major: a control the page has staged now arrives under `staged` instead of among
+`controls`, and a sign-in page answers with `signIn`. lethe reads this contract in
+its `vault_add` description, so the two move together.
+
 **The staged password came back as a flag, and the flag was read straight past.**
 `form-inspect` was reporting a control the page had taken out of the
 accessibility tree with `hidden: true` rather than leaving it out. An agent
 inspecting Booking.com's e-mail screen saw a password control, said as much —
 "I saw a technical password field in the markup" — and stored a credential the
-site has no use for. It is left out again, which is safe now that a control only
-counts as staged while the page is asking for something else: a page hiding its
-only form is not staged, so its controls still arrive and stay fillable.
+site has no use for. It moves to `staged` — not left among the fields on offer, and not dropped either.
+Dropping was tried and was worse: "the page is asking for something else" is
+satisfied by ANY live input anywhere, so a cookie banner carrying a checkbox took a
+whole sign-in form out of reach with no ref left to recover it.
 
 And the conclusion is stated rather than implied. On a page with an identifier
-field, `form-inspect` now answers with `signIn: { identifier, passwordAsked }`.
+field and a submit beside it, `form-inspect` now answers with
+`signIn: { identifier, passwordAsked }`. The submit is what keeps a newsletter box
+in a footer from being reported as a site with no password.
 A caller acts on a statement; a flag on one control among ten is something it
 has to interpret, and interpretation is what failed.
 

--- a/plugins/agent-id-browser/bin/cli.mjs
+++ b/plugins/agent-id-browser/bin/cli.mjs
@@ -1008,7 +1008,7 @@ runCli({
         "  snapshot --name N             accessibility tree with element refs; iframe\n" +
         "          elements get frame-prefixed refs (f1e3); reports open tabs when >1\n" +
         "  form-inspect --name N           compact form controls + labels/types/requirements;\n" +
-        "          hidden:true = present but not what the page is asking for now\n" +
+        "          on a sign-in page adds signIn:{identifier,passwordAsked}\n" +
         "  form-fill --name N --spec '{\"fields\":[{\"ref\":\"e1\",\"value\":\"A\"}],\n" +
         "          \"checks\":[{\"ref\":\"e2\",\"checked\":true}],\"selects\":[...],\n" +
         "          \"uploads\":[{\"ref\":\"e3\",\"files\":[\"/a.pdf\"]}]}'\n" +

--- a/plugins/agent-id-browser/bin/cli.mjs
+++ b/plugins/agent-id-browser/bin/cli.mjs
@@ -1008,6 +1008,8 @@ runCli({
         "  snapshot --name N             accessibility tree with element refs; iframe\n" +
         "          elements get frame-prefixed refs (f1e3); reports open tabs when >1\n" +
         "  form-inspect --name N           compact form controls + labels/types/requirements;\n" +
+        "          staged[] = present but not what the page asks for now (refs still work);\n" +
+        "          hidden:true = native control outside the layout;\n" +
         "          on a sign-in page adds signIn:{identifier,passwordAsked}\n" +
         "  form-fill --name N --spec '{\"fields\":[{\"ref\":\"e1\",\"value\":\"A\"}],\n" +
         "          \"checks\":[{\"ref\":\"e2\",\"checked\":true}],\"selects\":[...],\n" +

--- a/plugins/agent-id-browser/lib/auto-login.mjs
+++ b/plugins/agent-id-browser/lib/auto-login.mjs
@@ -37,7 +37,7 @@
 import { generateTotp } from "@alien-id/agent-id-core/lib/totp.mjs";
 import { collectSecret } from "@alien-id/agent-id-core/lib/secure-prompt.mjs";
 import { notifyHost } from "@alien-id/agent-id-core/lib/notice.mjs";
-import { assertHostAllowed, credentialHost } from "@alien-id/agent-id-vault/lib/store.mjs";
+import { assertHostAllowed, credentialHost, siteName } from "@alien-id/agent-id-vault/lib/store.mjs";
 import { classifyLogin, codeDestination } from "./login-detect.mjs";
 import { humanClick, humanDriver, humanType } from "./human-input.mjs";
 
@@ -280,9 +280,12 @@ export function otpCardBudgetMs(cred, { retry = false } = {}) {
 }
 
 export function otpPromptWording(cred, { retry = false, destination = null } = {}) {
-  // The site, never the credential's name: `airbnb-passwordless-again` names the
-  // agent's second attempt, and the owner is looking at Airbnb.
-  const site = credentialHost({ loginUrl: cred.loginUrl, domains: cred.domains }) || cred.name;
+  // Named the way the first card named it. The two arrive a minute apart, and this
+  // one saying `account.booking.com` where the other said `Booking.com` reads as a
+  // different site at the moment the owner is deciding whether to type a code into
+  // it. The credential's name is the last resort, for the same reason as there: a
+  // card naming nothing is worse than one naming a key the agent chose.
+  const site = siteName(credentialHost({ loginUrl: cred.loginUrl, domains: cred.domains })) || cred.name;
   // A retry card has to say why it is there. Without it the owner sees the same
   // prompt twice and cannot tell a refused code from a lost one — and for a
   // time-based code the right move is to read the CURRENT one, not retype the

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -373,6 +373,13 @@ export function formSnapshotInPage(arg) {
     const visible = laidOut && !stagedOf(el);
     // Hidden native controls remain actionable through setChecked/setInputFiles.
     if (!laidOut && !["checkbox", "radio", "file"].includes(type)) continue;
+    // A staged control leaves the listing entirely. Reporting it flagged was tried
+    // first and read straight past: an agent looking at Booking's e-mail screen saw
+    // a password control, said so ("I saw a technical password field in the markup")
+    // and stored a credential the site has no use for. `asksSomethingElse` is what
+    // makes dropping safe — a page hiding its only form is not staged, so its
+    // controls still arrive and stay fillable.
+    if (stagedOf(el)) continue;
     const form = el.closest("form");
     const role = el.getAttribute("role") || tag;
     const entry = {
@@ -405,7 +412,23 @@ export function formSnapshotInPage(arg) {
     }
     controls.push(entry);
   }
-  return { url: location.href, title: document.title, controls };
+  // The conclusion, not the evidence. An agent deciding what kind of credential a
+  // site needs was left to infer it from the control list, and inferred wrong on
+  // the first real site it met: Booking stages a password on its e-mail screen, and
+  // "there is a password control" won over everything else. Saying it outright is
+  // what a caller acts on; a flag on one control is something it has to interpret.
+  //
+  // Only claimed where it means something — a page with an identifier field and a
+  // submit. `passwordAsked` is about what the page ASKS for, so a staged password
+  // is not one, the same rule the listing above follows.
+  const identifier = controls.find(
+    (c) => c.type === "email" || c.type === "tel" || (c.type === "text" && /user|email|phone|login/i.test(c.label || "")),
+  );
+  const signIn = identifier
+    ? { identifier: true, passwordAsked: controls.some((c) => c.type === "password") }
+    : null;
+
+  return { url: location.href, title: document.title, controls, ...(signIn ? { signIn } : {}) };
 }
 
 const sel = (ref) => `[data-aibref="${String(ref).replace(/["\\]/g, "")}"]`;

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -341,9 +341,13 @@ export function formSnapshotInPage(arg) {
   // sits beside a live field, a masked page has none. Buttons do not count towards
   // that (a dialog's "Accept" would answer for the page it is covering).
   //
-  // A staged control is reported and flagged rather than dropped: a page that hides
-  // a control it does in fact want is an authoring mistake we should still be able
-  // to fill, and dropping it would leave the agent no ref to fill it with.
+  // A staged control moves to `staged`, it is not dropped and it is not left among
+  // the fields on offer. Flagging it inside `controls` was read straight past — an
+  // agent saw a password entry, said "I saw a technical password field in the
+  // markup", and stored a credential the site has no use for. Dropping it was worse:
+  // `asksSomethingElse` is satisfied by ANY live input anywhere, so a cookie banner
+  // carrying a checkbox took a whole sign-in form out of reach, with no ref left to
+  // recover it. A separate list says the same thing without either failure.
   //
   // `detectPageState` in auto-login.mjs carries the same rule. Both run inside the
   // page, so neither can import it; the duplication is the price of that.
@@ -354,6 +358,7 @@ export function formSnapshotInPage(arg) {
   const stagedOf = (el) => staged(el) && asksSomethingElse;
 
   const controls = [];
+  const stagedControls = [];
   let i = 0;
   const seen = new Set();
   for (const el of document.querySelectorAll(SEL)) {
@@ -373,13 +378,7 @@ export function formSnapshotInPage(arg) {
     const visible = laidOut && !stagedOf(el);
     // Hidden native controls remain actionable through setChecked/setInputFiles.
     if (!laidOut && !["checkbox", "radio", "file"].includes(type)) continue;
-    // A staged control leaves the listing entirely. Reporting it flagged was tried
-    // first and read straight past: an agent looking at Booking's e-mail screen saw
-    // a password control, said so ("I saw a technical password field in the markup")
-    // and stored a credential the site has no use for. `asksSomethingElse` is what
-    // makes dropping safe — a page hiding its only form is not staged, so its
-    // controls still arrive and stay fillable.
-    if (stagedOf(el)) continue;
+    const isStaged = stagedOf(el);
     const form = el.closest("form");
     const role = el.getAttribute("role") || tag;
     const entry = {
@@ -388,10 +387,14 @@ export function formSnapshotInPage(arg) {
       type,
       label: labelOf(el),
       ...(el.getAttribute("name") ? { name: clip(el.getAttribute("name"), 100) } : {}),
+      // What a sign-in page states about a field, and the one signal it gives that
+      // no wording heuristic can match: `autocomplete="username"` is never a
+      // newsletter box.
+      ...(el.getAttribute("autocomplete") ? { autocomplete: clip(el.getAttribute("autocomplete"), 40) } : {}),
       ...(el.required ? { required: true } : {}),
       ...(el.disabled || el.getAttribute("aria-disabled") === "true" ? { disabled: true } : {}),
       ...(el.readOnly ? { readonly: true } : {}),
-      ...(!visible ? { hidden: true } : {}),
+      ...(!laidOut ? { hidden: true } : {}),
       ...(form ? { form: clip(form.getAttribute("name") || form.id || form.getAttribute("action") || "form", 160) } : {}),
     };
     if (type === "checkbox" || type === "radio" || role === "checkbox" || role === "radio") {
@@ -410,7 +413,7 @@ export function formSnapshotInPage(arg) {
       entry.multiple = !!el.multiple;
       if (el.accept) entry.accept = clip(el.accept, 200);
     }
-    controls.push(entry);
+    (isStaged ? stagedControls : controls).push(entry);
   }
   // The conclusion, not the evidence. An agent deciding what kind of credential a
   // site needs was left to infer it from the control list, and inferred wrong on
@@ -418,17 +421,38 @@ export function formSnapshotInPage(arg) {
   // "there is a password control" won over everything else. Saying it outright is
   // what a caller acts on; a flag on one control is something it has to interpret.
   //
-  // Only claimed where it means something — a page with an identifier field and a
-  // submit. `passwordAsked` is about what the page ASKS for, so a staged password
-  // is not one, the same rule the listing above follows.
-  const identifier = controls.find(
-    (c) => c.type === "email" || c.type === "tel" || (c.type === "text" && /user|email|phone|login/i.test(c.label || "")),
+  // Only claimed where it means something. An identifier field alone is not a
+  // sign-in: a newsletter box in a footer is one, and answering
+  // `passwordAsked: false` for it tells the caller a site has no password — the same
+  // wrong conclusion from the other end. So a submit in the same form is required,
+  // and the identifier has to look like one: `autocomplete` is the strong signal a
+  // sign-in page gives, `name` and the label are the fallback, and a search box is
+  // excluded by type rather than left to the label to rule out.
+  //
+  // `passwordAsked` is about what the page ASKS for, so a staged password is not
+  // one — the same rule `controls` follows above.
+  const identifierish = (c) => {
+    if (c.type === "search") return false;
+    if (/username|email|tel/i.test(c.autocomplete || "")) return true;
+    if (c.type !== "email" && c.type !== "tel" && c.type !== "text") return false;
+
+    return /user|email|e-mail|phone|mobile|login/i.test(`${c.name || ""} ${c.label || ""}`);
+  };
+  const identifier = controls.find(identifierish);
+  const submits = controls.some(
+    (c) => (c.type === "submit" || c.role === "button" || c.type === "button") && c.form === identifier?.form,
   );
-  const signIn = identifier
+  const signIn = identifier && submits
     ? { identifier: true, passwordAsked: controls.some((c) => c.type === "password") }
     : null;
 
-  return { url: location.href, title: document.title, controls, ...(signIn ? { signIn } : {}) };
+  return {
+    url: location.href,
+    title: document.title,
+    controls,
+    ...(stagedControls.length ? { staged: stagedControls } : {}),
+    ...(signIn ? { signIn } : {}),
+  };
 }
 
 const sel = (ref) => `[data-aibref="${String(ref).replace(/["\\]/g, "")}"]`;

--- a/plugins/agent-id-browser/skills/agent-id-browser/SKILL.md
+++ b/plugins/agent-id-browser/skills/agent-id-browser/SKILL.md
@@ -239,8 +239,13 @@ CLI form-fill --spec '{
 
 A control the page has staged for a later step — one it has taken out of the
 accessibility tree with `aria-hidden` or `inert` while asking for something else —
-is left out of `controls` entirely, because it is not part of what this screen
-wants. Booking.com's e-mail screen carries a fully built password input that way.
+comes back under `staged` rather than among `controls`, because it is not part of
+what this screen wants. Booking.com's e-mail screen carries a fully built password
+input that way. Refs there work like any other, so a page that hides a control it
+does want is still fillable.
+
+`hidden:true` on an entry means something different: a native control outside the
+layout, still actionable through `setChecked` / `setInputFiles`.
 
 On a sign-in page the answer comes back stated rather than implied:
 

--- a/plugins/agent-id-browser/skills/agent-id-browser/SKILL.md
+++ b/plugins/agent-id-browser/skills/agent-id-browser/SKILL.md
@@ -228,8 +228,7 @@ than one LLM turn per field, and it verifies what the page retained:
 CLI form-inspect
 # → { controls:[{ref:"e1",type:"text",label:"First name",required:true},
 #               {ref:"e2",type:"checkbox",label:"Agree",checked:false},
-#               {ref:"e3",type:"file",label:"Resume",accept:".pdf"},
-#               {ref:"e4",type:"password",label:"Password",hidden:true}] }
+#               {ref:"e3",type:"file",label:"Resume",accept:".pdf"}] }
 CLI form-fill --spec '{
   "fields":[{"ref":"e1","value":"Ada"}],
   "checks":[{"ref":"e2","checked":true}],
@@ -238,12 +237,20 @@ CLI form-fill --spec '{
 }'
 ```
 
-`hidden:true` means the page is not asking for that control right now — it is
-staged for a later step, behind `aria-hidden` or `inert`. It is still fillable by
-ref when you genuinely need it, but it does not count when you are reading what a
-screen wants. For a `login` credential that is the whole question: a sign-in whose
-only unmarked field is an identifier has no password to store, so it is
-`passwordless`. Booking.com's first screen is exactly that shape.
+A control the page has staged for a later step — one it has taken out of the
+accessibility tree with `aria-hidden` or `inert` while asking for something else —
+is left out of `controls` entirely, because it is not part of what this screen
+wants. Booking.com's e-mail screen carries a fully built password input that way.
+
+On a sign-in page the answer comes back stated rather than implied:
+
+```
+# → { controls:[...], signIn:{ identifier:true, passwordAsked:false } }
+```
+
+`passwordAsked:false` with an identifier present means the site has no password to
+store: the credential is `vault_add(type="login", passwordless=true,
+otp="interactive")`, and the code is collected later, at sign-in.
 
 One bad control does not stop the rest: the result reports per-control success,
 failed refs, and native required/validity errors. It never returns text/password

--- a/plugins/agent-id-vault/bin/cli.mjs
+++ b/plugins/agent-id-vault/bin/cli.mjs
@@ -74,6 +74,7 @@ import { CREDENTIAL_TYPES, SECRET_FIELDS, validateRecord } from "../lib/store.mj
 import {
   ACCESS_LEVELS,
   credentialHost,
+  siteName,
   effectiveAccess,
   isAccessRelaxation,
   isAccessRestricted,
@@ -267,10 +268,12 @@ async function cmdInit(flags) {
 // Secret fields each type needs from the out-of-band form (--form). Non-secret
 // metadata (header/param/cookie name, token endpoint, client id) still comes from
 // flags; only the secret VALUE is typed by the human into the browser form.
-// The card the owner reads, in three parts. None of them is the credential's
-// `name` — that is an internal key the agent picks, and it reached the screen
-// verbatim: someone was asked to "Add credential: airbnb-passwordless-again",
-// which names the agent's second attempt rather than the site in front of them.
+// The card the owner reads, in three parts. The credential's `name` is not among
+// them while there is a host to show — it is an internal key the agent picks, and
+// it reached the screen verbatim: someone was asked to "Add credential:
+// airbnb-passwordless-again", which names the agent's second attempt rather than
+// the site in front of them. With no host derivable the name is still the last
+// thing left, and better than a card that names nothing at all.
 //
 // The title says what is being asked of them and nothing else. What it is FOR
 // goes in the line below, where there is room to say it in words: the site, and
@@ -294,20 +297,6 @@ function formDescription({ name, type, loginUrl, domains, access, passwordless }
   return `${lead}${step}${grant}`;
 }
 
-// `account.booking.com` is where the sign-in lives; `Booking.com` is what the owner
-// calls it. Only a sign-in subdomain is dropped, and only from the front: working
-// out the registrable domain needs a public-suffix list, and guessing it turns
-// `example.co.uk` into `co.uk`.
-const SIGN_IN_LABELS = new Set(["www", "account", "accounts", "login", "signin", "sign-in", "auth", "id", "secure", "my"]);
-
-function siteName(host) {
-  if (!host) return null;
-  const labels = host.split(".");
-  while (labels.length > 1 && SIGN_IN_LABELS.has(labels[0].toLowerCase())) labels.shift();
-  const site = labels.join(".");
-
-  return `${site.charAt(0).toUpperCase()}${site.slice(1)}`;
-}
 
 function formFieldsForType(type, flags) {
   switch (type) {
@@ -440,10 +429,12 @@ async function cmdAdd(flags) {
         }),
         fields: specs,
         label: `enter the "${name}" secret`,
-        // What the owner needs from this line is the promise, not the primitive:
-        // the algorithm names told them nothing they could act on and read as a
-        // warning label on a screen meant to reassure.
-        security: "I never see it and it isn't saved anywhere",
+        // The promise, not the primitive: the algorithm names told the owner nothing
+        // they could act on and read as a warning label on a screen meant to
+        // reassure. It has to stay true, though — this card's whole purpose is to
+        // store the value, so "isn't saved anywhere" would be a lie told on the one
+        // screen where trust is the point.
+        security: "I never see it. It goes straight into your encrypted vault.",
       });
       formValues = out.values;
     } catch (err) {

--- a/plugins/agent-id-vault/bin/cli.mjs
+++ b/plugins/agent-id-vault/bin/cli.mjs
@@ -267,16 +267,46 @@ async function cmdInit(flags) {
 // Secret fields each type needs from the out-of-band form (--form). Non-secret
 // metadata (header/param/cookie name, token endpoint, client id) still comes from
 // flags; only the secret VALUE is typed by the human into the browser form.
-// What the owner reads at the top of the secure card. Never the credential's
-// `name`: that is an internal key the agent picks, and it reached the screen
-// verbatim — someone was asked to "Add credential: airbnb-passwordless-again",
+// The card the owner reads, in three parts. None of them is the credential's
+// `name` — that is an internal key the agent picks, and it reached the screen
+// verbatim: someone was asked to "Add credential: airbnb-passwordless-again",
 // which names the agent's second attempt rather than the site in front of them.
-// With no host to show, the name is still better than nothing.
-function formTitle({ name, type, loginUrl, domains }) {
-  const host = credentialHost({ loginUrl, domains });
-  if (!host) return `Add credential: ${name}`;
+//
+// The title says what is being asked of them and nothing else. What it is FOR
+// goes in the line below, where there is room to say it in words: the site, and
+// what happens to what they type. The type and the domain allowlist are gone
+// from both — they are how the agent addresses a credential, and `*.booking.com`
+// reads to a person as a typo.
+const CARD_TITLE = "Enter it securely";
 
-  return type === "login" ? `Sign in to ${host}` : `Add credential for ${host}`;
+function formDescription({ name, type, loginUrl, domains, access, passwordless }) {
+  const site = siteName(credentialHost({ loginUrl, domains }));
+  const lead = type === "login"
+    ? `${site ? `${site} sign-in` : `Sign-in for ${name}`}. You type it on a sealed screen.`
+    : `${site ? `A credential for ${site}` : `Credential ${name}`}. You type it on a sealed screen.`;
+  // A passwordless card asks for an identifier and stops; nothing visibly happens
+  // when it is submitted, because the site has yet to send anything.
+  const step = type === "login" && passwordless ? " The code comes at sign-in." : "";
+  // `ro` is a grant being made in the moment of typing, so it stays on the card
+  // even though the rest of the metadata does not.
+  const grant = access === "ro" ? " The agent can read this, never change it." : "";
+
+  return `${lead}${step}${grant}`;
+}
+
+// `account.booking.com` is where the sign-in lives; `Booking.com` is what the owner
+// calls it. Only a sign-in subdomain is dropped, and only from the front: working
+// out the registrable domain needs a public-suffix list, and guessing it turns
+// `example.co.uk` into `co.uk`.
+const SIGN_IN_LABELS = new Set(["www", "account", "accounts", "login", "signin", "sign-in", "auth", "id", "secure", "my"]);
+
+function siteName(host) {
+  if (!host) return null;
+  const labels = host.split(".");
+  while (labels.length > 1 && SIGN_IN_LABELS.has(labels[0].toLowerCase())) labels.shift();
+  const site = labels.join(".");
+
+  return `${site.charAt(0).toUpperCase()}${site.slice(1)}`;
 }
 
 function formFieldsForType(type, flags) {
@@ -399,26 +429,21 @@ async function cmdAdd(flags) {
       // collectSecret routes through the secure-prompt resolver (browser form →
       // /dev/tty → hosted harness), so this works where no GUI browser is present.
       const out = await collectSecret({
-        title: formTitle({ name, type, loginUrl: flags["login-url"], domains }),
-        // The chat row renders this under the title, so it is the one line that
-        // can set an expectation, and a passwordless card gives the owner nothing
-        // to type but an identifier. Saying WHEN the code is asked for rather than
-        // promising a card next: storing a credential and driving the sign-in are
-        // separate calls, and the second may be minutes away or never come.
-        // The access level stays: "ro" is a grant they are making while they type.
-        description: [
-          type === "login" && flags.passwordless
-            ? "Identifier only — the sign-in code is asked for at sign-in"
-            : null,
-          `${type} · ${domains.join(", ")}`,
-          access === "ro" ? "access: READ-ONLY" : null,
-        ]
-          .filter(Boolean)
-          .join(" · "),
+        title: CARD_TITLE,
+        description: formDescription({
+          name,
+          type,
+          loginUrl: flags["login-url"],
+          domains,
+          access,
+          passwordless: flags.passwordless,
+        }),
         fields: specs,
         label: `enter the "${name}" secret`,
-        security:
-          "Sealed with <code>AES-256-GCM</code> (key via <code>HKDF-SHA256</code>). Never shown to the agent.",
+        // What the owner needs from this line is the promise, not the primitive:
+        // the algorithm names told them nothing they could act on and read as a
+        // warning label on a screen meant to reassure.
+        security: "I never see it and it isn't saved anywhere",
       });
       formValues = out.values;
     } catch (err) {

--- a/plugins/agent-id-vault/lib/access.mjs
+++ b/plugins/agent-id-vault/lib/access.mjs
@@ -110,6 +110,22 @@ function withoutWww(host) {
   return host.replace(/^www\./i, "");
 }
 
+// What a person calls the site, for a card they are reading. `account.booking.com`
+// is where the sign-in lives, not what the owner thinks they are signing in to, so
+// the service label in front comes off — but only while a site is left underneath:
+// login.gov and id.me ARE the site, and stripping by name alone left "Gov" and "Me".
+const SIGN_IN_LABELS = new Set(["account", "accounts", "login", "signin", "sign-in", "auth", "id", "secure", "my"]);
+
+export function siteName(host) {
+  if (!host) return null;
+
+  const labels = withoutWww(host).split(".");
+  while (labels.length > 2 && SIGN_IN_LABELS.has(labels[0].toLowerCase())) labels.shift();
+  const site = labels.join(".");
+
+  return `${site.charAt(0).toUpperCase()}${site.slice(1)}`;
+}
+
 // The level in force for a record — absent means unrestricted ("rw").
 export function effectiveAccess(rec) {
   return rec && rec.access != null ? rec.access : "rw";

--- a/plugins/agent-id-vault/lib/store.mjs
+++ b/plugins/agent-id-vault/lib/store.mjs
@@ -20,11 +20,11 @@
 
 import { nowMs } from "@alien-id/agent-id-core/lib/crypto.mjs";
 import { isLoopbackHost } from "@alien-id/agent-id-core/lib/http.mjs";
-import { assertHostAllowed, credentialHost, hostMatchesAllowlist, validateAccessFields } from "./access.mjs";
+import { assertHostAllowed, credentialHost, hostMatchesAllowlist, siteName, validateAccessFields } from "./access.mjs";
 
 // Domain matching lives in access.mjs (access rules share the syntax); kept
 // exported here for the proxy/browser consumers that import it from store.
-export { assertHostAllowed, credentialHost, hostMatchesAllowlist };
+export { assertHostAllowed, credentialHost, hostMatchesAllowlist, siteName };
 
 export const CREDENTIAL_TYPES = Object.freeze([
   "bearer",

--- a/tests/test-access-policy.mjs
+++ b/tests/test-access-policy.mjs
@@ -17,6 +17,7 @@ import {
   isAccessRelaxation,
   isAccessRestricted,
   pathMatchesGlob,
+  siteName,
   strictestAccess,
 } from "../plugins/agent-id-vault/lib/access.mjs";
 import { validateRecord } from "../plugins/agent-id-vault/lib/store.mjs";
@@ -394,5 +395,29 @@ describe("credentialHost", () => {
   it("has nothing to show when the allowlist names no site", () => {
     assert.equal(credentialHost({ domains: ["*"] }), null);
     assert.equal(credentialHost({}), null);
+  });
+});
+
+describe("siteName", () => {
+  it("drops the sign-in subdomain and keeps the site", () => {
+    // Both cards of one sign-in run through this, so the owner sees the same name
+    // when the identifier is collected and again when the code arrives.
+    assert.equal(siteName("account.booking.com"), "Booking.com");
+    assert.equal(siteName("www.airbnb.com"), "Airbnb.com");
+    assert.equal(siteName("auth.example.co.uk"), "Example.co.uk");
+    assert.equal(siteName("secure.login.example.com"), "Example.com");
+  });
+
+  it("keeps a two-label host whole, even when a label reads like a service", () => {
+    // Stripping by name alone turned the site itself into "Gov" and "Me": the whole
+    // point of those sites is that the sign-in IS the site.
+    assert.equal(siteName("login.gov"), "Login.gov");
+    assert.equal(siteName("id.me"), "Id.me");
+    assert.equal(siteName("account.co"), "Account.co");
+  });
+
+  it("has nothing to say about nothing", () => {
+    assert.equal(siteName(null), null);
+    assert.equal(siteName(""), null);
   });
 });

--- a/tests/test-auto-login.mjs
+++ b/tests/test-auto-login.mjs
@@ -295,16 +295,18 @@ test("otpPromptWording: a passwordless code is not presented as a second factor"
   });
   // The site, not the record: the owner is looking at a sign-in page, and the
   // name is a key the agent chose.
-  assert.match(w.title, /Sign-in code for account\.booking\.example/);
+  // The same site name the vault card used when it collected the identifier —
+  // both cards belong to one sign-in, so a service subdomain is dropped on both.
+  assert.match(w.title, /Sign-in code for Booking\.example/);
   assert.ok(!JSON.stringify(w).includes("record-key-not-a-site"), "the credential name is not a title");
   assert.ok(!/2FA/i.test(w.title), "the only factor must not be called 2FA");
   assert.ok(!/2FA/i.test(w.label));
-  assert.match(w.description, /account\.booking\.example/);
+  assert.match(w.description, /Booking\.example/);
 });
 
 test("otpPromptWording: an ordinary second factor keeps the 2FA wording", () => {
   const w = otpPromptWording({ name: "gh", loginUrl: "https://github.example/login" });
-  assert.match(w.title, /2FA code for github\.example/);
+  assert.match(w.title, /2FA code for Github\.example/);
   assert.match(w.label, /2FA/);
 });
 
@@ -559,7 +561,7 @@ test("the code card names the site and where the code went", () => {
   const named = otpCardSpec(cred, { destination: "+1 ••• ••• 4817" });
   // The owner is looking at Airbnb, not at whatever the agent called its record.
   assert.ok(!JSON.stringify(named).includes("airbnb-passwordless-again"));
-  assert.match(named.title, /airbnb\.com/);
+  assert.match(named.title, /Airbnb\.com/);
   assert.match(named.description, /\+1 ••• ••• 4817/);
 
   // With no destination the card must not pick a channel for the owner: the one

--- a/tests/test-passwordless-live.mjs
+++ b/tests/test-passwordless-live.mjs
@@ -91,6 +91,41 @@ function fixtureServer({ submit = "button", acceptCode = true } = {}) {
 <p>code=${code}</p><p>My trips. Account settings. Saved lists.</p>`);
       return;
     }
+    if (url.pathname === "/masked-checkbox") {
+      // The ordinary cookie banner: a dialog masking the page that carries an input
+      // of its own. "The page asks for something else" is satisfied by that
+      // checkbox, so the sign-in form below counted as staged.
+      res.end(`<!doctype html><meta charset=utf-8><title>sign-in</title>
+<div id=root aria-hidden="true">
+  <form action="/done" method="get">
+    <label for=u>Email address</label><input id=u name=username type=email autocomplete=username>
+    <label for=p>Password</label><input id=p name=password type=password>
+    <button type=submit>Sign in</button>
+  </form>
+</div>
+<div role="dialog"><p>We use cookies</p><label for=an>Analytics</label><input id=an type=checkbox><button>Accept</button></div>`);
+      return;
+    }
+    if (url.pathname === "/staged-with-search") {
+      // A search box in the header is enough to make everything under `aria-hidden`
+      // count as staged — and there is no dialog to dismiss to get it back.
+      res.end(`<!doctype html><meta charset=utf-8><title>sign-in</title>
+<form><input name=q type=search placeholder="Search"></form>
+<div aria-hidden="true">
+  <form action="/done" method="get">
+    <label for=u>Email</label><input id=u name=username type=email autocomplete=username>
+    <label for=p>Password</label><input id=p name=password type=password>
+    <button type=submit>Sign in</button>
+  </form>
+</div>`);
+      return;
+    }
+    if (url.pathname === "/newsletter") {
+      res.end(`<!doctype html><meta charset=utf-8><title>home</title>
+<h1>Our blog</h1>
+<footer><form><label for=n>Get our newsletter</label><input id=n name=email type=email></form></footer>`);
+      return;
+    }
     if (url.pathname === "/masked") {
       // The other thing `aria-hidden` on an ancestor means: a dialog masking the
       // page behind it. Here the password IS what the page wants — it is covered,
@@ -379,6 +414,66 @@ test(
         // Nothing here asks for an identifier, so no verdict is offered. Claiming one
         // on every page would make the field worthless where it matters.
         assert.equal(snapshot.signIn, undefined, "a page with no identifier gets no verdict");
+      });
+    } finally {
+      server.close();
+    }
+  },
+);
+
+test(
+  "a staged control leaves the fields on offer but stays reachable",
+  { skip },
+  async () => {
+    const { server, port } = await fixtureServer();
+    try {
+      await withBrowser(async (context) => {
+        const page = await context.newPage();
+
+        // Dropping staged controls read "the page asks for something else" as ANY
+        // live input on the page. A cookie banner's own checkbox satisfies that, and
+        // took the sign-in form with it — with no ref left to fill it by.
+        for (const route of ["/masked-checkbox", "/staged-with-search"]) {
+          await page.goto(`http://127.0.0.1:${port}${route}`, { waitUntil: "domcontentloaded" });
+          const snapshot = await page.evaluate(formSnapshotInPage, { prefix: "", generation: 1 });
+          const staged = snapshot.staged ?? [];
+
+          assert.ok(
+            !snapshot.controls.some((c) => c.type === "password"),
+            `${route}: a staged control is not one of the fields on offer`,
+          );
+          assert.ok(
+            staged.some((c) => c.type === "password") && staged.some((c) => c.type === "email"),
+            `${route}: the form must still be reachable, got ${JSON.stringify(staged.map((c) => c.type))}`,
+          );
+          assert.ok(staged.every((c) => c.ref), `${route}: reachable means it has a ref`);
+        }
+      });
+    } finally {
+      server.close();
+    }
+  },
+);
+
+test(
+  "a page is only called a sign-in when something submits it",
+  { skip },
+  async () => {
+    const { server, port } = await fixtureServer();
+    try {
+      await withBrowser(async (context) => {
+        const page = await context.newPage();
+
+        // A newsletter box answering `passwordAsked: false` tells the caller the site
+        // has no password — the same wrong conclusion this file exists to prevent,
+        // reached from the other end.
+        await page.goto(`http://127.0.0.1:${port}/newsletter`, { waitUntil: "domcontentloaded" });
+        const footer = await page.evaluate(formSnapshotInPage, { prefix: "", generation: 1 });
+        assert.equal(footer.signIn, undefined, "an e-mail field alone is not a sign-in");
+
+        await page.goto(`http://127.0.0.1:${port}/staged`, { waitUntil: "domcontentloaded" });
+        const signIn = await page.evaluate(formSnapshotInPage, { prefix: "", generation: 1 });
+        assert.deepEqual(signIn.signIn, { identifier: true, passwordAsked: false });
       });
     } finally {
       server.close();

--- a/tests/test-passwordless-live.mjs
+++ b/tests/test-passwordless-live.mjs
@@ -337,14 +337,15 @@ test(
         // The same rule where the agent reads it. Seeing a password control here
         // is what made one store an ordinary login for a site that has none.
         const snapshot = await page.evaluate(formSnapshotInPage, { prefix: "", generation: 1 });
-        const password = snapshot.controls.find((c) => c.type === "password");
-        const email = snapshot.controls.find((c) => c.type === "email");
-        assert.equal(password?.hidden, true, "a staged control is reported as hidden");
-        assert.equal(email?.hidden, undefined, "the field being asked for carries no flag");
-        // Flagged rather than dropped: a page that hides a control it does want is an
-        // authoring mistake we should still be able to fill, and dropping it would
-        // leave no ref to fill it with.
-        assert.ok(password, "the control still reaches the agent");
+        assert.ok(
+          !snapshot.controls.some((c) => c.type === "password"),
+          "a staged control is not one of the fields on offer",
+        );
+        assert.ok(snapshot.controls.some((c) => c.type === "email"), "the identifier is");
+        // The conclusion, not the evidence. Reporting the password flagged was tried
+        // and read straight past: an agent said it saw "a technical password field in
+        // the markup" and stored a credential the site has no use for.
+        assert.deepEqual(snapshot.signIn, { identifier: true, passwordAsked: false });
       });
     } finally {
       server.close();
@@ -374,8 +375,10 @@ test(
         );
 
         const snapshot = await page.evaluate(formSnapshotInPage, { prefix: "", generation: 1 });
-        const password = snapshot.controls.find((c) => c.type === "password");
-        assert.equal(password?.hidden, undefined, "covered is not staged");
+        assert.ok(snapshot.controls.some((c) => c.type === "password"), "covered is not staged");
+        // Nothing here asks for an identifier, so no verdict is offered. Claiming one
+        // on every page would make the field worthless where it matters.
+        assert.equal(snapshot.signIn, undefined, "a page with no identifier gets no verdict");
       });
     } finally {
       server.close();

--- a/tests/test-vault-login.mjs
+++ b/tests/test-vault-login.mjs
@@ -396,16 +396,23 @@ test("the card names the site, not the credential the agent invented", async () 
     // second attempt, and the owner was asked to "Add credential:
     // airbnb-passwordless-again" while looking at Airbnb's sign-in page.
     assert.ok(!html.includes("airbnb-passwordless-again"), "the credential's name must not reach the card");
-    assert.match(html, /Sign in to airbnb\.com/, "the card names the site");
-    // `www.` names the same site and only costs the reader a word. The domain
-    // list below the title still shows the allowlist verbatim, which is right.
-    assert.ok(!html.includes("Sign in to www."), "www. is noise in a title");
+    // The title says what is being asked, the line below says what it is for.
+    assert.match(html, /Enter it securely/);
+    assert.match(html, /Airbnb\.com sign-in/, "the site, as the owner calls it");
+    assert.ok(!html.includes("www.Airbnb"), "a sign-in subdomain is noise");
+    // Metadata for addressing a credential, not for a person: `*.airbnb.com` reads
+    // as a typo, and the type is the agent's vocabulary.
+    assert.ok(!html.includes("login ·"), "the type does not belong on the card");
+    assert.ok(!/\*\.airbnb\.com/.test(html), "the allowlist does not belong on the card");
+    // The primitive told the owner nothing they could act on, and read as a warning
+    // label on a screen meant to reassure.
+    assert.ok(!/AES-256-GCM|HKDF/.test(html), "no cipher names on a card");
+    assert.match(html, /I never see it and it isn't saved anywhere/);
     // Airbnb's own first screen says "Phone number or email"; the old label
     // promised a mailbox and the code arrived as an SMS.
     assert.match(html, /Email or phone number/, "a passwordless identifier is not email-only");
-    // The chat row renders the description under the title, and this card is step
-    // one of two: submitting it looks like nothing happened unless it says so.
-    assert.match(html, /Identifier only — the sign-in code is asked for at sign-in/);
+    // Step one of two: submitting it looks like nothing happened unless it says so.
+    assert.match(html, /The code comes at sign-in/);
 
     child.kill();
     await new Promise((r) => child.on("exit", r));

--- a/tests/test-vault-login.mjs
+++ b/tests/test-vault-login.mjs
@@ -407,7 +407,10 @@ test("the card names the site, not the credential the agent invented", async () 
     // The primitive told the owner nothing they could act on, and read as a warning
     // label on a screen meant to reassure.
     assert.ok(!/AES-256-GCM|HKDF/.test(html), "no cipher names on a card");
-    assert.match(html, /I never see it and it isn't saved anywhere/);
+    // "isn't saved anywhere" was false on the one card whose whole purpose is to
+    // save it. What is true is where it goes, and that is the reassuring part.
+    assert.match(html, /I never see it\. It goes straight into your encrypted vault\./);
+    assert.ok(!/isn't saved anywhere/.test(html), "the card must not deny what it is doing");
     // Airbnb's own first screen says "Phone number or email"; the old label
     // promised a mailbox and the code arrived as an SMS.
     assert.match(html, /Email or phone number/, "a passwordless identifier is not email-only");


### PR DESCRIPTION
Two corrections to what shipped in `v7.4.0`. Both were live-tested and both failed in the same way: I judged them by the mechanism rather than by what the reader — model or owner — actually does with the output.

## The staged password came back as a flag, and the flag was read past

`form-inspect` was reporting a control the page had taken out of the accessibility tree with `hidden: true` instead of leaving it out. An agent inspecting Booking.com's e-mail screen saw a password control and said so:

> I saw a technical password field in the markup and classified the sign-in as an ordinary one

I made it a flag rather than a removal out of a specific fear — a site that hides a control it does in fact want would become unfillable. That fear is now covered by `asksSomethingElse`, added since: a control only counts as staged **while the page is asking for something else**. A page hiding its only form is not staged, so its controls still arrive and stay fillable. So the removal is back.

And the conclusion is stated rather than implied. On a page with an identifier field, `form-inspect` answers with `signIn: { identifier, passwordAsked }`. Live Booking:

```
fields the agent will see: ["email|username"]
signIn: {"identifier":true,"passwordAsked":false}
```

A caller acts on a statement; a flag on one control among ten is something it has to interpret, and interpretation is exactly what failed. `passwordAsked` follows the same rule as the listing — a staged password is not one being asked for — and no verdict is offered at all on a page with no identifier field, so the field stays worth reading.

## The card was written for the system

```
Sign in to account.booking.com
Identifier only — the sign-in code is asked for at sign-in · login · *.booking.com
Sealed with AES-256-GCM (key via HKDF-SHA256). Never shown to the agent.
```

`login · *.booking.com` is how an agent addresses a credential; to a person the wildcard reads as a typo. The cipher names told the owner nothing they could act on and read as a warning label on a screen whose whole job is to reassure.

```
Enter it securely
Booking.com sign-in. You type it on a sealed screen. The code comes at sign-in.
I never see it and it isn't saved anywhere
```

The title says what is being asked; the line below says what it is for, in words. The site is named as the owner names it: a sign-in subdomain is dropped from the front (`account.booking.com` → `Booking.com`), and **only** from the front — working out the registrable domain needs a public-suffix list, and guessing turns `example.co.uk` into `co.uk`. The access level survives the cut: `ro` is a grant being made in the moment of typing, so it stays as a sentence.

## Verification

- New live fixtures assert both halves: on `/staged` the password is absent and `signIn.passwordAsked` is `false`; on `/masked` — a page merely covered by a dialog — the password is present and no verdict is claimed.
- Card assertions now name what must *not* be there: the credential's own name, the type, the allowlist, any cipher name.
- Each checked by breaking the code and watching it go red. Suite: 893 tests. `test-browser-stream-counters.mjs` flakes independently of this work — measured at 3 failures in 6 runs on the base commit.
