### PR TITLE
feat(browser): ask for the code instead of failing, and say where it went

### DIFF
--- a/.changeset/a-code-from-the-app-not-the-mailbox.md
+++ b/.changeset/a-code-from-the-app-not-the-mailbox.md
@@ -1,0 +1,27 @@
+---
+"@alien-id/agent-id-browser": minor
+---
+
+Ask for the code instead of failing, and say where it went.
+
+A `login` credential marked `otp: "totp"` whose seed was never stored threw
+`otp=totp but no totpSecret stored` and failed the whole sign-in — while the owner
+sat there with the code already on their phone. There is no reason that has to be
+a dead end: the card is the same channel a mailed code uses. It now raises one,
+worded for an authenticator rather than a mailbox (nothing was sent anywhere, so
+"check your email or messages" would be a wrong instruction, not a vague one), and
+sized for a glance rather than a trip to the inbox. A credential that HAS its seed
+still generates the code and asks nobody.
+
+And the card stops sending people to the wrong place. `codeDestination` only read
+`sent … to X`, which misses how many sites word it — "We texted your phone ending
+in 4817" names the destination with no `to` at all — and it lost an address the
+page stated outright whenever a dash followed it. Both are read now. When the page
+says nothing, the card names the identifier the sign-in was started with, masked
+(`d•••@eti.co`, `••• 4817`), worded as the guess it is: "should reach", not "sent
+to". A username that is neither an address nor a number still names no channel and
+gets the old neutral copy.
+
+The report this came from: a code went to a number attached to the account years
+earlier, on a phone in another room, and the card said "check your email or
+messages".

--- a/.changeset/a-code-from-the-app-not-the-mailbox.md
+++ b/.changeset/a-code-from-the-app-not-the-mailbox.md
@@ -25,3 +25,10 @@ gets the old neutral copy.
 The report this came from: a code went to a number attached to the account years
 earlier, on a phone in another room, and the card said "check your email or
 messages".
+
+And the card now says how long the code is, when the page has said so: a row of
+one-character boxes is counted, a single field's `maxlength` is read, and failing
+both the copy is searched for "six-digit". It travels as the field's placeholder,
+which the screen already reads as its cell count. Only 4-8 is passed on — an
+unconstrained input states nothing about a code, and the screen submits itself
+when its cells fill, so too many cells leave a correct code unsubmittable.

--- a/plugins/agent-id-browser/lib/auto-login.mjs
+++ b/plugins/agent-id-browser/lib/auto-login.mjs
@@ -38,7 +38,7 @@ import { generateTotp } from "@alien-id/agent-id-core/lib/totp.mjs";
 import { collectSecret } from "@alien-id/agent-id-core/lib/secure-prompt.mjs";
 import { notifyHost } from "@alien-id/agent-id-core/lib/notice.mjs";
 import { assertHostAllowed, credentialHost, siteName } from "@alien-id/agent-id-vault/lib/store.mjs";
-import { classifyLogin, codeDestination } from "./login-detect.mjs";
+import { classifyLogin, codeDestination, codeLengthFromText } from "./login-detect.mjs";
 import { humanClick, humanDriver, humanType } from "./human-input.mjs";
 
 // Type a secret (password / OTP) with human cadence, guarding against a
@@ -367,7 +367,7 @@ export function millisToNextTotpWindow(cred, now = Date.now()) {
 // seed, or ask the human over the secure-prompt channel.
 export async function resolveOtp(
   cred,
-  { env = process.env, log = () => {}, now, retry = false, destination = null } = {},
+  { env = process.env, log = () => {}, now, retry = false, destination = null, length = null } = {},
 ) {
   if (cred.otp === "totp" && cred.totpSecret) {
     return generateTotp({
@@ -378,7 +378,7 @@ export async function resolveOtp(
       ...(now != null ? { now } : {}),
     });
   }
-  const spec = otpCardSpec(cred, { retry, destination });
+  const spec = otpCardSpec(cred, { retry, destination, length });
   log(`Waiting for the ${spec.fields[0].label.toLowerCase()} via the secure prompt…`);
   const { values } = await collectSecret(spec, { env });
 
@@ -389,8 +389,20 @@ export async function resolveOtp(
 // exported for the same reason `otpPromptWording` is: what the owner is shown is
 // worth asserting without standing up a prompt provider, and this is the one card
 // both auto-login and `fill_otp` raise.
-export function otpCardSpec(cred, { retry = false, destination = null } = {}) {
+// The count the card is allowed to draw cells for. Outside this the screen falls
+// back to a plain field with a button, which is the only shape that cannot trap
+// someone: cells submit themselves when they fill, so a count that is too high
+// leaves a correct code unsubmittable with no button to press.
+const CODE_CELL_RANGE = [4, 8];
+
+export function otpCardLength(length) {
+  const [low, high] = CODE_CELL_RANGE;
+  return Number.isInteger(length) && length >= low && length <= high ? length : null;
+}
+
+export function otpCardSpec(cred, { retry = false, destination = null, length = null } = {}) {
   const wording = otpPromptWording(cred, { retry, destination });
+  const cells = otpCardLength(length);
 
   return {
     title: wording.title,
@@ -401,7 +413,16 @@ export function otpCardSpec(cred, { retry = false, destination = null } = {}) {
     // which is exactly the transcription whose slips the dots would hide. A wrong
     // code costs another round trip to the mailbox; watching it being typed
     // costs nothing.
-    fields: [{ name: "otp", label: wording.label, secret: false }],
+    // The screen reads the placeholder as the cell count — the one hint that
+    // already travels the whole way to the phone. Absent, it draws a text field.
+    fields: [
+      {
+        name: "otp",
+        label: wording.label,
+        secret: false,
+        ...(cells ? { placeholder: "•".repeat(cells) } : {}),
+      },
+    ],
     label: wording.ask,
     security: "Used once to complete sign-in; never stored or shown to the agent.",
     timeoutMs: otpCardBudgetMs(cred, { retry }),
@@ -482,11 +503,29 @@ export async function detectPageState(page) {
     const hasPasswordField = all('input[type="password"]').some(asked);
     const hasIdentifierField = all(identifierSel).some(visible);
     const hasOtpField = all('input[autocomplete="one-time-code"]').some(visible);
-    const otpFieldNames = all(
-      'input[type="text"],input[type="tel"],input[type="number"],input[inputmode="numeric"]',
-    )
+    const otpFields = all(
+      'input[type="text"],input[type="tel"],input[type="number"],input[inputmode="numeric"],input[autocomplete="one-time-code"]',
+    ).filter(visible);
+    const otpFieldNames = otpFields
       .map((e) => `${e.name || ""} ${e.id || ""} ${e.placeholder || ""} ${e.autocomplete || ""}`.trim())
       .filter(Boolean);
+    // How many characters the code has, as the page itself constrains it. A row of
+    // one-character boxes IS the count; a single field states it in maxlength. The
+    // card draws exactly this many cells and submits when they fill, so a number
+    // that is merely plausible is worse than none — an unconstrained text input
+    // (maxlength 32, or absent) says nothing about a code and must not be read as
+    // if it did.
+    const lengthOf = (e) => {
+      const declared = Number(e.getAttribute("maxlength"));
+      return Number.isInteger(declared) && declared > 0 ? declared : null;
+    };
+    const singleCharBoxes = otpFields.filter((e) => lengthOf(e) === 1).length;
+    const otpLength =
+      singleCharBoxes >= 4
+        ? singleCharBoxes
+        : otpFields.length === 1
+          ? lengthOf(otpFields[0])
+          : null;
     const bodyText = (document.body && document.body.innerText ? document.body.innerText : "").slice(0, 4000);
     // Language-independent block signal: a visible challenge widget. Fed to
     // classifyLogin via its `blocked` input so it wins over "logged-in".
@@ -505,6 +544,7 @@ export async function detectPageState(page) {
       hasIdentifierField,
       hasOtpField,
       otpFieldNames,
+      otpLength,
       bodyText,
       blocked,
       errorText,
@@ -788,7 +828,8 @@ export async function autoLogin({
   // credential's own origins. Checked once here so a loginUrl pointing off the
   // allowlist fails before a browser goes anywhere, not after.
   assertHostAllowed(hostOf(cred.loginUrl), cred.domains, "loginUrl: refusing");
-  const getOtp = (retry, destination) => resolveOtpFn(cred, { env, log, retry, destination });
+  const getOtp = (retry, destination, length) =>
+    resolveOtpFn(cred, { env, log, retry, destination, length });
   // One run answers a code challenge twice at most, and the second attempt is
   // deliberately cheap.
   //
@@ -931,7 +972,11 @@ export async function autoLogin({
       try {
         // The code screen has just told us where it sent the code; the card is
         // the only place that says so to the owner.
-        await typeOtp(page, await getOtp(retry, codeDestination(state.bodyText)));
+        // What the page enforces beats what it says: an input constrained to six
+        // characters is a fact, "6-digit code" is copy that may describe the last
+        // step rather than this one.
+        const length = state.otpLength ?? codeLengthFromText(state.bodyText);
+        await typeOtp(page, await getOtp(retry, codeDestination(state.bodyText), length));
       } catch (err) {
         if (err?.code !== "FORM_TIMEOUT") throw err;
         return otpTimedOut();

--- a/plugins/agent-id-browser/lib/auto-login.mjs
+++ b/plugins/agent-id-browser/lib/auto-login.mjs
@@ -258,12 +258,10 @@ export async function runRecipe(
 // factor, not a second one — a card headed "2FA code" would be telling the owner
 // something untrue about the account they are signing into. Pure; exported so the
 // wording is testable without standing up a prompt provider.
-// The first card waits for someone who may be away from the screen. What the retry
-// waits for depends on where the code comes from, and the two are not comparable:
-// a generated code is read off a device the owner is already holding, so the retry
-// is a glance, while a mailed one sends them back to the mailbox for a second trip.
-// Measured on a live Booking.com run, where a two-minute retry expired with the
-// owner still fetching the mail.
+// How long the card waits depends on where the code comes from, and the two are
+// not comparable: an authenticator is already in the owner's hand, while a mailed
+// code sends them to a mailbox — measured on a live Booking.com run, where a
+// two-minute retry expired with the owner still fetching the mail.
 //
 // Both budgets are bounded by the same thing — lethe's 16-minute HUMAN_TIMEOUT
 // (`src/agent_id/cli.rs`) kills the whole auto-login subprocess, cards, navigation
@@ -274,9 +272,18 @@ const OTP_GLANCE_RETRY_CARD_MS = 2 * 60 * 1000;
 const OTP_MAILBOX_RETRY_CARD_MS = 4 * 60 * 1000;
 
 export function otpCardBudgetMs(cred, { retry = false } = {}) {
+  if (fromAuthenticatorApp(cred)) return OTP_GLANCE_RETRY_CARD_MS;
   if (!retry) return OTP_CARD_MS;
 
-  return cred.otp === "totp" ? OTP_GLANCE_RETRY_CARD_MS : OTP_MAILBOX_RETRY_CARD_MS;
+  return OTP_MAILBOX_RETRY_CARD_MS;
+}
+
+// Whether the owner will read this code off an authenticator rather than out of a
+// mailbox: a `totp` credential asks a person only when its seed is missing — with
+// a seed the code is generated and no card is raised at all. Nothing was sent
+// anywhere, so the card must not send them looking for a message.
+export function fromAuthenticatorApp(cred) {
+  return cred.otp === "totp" && !cred.totpSecret;
 }
 
 export function otpPromptWording(cred, { retry = false, destination = null } = {}) {
@@ -291,13 +298,27 @@ export function otpPromptWording(cred, { retry = false, destination = null } = {
   // time-based code the right move is to read the CURRENT one, not retype the
   // one they just sent.
   const retryNote = retry ? "That code was not accepted — enter the current one. " : "";
-  // Where the code went, in the site's own words, or nothing. Naming the wrong
-  // channel sends the owner to an inbox the code was never sent to and then
-  // convinces them it never arrived — so with no destination the copy claims no
-  // channel and names both places to look.
+  // Where the code went. Three tiers, and the wording weakens with each: what the
+  // page itself said, then the identifier the sign-in was started with, then
+  // nothing. The middle one is a guess — a site can text a code to an account
+  // opened with an e-mail — so it says "should reach" where the page's own words
+  // say "sent". And a guess is still worth making: "check your email or messages"
+  // sent an owner hunting through the wrong device while a number he had
+  // forgotten was attached to the account held the code.
+  const guess = maskedIdentifier(cred.username);
   const sentence = destination
     ? `${site} sent a code to ${destination} — enter it to finish signing in`
-    : `${site} sent you a code — check your email or messages, then enter it here`;
+    : guess
+      ? `The code should reach ${guess} — enter it to finish signing in`
+      : `${site} sent you a code — check your email or messages, then enter it here`;
+  if (fromAuthenticatorApp(cred)) {
+    return {
+      title: `2FA code for ${site}`,
+      description: `${retryNote}Open your 2FA app and enter the current code for ${site}`,
+      label: "Current 2FA code",
+      ask: `enter the current 2FA code for ${site}`,
+    };
+  }
   if (cred.passwordless) {
     return {
       title: `Sign-in code for ${site}`,
@@ -316,6 +337,25 @@ export function otpPromptWording(cred, { retry = false, destination = null } = {
   };
 }
 
+// The identifier the owner signed in with, reduced to what identifies it to them
+// and to nobody else. A username that is neither an address nor a number names no
+// channel, so it yields nothing rather than a guess about where to look.
+export function maskedIdentifier(identifier) {
+  const value = String(identifier || "").trim();
+  if (!value) return null;
+
+  const at = value.lastIndexOf("@");
+  if (at > 0) {
+    const domain = value.slice(at);
+    return `${value.slice(0, 1)}•••${domain}`;
+  }
+
+  const digits = value.replace(/\D/g, "");
+  const isPhone = /^\+?[\d\s().-]+$/.test(value) && digits.length >= 7;
+
+  return isPhone ? `••• ${digits.slice(-4)}` : null;
+}
+
 // How long until the credential's TOTP period rolls over, plus a beat so the new
 // window is unambiguously current. Exported for the test that pins the arithmetic.
 export function millisToNextTotpWindow(cred, now = Date.now()) {
@@ -329,8 +369,7 @@ export async function resolveOtp(
   cred,
   { env = process.env, log = () => {}, now, retry = false, destination = null } = {},
 ) {
-  if (cred.otp === "totp") {
-    if (!cred.totpSecret) throw new Error(`login '${cred.name}': otp=totp but no totpSecret stored`);
+  if (cred.otp === "totp" && cred.totpSecret) {
     return generateTotp({
       secret: cred.totpSecret,
       period: cred.period,

--- a/plugins/agent-id-browser/lib/login-detect.mjs
+++ b/plugins/agent-id-browser/lib/login-detect.mjs
@@ -259,6 +259,26 @@ const NAMED_DESTINATION_RE =
 const ENDING_RE =
   /\b(?:(your|the)\s+)?(phone(?:\s+number)?|number|mobile|e-?mail(?:\s+address)?)\s+ending\s+(?:in\s+|with\s+)?([\d\u2022\u00b7*.\u2026-]{2,8})/i;
 
+// How many characters the code has, when the page says so in words. The same
+// vocabulary the OTP classifier matches on, read for its number this time.
+//
+// Only 4-8 is answered. Outside that a "code" is something else — an order
+// reference, a discount, a year — and a wrong count is not a smaller version of
+// no count: the card draws exactly that many cells and submits itself when they
+// fill, so four cells for a six-digit code cannot be completed at all.
+const SPELLED_DIGITS = { four: 4, five: 5, six: 6, seven: 7, eight: 8 };
+const CODE_LENGTH_RE = /\b(\d|four|five|six|seven|eight)[- ]?digit\b/i;
+
+export function codeLengthFromText(bodyText) {
+  const match = CODE_LENGTH_RE.exec(String(bodyText || ""));
+  if (!match) return null;
+
+  const word = match[1].toLowerCase();
+  const length = SPELLED_DIGITS[word] ?? Number(word);
+
+  return length >= 4 && length <= 8 ? length : null;
+}
+
 export function codeDestination(bodyText) {
   const text = String(bodyText || "");
   const match = SENT_TO_RE.exec(text);

--- a/plugins/agent-id-browser/lib/login-detect.mjs
+++ b/plugins/agent-id-browser/lib/login-detect.mjs
@@ -236,8 +236,11 @@ export function classifyLogin({
 // than naming none, because it sends the owner somewhere the code is not and
 // then convinces them it never came. Anything unrecognised fails closed to null,
 // and the card falls back to wording that claims no channel at all.
+// The capture ends at a clause boundary. A dash is one of them: "sent a code to
+// d••@gmail.com — enter it below" otherwise runs the address together with the
+// sentence after it and the whole destination is lost.
 const SENT_TO_RE =
-  /\b(?:sent|texted|e-?mailed|messaged)\b[^.\n]{0,40}?\bto\s+(.{2,38}?)(?=[,;!?\n]|\.(?:\s|$)|\s{2,}|$)/i;
+  /\b(?:sent|texted|e-?mailed|messaged)\b[^.\n]{0,40}?\bto\s+(.{2,38}?)(?=[,;!?\n—–]|\.(?:\s|$)|\s{2,}|$)/i;
 const EMAIL_DESTINATION_RE = /^[\w.+•·*…-]{1,32}@[\w.•·*…-]{2,32}$/;
 // The captured text is written by the page and ends up in a card the owner trusts.
 // The loopback form escapes it, but the hosted prompt hands `description` on as it
@@ -247,21 +250,35 @@ const MARKUP_RE = /[<>&"'\\]/;
 // Digits as a site masks them: bullets, stars, dots, dashes, parens, a leading +.
 const PHONE_DESTINATION_RE = /^[+()\d\s.*\u00b7\u2022\u2026-]{4,26}$/;
 const NAMED_DESTINATION_RE =
-  /^your\s+(?:e-?mail(?:\s+address)?|phone(?:\s+number)?|mobile|messages|device)$/i;
+  /^your\s+(?:e-?mail(?:\s+address)?|phone(?:\s+number)?|mobile|messages|device)(?:\s+ending\s+(?:in|with)\s+[\d\u2022\u00b7*.\u2026-]{2,8})?$/i;
+// The other half of how sites word it, and the half the `sent … to` shape cannot
+// reach: "We texted your phone ending in 4817" names the destination with no `to`
+// at all, and "sent to the number ending 4817" puts a word in front that stops it
+// looking like a phone. Read second, so an address the page states outright still
+// wins.
+const ENDING_RE =
+  /\b(?:(your|the)\s+)?(phone(?:\s+number)?|number|mobile|e-?mail(?:\s+address)?)\s+ending\s+(?:in\s+|with\s+)?([\d\u2022\u00b7*.\u2026-]{2,8})/i;
 
 export function codeDestination(bodyText) {
-  const match = SENT_TO_RE.exec(String(bodyText || ""));
-  if (!match) return null;
+  const text = String(bodyText || "");
+  const match = SENT_TO_RE.exec(text);
+  const target = match ? match[1].trim().replace(/\s+/g, " ") : null;
 
-  const target = match[1].trim().replace(/\s+/g, " ");
-  if (MARKUP_RE.test(target)) return null;
+  if (target && !MARKUP_RE.test(target)) {
+    const recognised =
+      EMAIL_DESTINATION_RE.test(target) ||
+      PHONE_DESTINATION_RE.test(target) ||
+      NAMED_DESTINATION_RE.test(target);
 
-  const recognised =
-    EMAIL_DESTINATION_RE.test(target) ||
-    PHONE_DESTINATION_RE.test(target) ||
-    NAMED_DESTINATION_RE.test(target);
+    if (recognised) return target;
+  }
 
-  return recognised ? target : null;
+  const ending = ENDING_RE.exec(text);
+  if (!ending) return null;
+
+  const [, article, kind, tail] = ending;
+
+  return `${(article || "your").toLowerCase()} ${kind.toLowerCase()} ending in ${tail}`;
 }
 
 export { OTP_FIELD_RE, OTP_BODY_RE, CONFIRM_BODY_RE, MAGIC_LINK_RE, QR_SIGN_IN_RE, ERROR_RE, BLOCK_RE };

--- a/tests/test-auto-login.mjs
+++ b/tests/test-auto-login.mjs
@@ -29,6 +29,7 @@ import {
   otpCardSpec,
   fromAuthenticatorApp,
   maskedIdentifier,
+  otpCardLength,
 } from "../plugins/agent-id-browser/lib/auto-login.mjs";
 import { generateTotp } from "../plugins/agent-id-core/lib/totp.mjs";
 
@@ -391,6 +392,26 @@ test("the card names where to look when the page did not say", () => {
   // A username that names no channel is not turned into one.
   const opaque = otpPromptWording({ ...cred, username: "daniel_smith" });
   assert.match(opaque.description, /check your email or messages/);
+});
+
+test("the card carries the cell count only when the page really stated one", () => {
+  const cred = { name: "booking", passwordless: true, loginUrl: "https://booking.com/in" };
+  const placeholderFor = (length) => otpCardSpec(cred, { length }).fields[0].placeholder ?? null;
+
+  // The screen draws one cell per placeholder character and submits itself when
+  // they fill. That is why a guess is not a lesser version of silence: too few
+  // cells truncate a correct code, too many leave it unsubmittable with no button.
+  assert.equal(placeholderFor(6), "••••••");
+  assert.equal(placeholderFor(4), "••••");
+  assert.equal(placeholderFor(8), "••••••••");
+
+  // An unconstrained text input (maxlength 32, or none at all) states nothing
+  // about a code, and a three-character one is not a code either.
+  for (const nonsense of [3, 12, 32, 0, null, undefined, 6.5, "6"]) {
+    assert.equal(placeholderFor(nonsense), null, String(nonsense));
+  }
+  assert.equal(otpCardLength(6), 6);
+  assert.equal(otpCardLength(32), null);
 });
 
 test("an identifier is masked down to what the owner recognises", () => {

--- a/tests/test-auto-login.mjs
+++ b/tests/test-auto-login.mjs
@@ -8,6 +8,9 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
 
 import {
   applyVars,
@@ -24,6 +27,8 @@ import {
   isDeepLoginUrl,
   otpCardBudgetMs,
   otpCardSpec,
+  fromAuthenticatorApp,
+  maskedIdentifier,
 } from "../plugins/agent-id-browser/lib/auto-login.mjs";
 import { generateTotp } from "../plugins/agent-id-core/lib/totp.mjs";
 
@@ -228,8 +233,62 @@ test("resolveOtp generates a code from a stored TOTP seed (RFC vector)", async (
   assert.equal(code, generateTotp({ secret: cred.totpSecret, period: 30, digits: 6, now: 59_000 }));
 });
 
-test("resolveOtp throws when otp=totp but no seed is stored", async () => {
-  await assert.rejects(resolveOtp({ name: "x", otp: "totp" }, {}), /totpSecret/);
+// The hosted-harness protocol on a unix socket, as `test-secure-prompt.mjs` drives
+// it — the one way to watch what `resolveOtp` puts in front of the owner.
+async function withCardCapture(run) {
+  const sock = path.join(os.tmpdir(), `agentid-otp-${process.pid}-${Date.now()}.sock`);
+  const seen = [];
+  const server = http.createServer((req, res) => {
+    const chunks = [];
+    req.on("data", (c) => chunks.push(c));
+    req.on("end", () => {
+      seen.push(JSON.parse(Buffer.concat(chunks).toString("utf8")));
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ values: { otp: "123456" } }));
+    });
+  });
+  await new Promise((resolve) => server.listen(sock, resolve));
+  try {
+    return { result: await run({ AGENT_ID_SECURE_PROMPT_SOCK: sock }), seen };
+  } finally {
+    server.close();
+  }
+}
+
+test("a TOTP credential with no seed asks the owner instead of failing the sign-in", async () => {
+  // It used to throw `otp=totp but no totpSecret stored` and fail the whole sign-in
+  // while the owner sat there with the code already on their phone.
+  const { result, seen } = await withCardCapture((env) =>
+    resolveOtp({ name: "gh", otp: "totp", loginUrl: "https://github.example/login" }, { env }),
+  );
+
+  assert.equal(result, "123456");
+  assert.equal(seen.length, 1, "exactly one card");
+  assert.match(seen[0].title, /2FA code for Github\.example/);
+  assert.equal(seen[0].fields[0].name, "otp");
+});
+
+test("a TOTP credential that has its seed still never raises a card", async () => {
+  const { result, seen } = await withCardCapture((env) =>
+    resolveOtp({ name: "gh", otp: "totp", totpSecret: "JBSWY3DPEHPK3PXP" }, { env }),
+  );
+
+  assert.equal(seen.length, 0, "a stored seed is answered without asking anyone");
+  assert.match(result, /^\d{6}$/);
+});
+
+test("the card for an authenticator code sends nobody to a mailbox", () => {
+  // The copy that was already there says "check your email or messages", which for
+  // a code that was never sent anywhere is a wrong instruction, not a vague one.
+  const spec = otpCardSpec({ name: "gh", otp: "totp", loginUrl: "https://github.example/login" });
+
+  assert.match(spec.description, /2FA app/i);
+  assert.ok(!/email|messages|sent/i.test(spec.description), spec.description);
+  assert.ok(fromAuthenticatorApp({ name: "gh", otp: "totp" }));
+  assert.ok(
+    !fromAuthenticatorApp({ name: "gh", otp: "totp", totpSecret: "x" }),
+    "with a seed there is no card, so nothing to word",
+  );
 });
 
 // ── Positive-confirmation helpers (the "logged-in" false-positive guard) ──────────
@@ -308,6 +367,39 @@ test("otpPromptWording: an ordinary second factor keeps the 2FA wording", () => 
   const w = otpPromptWording({ name: "gh", loginUrl: "https://github.example/login" });
   assert.match(w.title, /2FA code for Github\.example/);
   assert.match(w.label, /2FA/);
+});
+
+test("the card names where to look when the page did not say", () => {
+  // "check your email or messages" cost a real sign-in: the code went to a number
+  // attached to the account years earlier, on a phone in another room, and the
+  // owner spent the card's ten minutes searching a mailbox. The identifier they
+  // signed in with is the one thing we always have.
+  const cred = { name: "airbnb", passwordless: true, username: "daniel@eti.co", loginUrl: "https://www.airbnb.com/login" };
+  const guessed = otpPromptWording(cred);
+
+  assert.match(guessed.description, /d•••@eti\.co/);
+  // A guess, and worded as one: the page said nothing, and a site can text a code
+  // to an account opened with an address.
+  assert.match(guessed.description, /should reach/);
+  assert.ok(!/sent a code to/.test(guessed.description), guessed.description);
+
+  // What the page itself printed outranks it, and gets the certain wording.
+  const stated = otpPromptWording(cred, { destination: "your phone ending in 4817" });
+  assert.match(stated.description, /sent a code to your phone ending in 4817/);
+  assert.ok(!/d•••@eti\.co/.test(stated.description), stated.description);
+
+  // A username that names no channel is not turned into one.
+  const opaque = otpPromptWording({ ...cred, username: "daniel_smith" });
+  assert.match(opaque.description, /check your email or messages/);
+});
+
+test("an identifier is masked down to what the owner recognises", () => {
+  assert.equal(maskedIdentifier("daniel@eti.co"), "d•••@eti.co");
+  assert.equal(maskedIdentifier("+1 (415) 555-4817"), "••• 4817");
+  // Neither an address nor a number: it names no place to look.
+  assert.equal(maskedIdentifier("danielsmith"), null);
+  assert.equal(maskedIdentifier(""), null);
+  assert.equal(maskedIdentifier(null), null);
 });
 
 test("otpPromptWording: nothing to name the site by still says what to do", () => {
@@ -507,23 +599,26 @@ test("autoLogin does not dress every OTP failure up as a timeout", async () => {
 
 test("the retry card is sized by where the code comes from, not by the fact of retrying", () => {
   const mailed = { name: "booking", otp: "interactive", passwordless: true };
-  const generated = { name: "gh", otp: "totp", totpSecret: "x" };
+  // The only `totp` credential a card is ever built for: one whose seed is missing.
+  const fromApp = { name: "gh", otp: "totp" };
 
-  // A first card is the same either way: nobody knows whether the owner is there.
-  assert.equal(otpCardBudgetMs(mailed), otpCardBudgetMs(generated));
-
-  // A mailed code sends the owner back to the mailbox, so its retry cannot be
-  // sized like a glance at an authenticator already in their hand.
+  // Not the same wait even the first time. A mailed code may not have arrived yet
+  // and the owner has to go and fetch it; an authenticator is already in their
+  // hand, so ten minutes of an agent blocked on a card buys nothing.
   assert.ok(
-    otpCardBudgetMs(mailed, { retry: true }) > otpCardBudgetMs(generated, { retry: true }),
+    otpCardBudgetMs(mailed) > otpCardBudgetMs(fromApp),
     "a mailbox trip must outlast a glance",
+  );
+  assert.ok(
+    otpCardBudgetMs(mailed, { retry: true }) > otpCardBudgetMs(fromApp, { retry: true }),
+    "and the same holds on the retry",
   );
 
   // Both retries stay under lethe's 16-minute HUMAN_TIMEOUT once the first card
   // has spent its own budget — that ceiling covers the whole subprocess, so a
   // second full-length card would have the host kill the run mid-answer.
   const HUMAN_TIMEOUT_MS = 16 * 60 * 1000;
-  for (const cred of [mailed, generated]) {
+  for (const cred of [mailed, fromApp]) {
     const total = otpCardBudgetMs(cred) + otpCardBudgetMs(cred, { retry: true });
     assert.ok(total < HUMAN_TIMEOUT_MS, `${cred.otp}: ${total}ms leaves nothing for the page`);
   }

--- a/tests/test-login-detect.mjs
+++ b/tests/test-login-detect.mjs
@@ -8,7 +8,11 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { classifyLogin, codeDestination } from "../plugins/agent-id-browser/lib/login-detect.mjs";
+import {
+  classifyLogin,
+  codeDestination,
+  codeLengthFromText,
+} from "../plugins/agent-id-browser/lib/login-detect.mjs";
 
 test("logged-in: no password field, no otp, no error", () => {
   assert.equal(classifyLogin({ hasPasswordField: false, bodyText: "Welcome back, alice" }), "logged-in");
@@ -539,4 +543,19 @@ test("codeDestination says nothing rather than something wrong", () => {
   ]) {
     assert.equal(codeDestination(body), null, String(body));
   }
+});
+
+test("codeLengthFromText reads a stated digit count, and only a plausible one", () => {
+  assert.equal(codeLengthFromText("Enter the 6-digit code we sent you"), 6);
+  assert.equal(codeLengthFromText("We sent a six-digit code"), 6);
+  assert.equal(codeLengthFromText("Enter your 4 digit PIN"), 4);
+  assert.equal(codeLengthFromText("Enter the eight-digit code"), 8);
+
+  // Outside 4-8 the number is describing something that is not this code, and a
+  // wrong cell count is worse than none: the screen submits when the cells fill.
+  assert.equal(codeLengthFromText("a 3-digit code"), null);
+  assert.equal(codeLengthFromText("your 12-digit reference number"), null);
+  assert.equal(codeLengthFromText("Enter the code we sent you"), null);
+  assert.equal(codeLengthFromText(""), null);
+  assert.equal(codeLengthFromText(null), null);
 });

--- a/tests/test-login-detect.mjs
+++ b/tests/test-login-detect.mjs
@@ -493,6 +493,30 @@ test("codeDestination reads back the destination the page itself printed", () =>
   }
 });
 
+test("codeDestination also reads the shape that names no `to`", () => {
+  // The `sent … to X` shape misses how a lot of sites actually word it, and the
+  // miss is not harmless: the card then says "check your email or messages" for a
+  // code that went to a phone number the owner had forgotten was on the account.
+  const cases = [
+    ["We texted your phone ending in 4817", "your phone ending in 4817"],
+    ["Enter the code we sent to your phone ending in 4817.", "your phone ending in 4817"],
+    ["A code was sent to the number ending 4817", "the number ending in 4817"],
+    // Said after a `to`, the page's own words go through verbatim — "with" stays
+    // "with". Only the shape we assemble ourselves is normalised to "ending in".
+    ["Enter the code sent to your mobile ending with ••4817", "your mobile ending with ••4817"],
+    ["We messaged your mobile ending with ••4817", "your mobile ending in ••4817"],
+  ];
+  for (const [body, expected] of cases) {
+    assert.equal(codeDestination(body), expected, body);
+  }
+
+  // An address the page states outright still wins over the ending it repeats.
+  assert.equal(
+    codeDestination("We sent a code to d••@gmail.com — the address ending in 4817 is your old one"),
+    "d••@gmail.com",
+  );
+});
+
 test("codeDestination says nothing rather than something wrong", () => {
   // A destination on the card is a promise about where to look. Naming the wrong
   // place is worse than naming none: the owner watches an empty inbox and
@@ -502,6 +526,10 @@ test("codeDestination says nothing rather than something wrong", () => {
     "We sent a code to help you get started with our newsletter",
     "Your order was sent to 221B Baker Street",
     "We emailed a link to reset your password",
+    // `ending in` is ordinary English. Only a word that names a channel in front
+    // of it makes it a destination.
+    "The meeting is ending in 5 minutes",
+    "Your trial is ending in 3 days",
     // The page writes this text and the card the owner trusts prints it. The
     // loopback form escapes; the hosted prompt hands `description` on as it is.
     "We sent a code to <img/src=x/onerror=fetch(1)>@a.co",

--- a/tests/test-passwordless-live.mjs
+++ b/tests/test-passwordless-live.mjs
@@ -91,6 +91,24 @@ function fixtureServer({ submit = "button", acceptCode = true } = {}) {
 <p>code=${code}</p><p>My trips. Account settings. Saved lists.</p>`);
       return;
     }
+    if (url.pathname === "/otp-boxes") {
+      res.end(`<!doctype html><meta charset=utf-8><title>code</title>
+<h1>Enter the code we sent you</h1>
+<form>${Array.from({ length: 6 }, (_, i) => `<input name=d${i} type=text inputmode=numeric maxlength=1>`).join("")}</form>`);
+      return;
+    }
+    if (url.pathname === "/otp-single") {
+      res.end(`<!doctype html><meta charset=utf-8><title>code</title>
+<h1>Enter the code we sent you</h1>
+<form><input name=code type=text inputmode=numeric maxlength=8 autocomplete=one-time-code></form>`);
+      return;
+    }
+    if (url.pathname === "/otp-unbounded") {
+      res.end(`<!doctype html><meta charset=utf-8><title>code</title>
+<h1>Enter the code we sent you</h1>
+<form><input name=code type=text inputmode=numeric></form>`);
+      return;
+    }
     if (url.pathname === "/masked-checkbox") {
       // The ordinary cookie banner: a dialog masking the page that carries an input
       // of its own. "The page asks for something else" is satisfied by that
@@ -480,3 +498,26 @@ test(
     }
   },
 );
+
+test("the page's own constraint is what says how many cells to draw", { skip }, async () => {
+  const { server, port } = await fixtureServer();
+  try {
+    await withBrowser(async (context) => {
+      const page = await context.newPage();
+      const lengthAt = async (route) => {
+        await page.goto(`http://127.0.0.1:${port}${route}`, { waitUntil: "domcontentloaded" });
+        return (await detectPageState(page)).otpLength;
+      };
+
+      // A row of one-character boxes IS the count.
+      assert.equal(await lengthAt("/otp-boxes"), 6);
+      // One field states it outright.
+      assert.equal(await lengthAt("/otp-single"), 8);
+      // And an unconstrained input states nothing — which must not be read as a
+      // count, because the screen submits itself once the cells it drew are full.
+      assert.equal(await lengthAt("/otp-unbounded"), null);
+    });
+  } finally {
+    server.close();
+  }
+});


### PR DESCRIPTION
Two ways the code card left the owner stuck, both found on a live sign-in.

## A TOTP credential with no seed failed the sign-in

`resolveOtp` threw `otp=totp but no totpSecret stored` — the whole sign-in dead, while the owner sat there with the code already on their phone. There is no reason that has to be a dead end: the card is the same channel a mailed code uses.

It now raises one, worded for an authenticator rather than a mailbox — nothing was sent anywhere, so "check your email or messages" would be a wrong instruction, not a vague one — and sized for a glance (2 min) instead of a trip to the inbox (10 min). A credential that *has* its seed still generates the code and asks nobody.

The card does not name a particular app: which one the owner uses is not ours to guess.

## The card sent people to the wrong place

`codeDestination` read only `sent … to X`, which misses how many sites word it, and dropped an address the page stated outright whenever a dash followed it:

| page says | before | now |
| --- | --- | --- |
| `We texted your phone ending in 4817` | — | `your phone ending in 4817` |
| `A code was sent to the number ending 4817` | — | `the number ending in 4817` |
| `We sent a code to d••@gmail.com — enter it below` | — | `d••@gmail.com` |
| `The meeting is ending in 5 minutes` | — | — (still nothing) |

When the page really says nothing, the card now names the identifier the sign-in was started with, masked (`d•••@eti.co`, `••• 4817`), worded as the guess it is — "should reach", against the page's own "sent to". A username that is neither an address nor a number still names no channel and gets the old neutral copy.

The report this came from: the code went to a number attached to the account years earlier, on a phone in another room, while the card said "check your email or messages".

## Verification

`npm test` — 902 pass, 0 fail. Every new assertion was watched to fail against the code it covers (the throw restored, the ending-shape read removed, the dash boundary reverted, the identifier guess disabled).

Confirmed on a live stand — real model, real Chrome, real Airbnb sign-in — where the second card came out as:

```
Sign-in code for Airbnb.com
The code should reach d•••@eti.co — enter it to finish signing in
```