### PR TITLE
chore: keep comments and docs inside this repo, and check they stay

### DIFF
--- a/.changeset/neutralize-implementation-comments.md
+++ b/.changeset/neutralize-implementation-comments.md
@@ -1,0 +1,12 @@
+---
+"@alien-id/agent-id-browser": patch
+---
+
+Describe behaviour in terms of this package.
+
+Some implementation comments explained a decision by pointing at something
+outside this repo. They now say what holds here — an auto-login run is bounded
+by "the caller's own 16-minute ceiling", and the sandbox opt-in describes
+containerized per-user deployments.
+
+Comments only; no behaviour change.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
         include:
           - name: Test
             run: bun run test
+          - name: Public-repo hygiene
+            run: bun run ci:hygiene
           - name: Script tests
             run: bun test scripts/tests
           - name: Version sync (drift check)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ agent-id/
 │   ├── agent-id-auth/     # marketplace-only (private) — DPoP calls (→ core)
 │   ├── agent-id-git/      # marketplace-only (private) — SSH-signed commits (→ core)
 │   ├── agent-id-proxy/    # marketplace-only (private) — credential-injecting proxy (→ core, vault)
-│   └── agent-id-browser/  # marketplace-only (private) — vault-sealed browser (→ core, vault)
+│   └── agent-id-browser/  # @alien-id/agent-id-browser (npm, public) + marketplace — vault-sealed browser (→ core, vault)
 ├── .claude-plugin/marketplace.json   # marketplace catalog (versions synced from package.json)
 ├── scripts/               # changesets release tooling (.ts, run with bun)
 ├── tests/                 # node --test suite (test-*.mjs)
@@ -26,10 +26,27 @@ agent-id/
 
 ### Two distribution layers
 
-- **npm**: only `@alien-id/agent-id-core` and `@alien-id/agent-id-vault` are
-  published. They are the shared libraries the other plugins import.
-- **Claude Code marketplace**: all six plugins. `auth`/`git`/`proxy`/`browser`
-  are `private` (never on npm) and consume the two libs at runtime.
+- **npm**: `@alien-id/agent-id-core`, `@alien-id/agent-id-vault` and
+  `@alien-id/agent-id-browser` are published. `core` and `vault` are the shared
+  libraries the other plugins import; `browser` is dual-channel — a marketplace
+  plugin **and** an npm package, so external apps can depend on it instead of
+  vendoring a tarball. See RELEASING.md.
+- **Claude Code marketplace**: all six plugins. `auth`/`git`/`proxy` are
+  `private` (never on npm) and consume the libs at runtime.
+
+### This repository is public
+
+Everything here is world-readable, and the three npm packages above carry their
+`lib/` to the registry — a comment written for a colleague is published with the
+next release. Two rules, both enforced by `bun run ci:hygiene` (CI):
+
+- **Write about this repo only.** No project, repository, or file path from
+  another codebase, and no detail of how anything else is deployed. State what
+  holds here — "the caller's 16-minute ceiling" — rather than where someone else
+  implements it. This applies to commit messages, changesets and PR descriptions
+  as much as to comments; a cleanup that explains what it removed puts it back.
+- **Our prose is English.** Cyrillic is allowed only as data the product must
+  match: the rejection copy in `login-detect.mjs` and the fixtures pinning it.
 
 ### Cross-plugin code sharing
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,7 +13,7 @@ Three packages go to npm:
 | --- | --- | --- |
 | `@alien-id/agent-id-core` | public | shared crypto / bundle / verifier / OIDC / state |
 | `@alien-id/agent-id-vault` | public | encrypted credential vault (depends on core) |
-| `@alien-id/agent-id-browser` | public | vault-sealed browser automation; also consumed as a library (the Lethe desktop bundles it as an npm dependency) |
+| `@alien-id/agent-id-browser` | public | vault-sealed browser automation; also consumed as a library (the desktop host bundles it as an npm dependency) |
 
 `agent-id-browser` is dual-channel: it ships as a marketplace plugin **and** is
 published to npm, so external apps can depend on it instead of vendoring a

--- a/docs/COWORK-MCP.md
+++ b/docs/COWORK-MCP.md
@@ -31,7 +31,7 @@ locked VM."
 MCP connectors are exactly how Cowork wires in tools. Instead of shipping bash-CLI
 plugins, ship an **MCP server** that Cowork adds as a **remote connector** over
 HTTPS. The server is a **thin adapter over the existing `agent-id-*` CLIs** — the
-same pattern Lethe already uses (shell out, return JSON) — so there is no
+same pattern the desktop host already uses (shell out, return JSON) — so there is no
 re-implementation of command logic.
 
 ```
@@ -45,7 +45,7 @@ Cowork VM ── HTTPS (Streamable-HTTP MCP, per-user bearer) ──▶  agent-i
 Running the server **hosted** (not in the VM) sidesteps every VM limitation — no
 hooks, no plugin env vars, no npm-in-VM, no Chrome-in-VM. The VM just opens one
 allowed HTTPS connection. The **vault-sealed browser runs server-side**, exactly
-as `lethe-hosted` already does, so the "agent never sees the credential" seal is
+as the hosted runtime already does, so the "agent never sees the credential" seal is
 preserved (a host-Chrome path would break it — secrets would flow through Cowork's
 own browser). Vault + identity state persist on the service, not the ephemeral VM.
 
@@ -53,15 +53,15 @@ own browser). Vault + identity state persist on the service, not the ephemeral V
 
 1. **`plugins/agent-id-mcp/`** (new, private) — an MCP server (`@modelcontextprotocol/sdk`).
    - Maps MCP tools → the existing CLIs via subprocess, returning their JSON.
-   - Resolves each CLI by `AGENT_ID_{CORE,VAULT,BROWSER}_BIN` env or PATH (mirrors
-     lethe's `find_bin`).
+   - Resolves each CLI by `AGENT_ID_{CORE,VAULT,BROWSER}_BIN` env or PATH (the same
+     resolution order the desktop host uses).
    - Two transports from one tool registry: **stdio** (local dev / in-VM option)
      and **Streamable HTTP** (hosted connector).
-   - Tool surface = the current lethe surface: `agent_id_status/sign/bind`,
+   - Tool surface = the current desktop-host surface: `agent_id_status/sign/bind`,
      `vault_list/add/remove/set_totp`, `browser_open/act/close/login/auto_login/fill_secret/fill_otp`.
-2. **Hosting** — reuse the `lethe-hosted` runtime image (Chrome + CLIs baked, the
+2. **Hosting** — reuse the hosted runtime image (Chrome + CLIs baked, the
    `AGENT_ID_BROWSER_NO_SANDBOX`/`--shm-size` work already done). Expose the MCP
-   server on an HTTPS route with per-user auth (lethe-hosted already issues
+   server on an HTTPS route with per-user auth (the hosted runtime already issues
    per-user tokens). Per-user state dir → per-user vault/identity.
 3. **Cowork plugin** — a thin bundle (a `.claude-plugin` + a connector manifest
    declaring the MCP server + optional `/`-skills that call it) so it appears in
@@ -77,16 +77,16 @@ own browser). Vault + identity state persist on the service, not the ephemeral V
   already runs server-side; the MCP server just relays `open/act/close/fill_*`).
 - [ ] **3. HTTP transport + auth** — Streamable-HTTP with a per-user bearer; map
   the bearer → per-user `AGENT_ID_STATE_DIR`.
-- [ ] **4. Hosting** — add the MCP route to lethe-hosted (or a sibling service);
+- [ ] **4. Hosting** — add the MCP route to the hosted runtime (or a sibling service);
   bake `agent-id-mcp` into the runtime image; nginx route + TLS.
 - [ ] **5. Cowork plugin** — connector manifest + skills; validate install via the
   Cowork setup flow.
 
 ### Open decisions
 
-- **Where hosted**: fold into the lethe-hosted control plane vs a standalone
+- **Where hosted**: fold into the hosted runtime's control plane vs a standalone
   `agent-id-mcp` service. Leaning fold-in (reuses per-user containers + Chrome).
-- **Auth**: reuse lethe-hosted per-user tokens vs a dedicated OAuth for the
+- **Auth**: reuse the hosted runtime's per-user tokens vs a dedicated OAuth for the
   connector. Cowork connectors support both bearer and OAuth.
 - **Multi-tenant browser**: one sealed-browser daemon per user (as today) keyed by
   the per-user state dir.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:develop-smoke": "bash tests/integration/develop-sso-smoke.sh",
     "changeset": "changeset",
     "changeset:status": "changeset status --verbose",
+    "ci:hygiene": "bun scripts/check-public-hygiene.ts",
     "ci:detect": "bun scripts/detect-release.ts",
     "ci:version": "changeset version && bun install && bun run sync-plugin-versions",
     "ci:publish": "bun scripts/publish-topological.ts && changeset tag",

--- a/plugins/agent-id-browser/CHANGELOG.md
+++ b/plugins/agent-id-browser/CHANGELOG.md
@@ -11,7 +11,7 @@
 
   **`form-inspect`'s output shape changed**, which is why the browser package takes a
   major: a control the page has staged now arrives under `staged` instead of among
-  `controls`, and a sign-in page answers with `signIn`. lethe reads this contract in
+  `controls`, and a sign-in page answers with `signIn`. The desktop host reads this contract in
   its `vault_add` description, so the two move together.
 
   **The staged password came back as a flag, and the flag was read straight past.**

--- a/plugins/agent-id-browser/lib/auto-login.mjs
+++ b/plugins/agent-id-browser/lib/auto-login.mjs
@@ -265,10 +265,10 @@ export async function runRecipe(
 // Measured on a live Booking.com run, where a two-minute retry expired with the
 // owner still fetching the mail.
 //
-// Both budgets are bounded by the same thing — lethe's 16-minute HUMAN_TIMEOUT
-// (`src/agent_id/cli.rs`) kills the whole auto-login subprocess, cards, navigation
-// and settles included. That is what rules out a second full-length card: 10 + 4
-// leaves room for the page work either side, where 10 + 10 does not.
+// Both budgets are bounded by the same thing — the caller's own 16-minute ceiling
+// kills the whole auto-login run, cards, navigation and settles included. That is
+// what rules out a second full-length card: 10 + 4 leaves room for the page work
+// either side, where 10 + 10 does not.
 const OTP_CARD_MS = 10 * 60 * 1000;
 const OTP_GLANCE_RETRY_CARD_MS = 2 * 60 * 1000;
 const OTP_MAILBOX_RETRY_CARD_MS = 4 * 60 * 1000;

--- a/plugins/agent-id-browser/lib/launch.mjs
+++ b/plugins/agent-id-browser/lib/launch.mjs
@@ -84,8 +84,8 @@ export async function loadChromium() {
 
 // Chrome hard-refuses to start as root with the sandbox on ("Running as root
 // without --no-sandbox is not supported"), which is exactly the situation in a
-// containerized deployment (e.g. lethe-hosted per-user containers run as root;
-// the container itself is the isolation boundary there). This explicit opt-in
+// containerized deployment (e.g. hosted per-user containers run as root; the
+// container itself is the isolation boundary there). This explicit opt-in
 // KEEPS patchright's injected --no-sandbox instead of stripping it. Default
 // (unset) preserves the stealth-validated sandbox-on launch. Not fingerprintable
 // from the page: --no-sandbox changes no JS surface and no request header.

--- a/plugins/agent-id-browser/lib/login-detect.mjs
+++ b/plugins/agent-id-browser/lib/login-detect.mjs
@@ -123,8 +123,8 @@ const CONFIRM_BODY_RE =
 // Russian: a datacenter-hosted browser gets the page in the site's language,
 // and a rejection it cannot read degrades to `unknown` → `timeout` →
 // `owner_must_drive`, which sends the owner to a browser for what is really a
-// wrong password (seen on lk.eneva.ru: «Пользователь не найден или неверный
-// пароль»). Keep each phrase specific to a failed sign-in.
+// wrong password — seen on a live Russian-language sign-in. Keep each phrase
+// specific to a failed sign-in.
 const ERROR_RE =
   /(incorrect|invalid|wrong password|that password|couldn.?t (?:sign|log) ?you in|try again|doesn.?t match|not recognized|too many attempts|account.*lock|неверн[а-яё]*\s+(?:логин|парол|имя|номер|данные|код)|неправильн[а-яё]*\s+(?:логин|парол|имя|номер|данные)|пользователь не найден|не найден или неверн|ошибка (?:входа|авторизации|аутентификации)|попробуйте (?:ещё|еще) раз|слишком много попыток|учетн[а-яё]* запись заблокирована)/i;
 

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -126,11 +126,11 @@ export function probeSession(info, timeoutMs = 450) {
 
 // Drop session files whose daemon is gone. A clean `close` reseals and removes
 // its own file (see finalize), but a killed container — or any abrupt death —
-// leaves the file behind while /home/lethe persists. Those orphans still
-// advertise a streamPort, so a viewer that picks "the newest session" can dial
-// a dead port and show nothing, and `status` reports sessions that do not
-// exist. Best effort by design: a file we cannot read or unlink is skipped
-// rather than failing the caller's real work. Returns the pruned names.
+// leaves the file behind while the container's home directory persists. Those
+// orphans still advertise a streamPort, so a viewer that picks "the newest
+// session" can dial a dead port and show nothing, and `status` reports sessions
+// that do not exist. Best effort by design: a file we cannot read or unlink is
+// skipped rather than failing the caller's real work. Returns the pruned names.
 export async function pruneDeadSessions(stateDir) {
   const pruned = [];
   const live = new Set();

--- a/plugins/agent-id-mcp/cowork/README.md
+++ b/plugins/agent-id-mcp/cowork/README.md
@@ -45,7 +45,7 @@ the `SessionStart` hook the CLI plugins rely on.
   bundled alongside.
 - **`runtime: cowork-vm`** (or chrome missing / localhost blocked) → the local
   browser can't run there; use the **hosted** transport (Streamable-HTTP connector
-  backed by the lethe-hosted service, browser server-side). Identity + vault may
+  backed by the hosted runtime, browser server-side). Identity + vault may
   still work locally if the CLIs are bundled.
 
 ## Rebuilding the bundle

--- a/plugins/agent-id-mcp/lib/cli-adapter.mjs
+++ b/plugins/agent-id-mcp/lib/cli-adapter.mjs
@@ -1,8 +1,8 @@
 // Resolve and run the agent-id-* CLIs as subprocesses, returning their JSON.
 //
 // The MCP server is a THIN adapter: every tool maps to a CLI subcommand (the same
-// battle-tested surface Lethe shells out to), so there is no re-implementation of
-// command logic. Resolution mirrors lethe's `find_bin`: an explicit
+// battle-tested surface the desktop host shells out to), so there is no
+// re-implementation of command logic. Resolution mirrors the host's: an explicit
 // AGENT_ID_{CORE,VAULT,BROWSER}_BIN override, else the CLI on PATH, else the dev
 // workspace sibling. A `.mjs`/`.js` target is run with the current node.
 

--- a/plugins/agent-id-mcp/lib/tools.mjs
+++ b/plugins/agent-id-mcp/lib/tools.mjs
@@ -1,5 +1,5 @@
 // The MCP tool surface, each mapped to an agent-id-* CLI subcommand. Mirrors the
-// surface Lethe exposes (src/tools/agent_id.rs). Increment 1: identity + vault.
+// surface the desktop host exposes. Increment 1: identity + vault.
 // Browser tools (browser_open/act/close/…) are added in increment 2 once the
 // server-side sealed-browser daemon relay is wired (see docs/COWORK-MCP.md).
 //

--- a/plugins/agent-id-vault/CHANGELOG.md
+++ b/plugins/agent-id-vault/CHANGELOG.md
@@ -11,7 +11,7 @@
 
   **`form-inspect`'s output shape changed**, which is why the browser package takes a
   major: a control the page has staged now arrives under `staged` instead of among
-  `controls`, and a sign-in page answers with `signIn`. lethe reads this contract in
+  `controls`, and a sign-in page answers with `signIn`. The desktop host reads this contract in
   its `vault_add` description, so the two move together.
 
   **The staged password came back as a flag, and the flag was read straight past.**

--- a/scripts/check-public-hygiene.ts
+++ b/scripts/check-public-hygiene.ts
@@ -1,0 +1,60 @@
+#!/usr/bin/env bun
+
+// Fail the build when a tracked file reaches outside this repo or carries
+// Russian prose of our own. The rules and their reasoning live in ./lib/hygiene;
+// this is the I/O shell: enumerate what git tracks, scan it, report.
+//
+// Run locally with `bun run ci:hygiene`.
+
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { adviceFor, scanFile } from './lib/hygiene';
+
+const REPO_ROOT = new URL('..', import.meta.url).pathname;
+
+function trackedFiles(): string[] {
+  const result = spawnSync('git', ['ls-files', '-z'], { cwd: REPO_ROOT, encoding: 'utf8' });
+  if (result.status !== 0) {
+    throw new Error(`git ls-files failed: ${result.stderr.trim()}`);
+  }
+  return result.stdout.split('\0').filter(Boolean);
+}
+
+function main() {
+  const findings = trackedFiles().flatMap((path) => {
+    // A file git tracks but that cannot be read as text (or was deleted from the
+    // working tree) is not this check's business.
+    let text: string;
+    try {
+      text = readFileSync(join(REPO_ROOT, path), 'utf8');
+    } catch {
+      return [];
+    }
+    return scanFile(path, text);
+  });
+
+  if (findings.length === 0) {
+    console.log('check-public-hygiene: clean');
+    return;
+  }
+
+  const byRule = new Map<string, typeof findings>();
+  for (const finding of findings) {
+    byRule.set(finding.rule, [...(byRule.get(finding.rule) ?? []), finding]);
+  }
+
+  for (const [rule, hits] of byRule) {
+    console.error(`\n${rule} — ${hits.length} ${hits.length === 1 ? 'line' : 'lines'}`);
+    console.error(`  ${adviceFor(rule)}\n`);
+    for (const hit of hits) {
+      // The `file:line: error:` shape is what GitHub Actions renders inline.
+      console.error(`${hit.path}:${hit.line}: error: ${hit.excerpt}`);
+    }
+  }
+
+  console.error(`\nThis repository is public. ${findings.length} line(s) must not ship.`);
+  process.exit(1);
+}
+
+main();

--- a/scripts/lib/hygiene.ts
+++ b/scripts/lib/hygiene.ts
@@ -1,0 +1,88 @@
+// This repository is public, and three of its packages ship their `lib/` to npm.
+// A comment written for a colleague therefore leaves with the next release.
+//
+// These rules say what may not appear. They are deliberately narrow: widening
+// them is a decision to take on purpose, because a rule that fires on ordinary
+// prose gets disabled, and then it protects nothing.
+//
+// `scanFile` takes its rules as an argument so tests can exercise the mechanism
+// without restating the terms below — the point of the check is that those
+// appear in exactly one place.
+
+export type Rule = {
+  name: string;
+  pattern: RegExp;
+  // Shown under the finding, so whoever trips a rule can fix it without going
+  // to find whoever wrote it.
+  advice: string;
+};
+
+export type Finding = {
+  path: string;
+  line: number;
+  rule: string;
+  excerpt: string;
+};
+
+export const RULES: Rule[] = [
+  {
+    name: 'external project name',
+    pattern: /lethe/i,
+    advice: 'Describe the behaviour in terms of this package — "the caller", "the desktop host".',
+  },
+  {
+    name: 'path into another codebase',
+    pattern: /\bsrc\/[\w/-]*\.rs\b/,
+    advice: 'Cite no file path outside this repo; say what the behaviour is instead.',
+  },
+];
+
+// The file that defines the terms cannot avoid containing them, and the test
+// file carries a Cyrillic fixture. Exempting them by name is what every scanner
+// of this shape does; spelling the terms obfuscated would hide them from the
+// reader without hiding them from anyone else.
+export const SELF_EXEMPT = new Set(['scripts/lib/hygiene.ts', 'scripts/tests/hygiene.test.ts']);
+
+// Cyrillic is allowed only where it is data the product must match: the
+// rejection vocabulary a Russian-language sign-in page prints, the fixtures
+// that pin it, and the changelog entry describing that feature. Our own prose
+// is English.
+export const CYRILLIC_ALLOWLIST = new Set([
+  'plugins/agent-id-browser/lib/login-detect.mjs',
+  'tests/test-login-detect.mjs',
+  'plugins/agent-id-browser/CHANGELOG.md',
+]);
+
+const BINARY_OR_GENERATED = /\.(png|jpg|jpeg|gif|ico|svg|woff2?|tgz|lock)$|^bun\.lock$/;
+const CYRILLIC = /[Ѐ-ӿ]/;
+
+export function scanFile(path: string, text: string, rules: Rule[] = RULES): Finding[] {
+  if (SELF_EXEMPT.has(path) || BINARY_OR_GENERATED.test(path)) return [];
+
+  const findings: Finding[] = [];
+  const cyrillicAllowed = CYRILLIC_ALLOWLIST.has(path);
+
+  text.split('\n').forEach((line, index) => {
+    for (const rule of rules) {
+      if (rule.pattern.test(line)) {
+        findings.push({ path, line: index + 1, rule: rule.name, excerpt: excerpt(line) });
+      }
+    }
+    if (!cyrillicAllowed && CYRILLIC.test(line)) {
+      findings.push({ path, line: index + 1, rule: 'Cyrillic prose', excerpt: excerpt(line) });
+    }
+  });
+
+  return findings;
+}
+
+export function adviceFor(rule: string, rules: Rule[] = RULES): string {
+  return (
+    rules.find((r) => r.name === rule)?.advice ??
+    'Write our own prose in English. Cyrillic belongs only in matched page copy and its fixtures.'
+  );
+}
+
+function excerpt(line: string): string {
+  return line.trim().slice(0, 100);
+}

--- a/scripts/tests/hygiene.test.ts
+++ b/scripts/tests/hygiene.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from 'bun:test';
+import { CYRILLIC_ALLOWLIST, RULES, type Rule, SELF_EXEMPT, adviceFor, scanFile } from '../lib/hygiene';
+
+const SOURCE = 'plugins/agent-id-browser/lib/auto-login.mjs';
+
+// The matching behaviour is tested against a stand-in rule rather than the real
+// ones: a test that restated the terms would put them back in the repo, which is
+// the whole thing this check exists to prevent. What the real rules match is
+// proved where it counts — by the check running over every tracked file in CI.
+const STAND_IN: Rule[] = [
+  { name: 'stand-in', pattern: /forbidden-token/i, advice: 'say it another way' },
+];
+
+describe('scanFile', () => {
+  test('flags a rule match and reports where it is', () => {
+    const findings = scanFile(SOURCE, ['clean', '// a forbidden-token here'].join('\n'), STAND_IN);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.rule).toBe('stand-in');
+    expect(findings[0]?.line).toBe(2);
+  });
+
+  test('matches case-insensitively and inside a compound word', () => {
+    expect(scanFile(SOURCE, '// Forbidden-Token-hosted containers', STAND_IN)).toHaveLength(1);
+    expect(scanFile(SOURCE, '// the file stays under /home/forbidden-token', STAND_IN)).toHaveLength(1);
+  });
+
+  test('reports every rule a single line trips', () => {
+    const rules: Rule[] = [...STAND_IN, { name: 'second', pattern: /token/i, advice: 'no' }];
+    expect(scanFile(SOURCE, '// forbidden-token', rules).map((f) => f.rule)).toEqual([
+      'stand-in',
+      'second',
+    ]);
+  });
+
+  test('leaves ordinary prose alone', () => {
+    const lines = [
+      "// agent-browser's message shapes (frame/status/ack/config/input_*)",
+      '// see https://agent-browser.dev/streaming',
+      "// the caller's own 16-minute ceiling kills the whole run",
+      '// resolution mirrors the desktop host: an explicit BIN override',
+    ];
+    expect(scanFile(SOURCE, lines.join('\n'), STAND_IN)).toEqual([]);
+    expect(scanFile(SOURCE, lines.join('\n'))).toEqual([]);
+  });
+
+  test('flags Cyrillic in our own prose', () => {
+    // Built from escapes so this file does not itself carry the thing under test.
+    const cyrillic = `// ${String.fromCodePoint(0x43f, 0x440, 0x438, 0x432, 0x435, 0x442)}`;
+    expect(scanFile(SOURCE, cyrillic).map((f) => f.rule)).toEqual(['Cyrillic prose']);
+  });
+
+  test('allows Cyrillic where it is page copy the product must match', () => {
+    const cyrillic = String.fromCodePoint(0x43f, 0x430, 0x440, 0x43e, 0x43b, 0x44c);
+    for (const path of CYRILLIC_ALLOWLIST) {
+      expect(scanFile(path, cyrillic)).toEqual([]);
+    }
+  });
+
+  test('the files that must carry the terms do not flag themselves', () => {
+    for (const path of SELF_EXEMPT) {
+      expect(scanFile(path, '// forbidden-token', STAND_IN)).toEqual([]);
+    }
+  });
+
+  test('skips binary and generated files', () => {
+    expect(scanFile('.github/assets/logo.png', '// forbidden-token', STAND_IN)).toEqual([]);
+    expect(scanFile('bun.lock', '// forbidden-token', STAND_IN)).toEqual([]);
+  });
+});
+
+describe('the real rules', () => {
+  test('every one carries advice a reader can act on', () => {
+    expect(RULES.length).toBeGreaterThan(0);
+    for (const rule of RULES) {
+      expect(rule.advice.length).toBeGreaterThan(20);
+      expect(adviceFor(rule.name)).toBe(rule.advice);
+    }
+  });
+
+  test('an unknown rule name still answers with the Cyrillic advice', () => {
+    expect(adviceFor('Cyrillic prose')).toMatch(/English/);
+  });
+});

--- a/tests/test-auto-login.mjs
+++ b/tests/test-auto-login.mjs
@@ -519,13 +519,13 @@ test("the retry card is sized by where the code comes from, not by the fact of r
     "a mailbox trip must outlast a glance",
   );
 
-  // Both retries stay under lethe's 16-minute HUMAN_TIMEOUT once the first card
-  // has spent its own budget — that ceiling covers the whole subprocess, so a
-  // second full-length card would have the host kill the run mid-answer.
-  const HUMAN_TIMEOUT_MS = 16 * 60 * 1000;
+  // Both retries stay under the caller's 16-minute ceiling once the first card
+  // has spent its own budget — that ceiling covers the whole run, so a second
+  // full-length card would be killed mid-answer.
+  const CALLER_CEILING_MS = 16 * 60 * 1000;
   for (const cred of [mailed, generated]) {
     const total = otpCardBudgetMs(cred) + otpCardBudgetMs(cred, { retry: true });
-    assert.ok(total < HUMAN_TIMEOUT_MS, `${cred.otp}: ${total}ms leaves nothing for the page`);
+    assert.ok(total < CALLER_CEILING_MS, `${cred.otp}: ${total}ms leaves nothing for the page`);
   }
 });
 

--- a/tests/test-browser-sandbox-toggle.mjs
+++ b/tests/test-browser-sandbox-toggle.mjs
@@ -4,7 +4,7 @@
 // launcher strips patchright's injected --no-sandbox to keep the renderer
 // sandbox ON (the stealth-validated config). Chrome refuses to start as root
 // with the sandbox on, so containerized deployments that run as root (e.g.
-// lethe-hosted per-user containers) set the env var to keep the injected flag.
+// hosted per-user containers) set the env var to keep the injected flag.
 // Pure — no browser.
 //
 // Run: node --test tests/test-browser-sandbox-toggle.mjs

--- a/tests/test-login-detect.mjs
+++ b/tests/test-login-detect.mjs
@@ -448,8 +448,8 @@ test("a code screen that also mentions a link is a code step, however weak its f
 });
 
 test("failed: a Russian rejection is read as a bad credential, not `unknown`", () => {
-  // lk.eneva.ru — without this the password field stays, every round is
-  // `unknown`, and the result is a `timeout` blamed on the owner.
+  // Without this the password field stays, every round is `unknown`, and the
+  // result is a `timeout` blamed on the owner.
   assert.equal(
     classifyLogin({
       hasPasswordField: true,


### PR DESCRIPTION
Some comments and documentation explained a decision by pointing at something
outside this repo. They now state what holds here — which is also the more
useful thing for whoever is reading the file. Comments and docs only; no
behaviour change.

Our own prose is English. The Russian that stays is page copy the product must
match and the fixtures pinning it; removing it would break sign-in
classification on Russian-language sites.

## The check

`bun run ci:hygiene` scans every tracked file and runs as its own CI job. The
rules are deliberately narrow — one that fires on ordinary prose gets disabled,
and then it protects nothing. They are passed in rather than reached for, so the
unit tests exercise the mechanism without restating the terms; what the real
rules match is proved by the check running over the whole tree.

`CLAUDE.md` also listed `agent-id-browser` as never published, while
`RELEASING.md` and the registry both say otherwise — which is how comments came
to be written into a file their author believed was internal. It now matches,
and states the rules the check enforces.

## Verification

- `bun run test` — 898, unchanged from the base commit.
  `test-browser-stream-counters.mjs:644` flakes independently of this branch:
  2 failures in 6 runs measured on base, and nothing this branch touches among
  that test's dependencies is more than a comment.
- `bun test scripts/tests` — 55, including the check's own.
- The check was proved able to fail: a tripwire line tripped it and exited
  non-zero, then was reverted.
- `npm pack` on the three published packages, unpacked and scanned: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)