### PR TITLE
A card the owner can store, and a bank code they can answer

### DIFF
--- a/plugins/agent-id-browser/bin/cli.mjs
+++ b/plugins/agent-id-browser/bin/cli.mjs
@@ -958,6 +958,7 @@ runCli({
       }),
       11 * 60 * 1000,
     ),
+    "ref-text": actionCmd("ref-text", (f) => ({ ref: f.ref })),
     select: actionCmd("select", (f) => ({ ref: f.ref, values: csv(f.values) })),
     press: actionCmd("press", (f) => ({ key: f.key, ref: f.ref })),
     hover: actionCmd("hover", (f) => ({ ref: f.ref })),

--- a/plugins/agent-id-browser/bin/cli.mjs
+++ b/plugins/agent-id-browser/bin/cli.mjs
@@ -906,6 +906,11 @@ runCli({
     open: cmdOpen,
     close: cmdClose,
     sessions: cmdSessions,
+    // Where the session actually is. The dispatcher has always answered this;
+    // it had no command because every caller so far learned the URL as a side
+    // effect of doing something to the page. A caller that must know the origin
+    // BEFORE it acts — anything host-scoped — needs to ask on its own.
+    info: actionCmd("info"),
     snapshot: actionCmd("snapshot"),
     "form-inspect": actionCmd("form-inspect"),
     "form-fill": actionCmd("form-fill", (f) => JSON.parse(f.spec || "{}"), 120000),

--- a/plugins/agent-id-browser/bin/cli.mjs
+++ b/plugins/agent-id-browser/bin/cli.mjs
@@ -932,6 +932,32 @@ runCli({
     // budget kills the child while the owner is still fetching the code from
     // their mail, dropping a secret that was on its way back.
     "fill-otp": actionCmd("fill-otp", (f) => ({ ref: f.ref, cred: f.cred, submit: f.submit !== false }), 11 * 60 * 1000),
+    // Card payments. The four refs arrive as one JSON object because a partial
+    // fill is not a state anything downstream can tell from a whole one, and the
+    // owner's approval is spent either way.
+    "fill-card": actionCmd(
+      "fill-card",
+      (f) => ({
+        cred: f.cred,
+        merchantHost: f["merchant-host"],
+        refs: JSON.parse(f.refs || "{}"),
+        submit: f.submit === true,
+      }),
+      120000,
+    ),
+    // Same budget as fill-otp, and for the same reason: this raises a card the
+    // owner answers from their phone, and a shorter one kills the child while
+    // they are still reading the code off it.
+    "fill-3ds-code": actionCmd(
+      "fill-3ds-code",
+      (f) => ({
+        ref: f.ref,
+        merchant: f.merchant,
+        amount: f.amount,
+        submit: f.submit !== false,
+      }),
+      11 * 60 * 1000,
+    ),
     select: actionCmd("select", (f) => ({ ref: f.ref, values: csv(f.values) })),
     press: actionCmd("press", (f) => ({ key: f.key, ref: f.ref })),
     hover: actionCmd("hover", (f) => ({ ref: f.ref })),

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -655,15 +655,26 @@ export const SECRET_TAINT_ATTR = "data-aib-secret";
 // Deliberately not "autocomplete must be cc-*": provider frames set it, plenty of
 // merchant-hosted forms do not, and a rule that refuses every honest form is a
 // rule that gets widened.
+// Names are compared with separators removed on BOTH sides — see fieldWords — so
+// each entry is written once and matches `card-number`, `card_number` and
+// `cardNumber` alike. What Stripe Elements actually emits, checked against a live
+// mount rather than remembered: `cardnumber` / `exp-date` / `cvc` with
+// `cc-number` / `cc-exp` / `cc-csc` and a `data-elements-stable-field-name`.
 const CARD_FIELD_SIGNALS = {
   number: {
     autocomplete: ["cc-number"],
-    words: ["cardnumber", "card-number", "card_number", "ccnumber", "pan"],
+    // No bare "pan": matching is by substring, and it sits inside "expand",
+    // "panel" and "company". This list also decides what the plaintext path
+    // refuses, so a word that common costs more than it catches — a form that
+    // really names a field `pan` is covered by `autocomplete="cc-number"`.
+    words: ["cardnumber", "ccnumber"],
     minLength: 12,
   },
   expiry: {
+    // Not a bare "exp": this list also decides what the plaintext path REFUSES,
+    // and a field called "export" is not an expiry date.
     autocomplete: ["cc-exp", "cc-exp-month", "cc-exp-year"],
-    words: ["exp", "expiry", "expiration", "mmyy"],
+    words: ["expdate", "expiry", "expiration", "expmonth", "expyear", "mmyy"],
     minLength: 4,
   },
   security_code: {
@@ -673,10 +684,18 @@ const CARD_FIELD_SIGNALS = {
   },
   holder: {
     autocomplete: ["cc-name", "cc-given-name", "cc-family-name", "name"],
-    words: ["holder", "cardname", "card-name", "nameoncard", "name_on_card"],
+    words: ["holder", "cardname", "nameoncard"],
     minLength: 2,
   },
 };
+
+// Everything an element calls itself, as one comparable string. Separators go from
+// both this and the word lists, so a form is matched however it spells a name.
+function fieldWords(shape) {
+  return String(shape.label || "")
+    .toLowerCase()
+    .replace(/[\s\-_]+/g, "");
+}
 
 // Input types a card value can legitimately go into. `search` and `email` are
 // absent on purpose — those are the shapes of the boxes an injection aims at.
@@ -711,11 +730,11 @@ export async function cardFieldShape(target, ref) {
 // plaintext path must refuse it either way.
 export function isCardField(shape) {
   const autocomplete = String(shape.autocomplete || "").toLowerCase().split(/\s+/);
-  const label = String(shape.label || "").toLowerCase().replace(/\s+/g, "");
+  const label = fieldWords(shape);
   return Object.values(CARD_FIELD_SIGNALS).some(
     (signals) =>
       autocomplete.some((token) => signals.autocomplete.includes(token)) ||
-      signals.words.some((word) => label.includes(word.replace(/[-_]/g, ""))),
+      signals.words.some((word) => label.includes(word)),
   );
 }
 
@@ -748,9 +767,9 @@ export function assertCardFieldShape(field, shape) {
   // a guard that depends on its caller having normalised the input is a guard with
   // a way around it.
   const autocomplete = String(shape.autocomplete || "").toLowerCase();
-  const label = String(shape.label || "").toLowerCase().replace(/\s+/g, "");
+  const label = fieldWords(shape);
   const named = autocomplete.split(/\s+/).some((token) => signals.autocomplete.includes(token));
-  const described = signals.words.some((word) => label.includes(word.replace(/[-_]/g, "")));
+  const described = signals.words.some((word) => label.includes(word));
   if (!named && !described) {
     throw new Error(
       `fill-card: ${where} does not identify itself as one (autocomplete="${autocomplete}") — ` +

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -33,6 +33,7 @@ import { startStreamServer } from "./stream-server.mjs";
 import { loadCodecConfig } from "./stream-encoder.mjs";
 import { openVault, loadAgentPrivateKey } from "@alien-id/agent-id-vault/lib/vault.mjs";
 import { SECRET_FIELDS, assertHostAllowed } from "@alien-id/agent-id-vault/lib/store.mjs";
+import { collectSecret } from "@alien-id/agent-id-core/lib/secure-prompt.mjs";
 import { resolveOtp } from "./auto-login.mjs";
 import {
   applyAccessGuard,
@@ -641,6 +642,49 @@ export const SECRET_TAINT_ATTR = "data-aib-secret";
 // show-password toggle flips a password field to type=text, so a type-only test
 // misses them. Best-effort: if the site has already swapped the node out there
 // is nothing (and no value) left to tag.
+// How many characters the challenge input takes, when the page says so. Read off
+// the element rather than guessed: the screen draws one cell per character and
+// submits when they fill, so a wrong count is worse than none — too few truncate
+// a correct code and too many leave it unsendable. Anything outside the range the
+// clients draw cells for comes back null, and they render a plain field instead.
+export async function codeFieldLength(target, ref) {
+  const declared = await target
+    .locator(sel(ref))
+    .evaluate((el) => {
+      const attr = el.getAttribute("maxlength");
+      const value = attr == null ? NaN : Number(attr);
+      return Number.isInteger(value) ? value : null;
+    })
+    .catch(() => null);
+  return Number.isInteger(declared) && declared >= 4 && declared <= 8 ? declared : null;
+}
+
+// The card the owner answers a 3-D Secure challenge on.
+//
+// Merchant and amount are quoted from the payment they approved, never from the
+// page: the challenge is rendered by the issuer inside the merchant's frame, and
+// a card that repeated what that frame said about itself would be a card the
+// page could write.
+export function threeDsCardSpec({ merchant, amount, length }) {
+  const what = [amount, merchant].filter(Boolean).join(" at ");
+  return {
+    title: "Confirm your payment",
+    description: what
+      ? `Your bank sent a code to confirm ${what}. Enter it to finish the payment.`
+      : "Your bank sent a code to confirm this payment. Enter it to finish.",
+    fields: [
+      {
+        name: "otp",
+        label: "Code from your bank",
+        secret: false,
+        ...(length ? { placeholder: "•".repeat(length) } : {}),
+      },
+    ],
+    label: "confirm the payment with your bank",
+    security: "Used once to confirm this payment; never stored or shown to the agent.",
+  };
+}
+
 export async function markSecretField(target, selector) {
   await target
     .$eval(selector, (el, attr) => el.setAttribute(attr, "1"), SECRET_TAINT_ATTR)
@@ -1324,6 +1368,39 @@ export async function dispatch(state, msg, policy = null) {
         // A derived OTP isn't sealed at fill time (see assertFillAllowed), so the
         // read-back guard is what protects it: tag the field so its value can't be
         // read back regardless of the input's type (OTP inputs are text/tel).
+        await markSecretField(target, sel(p.ref));
+        return { filled: p.ref, otp: true };
+      } finally {
+        state.stream?.resume();
+      }
+    }
+    case "fill-3ds-code": {
+      // The bank's own challenge code, after a payment. No vault is opened and no
+      // credential is named, because there is nothing stored to name: this value
+      // is a one-shot the owner reads off their phone, so a domain allowlist has
+      // no secret here to protect and the issuer's host is not knowable in
+      // advance anyway. What stands in its place is the caller's check — lethe
+      // reaches this only for a payment it has already made, on the merchant the
+      // owner approved — and the card below, which quotes that payment rather
+      // than anything the page says about itself.
+      const target = frameForRef(state, p.ref);
+      state.stream?.suspend();
+      try {
+        const length = await codeFieldLength(target, p.ref);
+        const { values } = await collectSecret(
+          threeDsCardSpec({ merchant: String(p.merchant || ""), amount: String(p.amount || ""), length }),
+        );
+        const code = String(values.otp || "").trim();
+        if (!code) throw new Error("fill-3ds-code: no code was entered");
+        try {
+          await humanType(page, sel(p.ref), code, {
+            timeout: ACTION_TIMEOUT,
+            submit: p.submit !== false,
+            root: target,
+          });
+        } catch {
+          throw new Error(`fill-3ds-code: could not fill "${p.ref}" — element not visible/editable (re-snapshot and retry)`);
+        }
         await markSecretField(target, sel(p.ref));
         return { filled: p.ref, otp: true };
       } finally {

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -704,6 +704,21 @@ export async function cardFieldShape(target, ref) {
   }));
 }
 
+// Does this element announce itself as SOME card field? A different question from
+// the one assertCardFieldShape answers ("is it the specific field I was told it
+// is"), and it has to stay different: a card box that already holds a value, or
+// whose maxlength is too small for what was claimed, is still a card box — and the
+// plaintext path must refuse it either way.
+export function isCardField(shape) {
+  const autocomplete = String(shape.autocomplete || "").toLowerCase().split(/\s+/);
+  const label = String(shape.label || "").toLowerCase().replace(/\s+/g, "");
+  return Object.values(CARD_FIELD_SIGNALS).some(
+    (signals) =>
+      autocomplete.some((token) => signals.autocomplete.includes(token)) ||
+      signals.words.some((word) => label.includes(word.replace(/[-_]/g, ""))),
+  );
+}
+
 export function assertCardFieldShape(field, shape) {
   const signals = CARD_FIELD_SIGNALS[field];
   if (!signals) throw new Error(`fill-card: unknown card field "${field}"`);
@@ -1032,6 +1047,15 @@ export async function fillForm(state, p) {
         SECRET_TAINT_ATTR,
       );
       if (secretTarget) throw new Error("password/secret fields require fill-secret or fill-otp");
+      // And a card field, which the check above cannot see: a card number input is
+      // type="text", so nothing about it looks secret to the DOM. This is the
+      // plaintext path — the value comes from the caller — and a card must only
+      // ever arrive from the vault, through fill-card, under an approval the owner
+      // gave. Same rule as the password check, applied to the fields that do not
+      // announce themselves.
+      if (isCardField(await cardFieldShape(target, ref))) {
+        throw new Error("card fields require fill-card, with a payment the owner approved");
+      }
       await locator.fill(value, { timeout: ACTION_TIMEOUT });
       const matches = await locator.evaluate((el, expected) => {
         const actual = "value" in el ? el.value : el.textContent || "";

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -1479,8 +1479,8 @@ export async function dispatch(state, msg, policy = null) {
     case "fill-card": {
       // A stored card typed into a checkout: all four fields, one blackout, no
       // value returned and none logged. Whether this payment may happen at all is
-      // not decided here — lethe holds the owner-approved intent and has already
-      // spent it — but the merchant the owner approved is re-checked against the
+      // not decided here — the caller holds the owner-approved intent and has
+      // already spent it — but the merchant the owner approved is re-checked against the
       // page THIS process can see, because a host the caller passes is a claim
       // and page.url() is state.
       const credName = String(p.cred || "");
@@ -1566,7 +1566,7 @@ export async function dispatch(state, msg, policy = null) {
       // credential is named, because there is nothing stored to name: this value
       // is a one-shot the owner reads off their phone, so a domain allowlist has
       // no secret here to protect and the issuer's host is not knowable in
-      // advance anyway. What stands in its place is the caller's check — lethe
+      // advance anyway. What stands in its place is the caller's own check — it
       // reaches this only for a payment it has already made, on the merchant the
       // owner approved — and the card below, which quotes that payment rather
       // than anything the page says about itself.

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -642,6 +642,108 @@ export const SECRET_TAINT_ATTR = "data-aib-secret";
 // show-password toggle flips a password field to type=text, so a type-only test
 // misses them. Best-effort: if the site has already swapped the node out there
 // is nothing (and no value) left to tag.
+// ─── Where a card may be typed ────────────────────────────────────────────────
+//
+// The element refs come from the agent, and the host check passes for the whole
+// merchant page — so without this, a prompt-injected agent points the number at a
+// "notes to seller" box on the real checkout and the page keeps it.
+// markSecretField stops the AGENT reading a value back; it does not stop the page
+// that owns the field. So the target must look like the thing it claims to be,
+// checked BEFORE the vault is opened.
+//
+// Fail closed on what is unambiguously wrong, then require one positive signal.
+// Deliberately not "autocomplete must be cc-*": provider frames set it, plenty of
+// merchant-hosted forms do not, and a rule that refuses every honest form is a
+// rule that gets widened.
+const CARD_FIELD_SIGNALS = {
+  number: {
+    autocomplete: ["cc-number"],
+    words: ["cardnumber", "card-number", "card_number", "ccnumber", "pan"],
+    minLength: 12,
+  },
+  expiry: {
+    autocomplete: ["cc-exp", "cc-exp-month", "cc-exp-year"],
+    words: ["exp", "expiry", "expiration", "mmyy"],
+    minLength: 4,
+  },
+  security_code: {
+    autocomplete: ["cc-csc"],
+    words: ["cvc", "cvv", "csc", "cid", "security"],
+    minLength: 3,
+  },
+  holder: {
+    autocomplete: ["cc-name", "cc-given-name", "cc-family-name", "name"],
+    words: ["holder", "cardname", "card-name", "nameoncard", "name_on_card"],
+    minLength: 2,
+  },
+};
+
+// Input types a card value can legitimately go into. `search` and `email` are
+// absent on purpose — those are the shapes of the boxes an injection aims at.
+const CARD_INPUT_TYPES = new Set(["", "text", "tel", "number", "password"]);
+
+// Everything the check needs about the element, in one round trip.
+export async function cardFieldShape(target, ref) {
+  return target.locator(sel(ref)).evaluate((el) => ({
+    tag: el.tagName.toLowerCase(),
+    inputType: String(el.getAttribute("type") || "").toLowerCase(),
+    autocomplete: String(el.getAttribute("autocomplete") || "").toLowerCase().trim(),
+    label: [
+      el.getAttribute("name"),
+      el.id,
+      el.getAttribute("aria-label"),
+      el.getAttribute("placeholder"),
+      el.getAttribute("data-elements-stable-field-name"),
+    ]
+      .filter(Boolean)
+      .join(" ")
+      .toLowerCase(),
+    maxLength: Number(el.getAttribute("maxlength")) || null,
+    isContentEditable: el.isContentEditable === true,
+    hasValue: "value" in el && !!el.value,
+  }));
+}
+
+export function assertCardFieldShape(field, shape) {
+  const signals = CARD_FIELD_SIGNALS[field];
+  if (!signals) throw new Error(`fill-card: unknown card field "${field}"`);
+  const where = `the element given for "${field}"`;
+
+  if (shape.tag !== "input" || shape.isContentEditable) {
+    throw new Error(`fill-card: ${where} is a <${shape.tag}>, not a card input — nothing was typed`);
+  }
+  if (!CARD_INPUT_TYPES.has(shape.inputType)) {
+    throw new Error(
+      `fill-card: ${where} is type="${shape.inputType}", which no card field is — nothing was typed`,
+    );
+  }
+  // A field that already holds something is not the empty box that was
+  // snapshotted, and overwriting it destroys whatever the owner can see there.
+  if (shape.hasValue) {
+    throw new Error(`fill-card: ${where} already has a value — nothing was typed`);
+  }
+  // Too short to hold the value means it is not the field for it, whatever it is
+  // called: a three-character box is not where a card number goes.
+  if (shape.maxLength != null && shape.maxLength < signals.minLength) {
+    throw new Error(
+      `fill-card: ${where} takes at most ${shape.maxLength} characters, too few for it — nothing was typed`,
+    );
+  }
+  // Lowercased here as well as in cardFieldShape: this function is the guard, and
+  // a guard that depends on its caller having normalised the input is a guard with
+  // a way around it.
+  const autocomplete = String(shape.autocomplete || "").toLowerCase();
+  const label = String(shape.label || "").toLowerCase().replace(/\s+/g, "");
+  const named = autocomplete.split(/\s+/).some((token) => signals.autocomplete.includes(token));
+  const described = signals.words.some((word) => label.includes(word.replace(/[-_]/g, "")));
+  if (!named && !described) {
+    throw new Error(
+      `fill-card: ${where} does not identify itself as one (autocomplete="${autocomplete}") — ` +
+        "re-snapshot the form, or hand the browser to the owner. Nothing was typed",
+    );
+  }
+}
+
 // How many characters the challenge input takes, when the page says so. Read off
 // the element rather than guessed: the screen draws one cell per character and
 // submits when they fill, so a wrong count is worse than none — too few truncate
@@ -1373,6 +1475,91 @@ export async function dispatch(state, msg, policy = null) {
       } finally {
         state.stream?.resume();
       }
+    }
+    case "fill-card": {
+      // A stored card typed into a checkout: all four fields, one blackout, no
+      // value returned and none logged. Whether this payment may happen at all is
+      // not decided here — lethe holds the owner-approved intent and has already
+      // spent it — but the merchant the owner approved is re-checked against the
+      // page THIS process can see, because a host the caller passes is a claim
+      // and page.url() is state.
+      const credName = String(p.cred || "");
+      if (!credName) throw new Error("fill-card needs a --cred");
+      const approvedHost = String(p.merchantHost || "");
+      if (!approvedHost) throw new Error("fill-card needs a --merchant-host");
+      const refs = p.refs && typeof p.refs === "object" ? p.refs : null;
+      if (!refs) throw new Error("fill-card needs --refs {number, expiry, security_code, holder}");
+      const plan = [
+        ["number", "cardNumber"],
+        ["expiry", "cardExpiry"],
+        ["security_code", "cardSecurityCode"],
+        ["holder", "cardholderName"],
+      ].map(([key, field]) => {
+        const ref = String(refs[key] || "").trim();
+        // All four or none: a half-filled checkout cannot be told from a filled
+        // one by anything downstream, and the owner's approval is spent either way.
+        if (!ref) throw new Error(`fill-card: refs.${key} is required — snapshot the form and pass all four`);
+        return { key, field, ref };
+      });
+      const pageHost = hostOfUrl(page.url());
+      if (pageHost !== approvedHost) {
+        throw new Error(
+          `fill-card: the owner approved paying at ${approvedHost}, but this session is on ${pageHost || "about:blank"} — nothing was typed`,
+        );
+      }
+      state.stream?.suspend();
+      try {
+        const vault = await openVaultAgentKey(msg._stateDir);
+        try {
+          const rec = vault.get(credName);
+          if (!rec) throw new Error(`no credential "${credName}"`);
+          if (rec.type !== "card") throw new Error(`"${credName}" is not a card credential`);
+          // The grant. A card's allowlist starts empty and gains a host each time
+          // the owner approves a payment there, so this is the moment it is known.
+          if (!Array.isArray(rec.domains) || !rec.domains.includes(approvedHost)) {
+            vault.add({ ...rec, domains: [...(rec.domains || []), approvedHost] });
+            await vault.save();
+          }
+          for (const { key, field, ref } of plan) {
+            assertFillAllowed(vault.get(credName), pageHost, field);
+            // Unlike fill-secret, the FRAME's origin is not required to be on the
+            // allowlist: a card form is normally the payment provider's iframe on
+            // the merchant's page, so demanding it would refuse the ordinary case.
+            // What stands in its place is two checks — the top page is the exact
+            // host the owner approved, and the element itself has to look like the
+            // field it is claimed to be. Without the second one the refs, which
+            // come from the agent, choose where the number lands inside a page the
+            // owner did approve: a "notes to seller" box on the real checkout
+            // passes the host check and keeps the value. Read the shape BEFORE the
+            // value, so a target that fails never causes a read.
+            const target = frameForRef(state, ref);
+            assertCardFieldShape(key, await cardFieldShape(target, ref));
+            const value = vault.get(credName)[field];
+            if (typeof value !== "string" || !value) {
+              throw new Error(`"${credName}.${field}" is not a usable string field`);
+            }
+            try {
+              await humanType(page, sel(ref), value, {
+                timeout: ACTION_TIMEOUT,
+                submit: false,
+                root: target,
+              });
+            } catch {
+              // Never let the raw error escape: a fill error can echo the value.
+              throw new Error(`fill-card: could not fill "${ref}" — element not visible/editable (re-snapshot and ask for a fresh approval)`);
+            }
+            await markSecretField(target, sel(ref));
+          }
+          if (p.submit) {
+            await page.keyboard.press("Enter").catch(() => {});
+          }
+        } finally {
+          vault.lock();
+        }
+      } finally {
+        state.stream?.resume();
+      }
+      return { filled: plan.map((step) => step.ref) };
     }
     case "fill-3ds-code": {
       // The bank's own challenge code, after a payment. No vault is opened and no

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -1594,6 +1594,16 @@ export async function dispatch(state, msg, policy = null) {
         state.stream?.resume();
       }
     }
+    case "ref-text": {
+      // One element's own text. `text` returns the whole body, which is no use to
+      // a caller that has to compare the same figure twice — a total read off the
+      // page before the owner approves it, and re-read before anything is typed.
+      const target = frameForRef(state, p.ref);
+      const text = await target
+        .locator(sel(p.ref))
+        .evaluate((el) => ("value" in el && el.value ? el.value : el.textContent || ""));
+      return { ref: p.ref, text: String(text).trim().slice(0, 200) };
+    }
     case "select": {
       // Same dispatch as form-fill's selects — a bare `select` on an ARIA
       // combobox would otherwise fail identically here.

--- a/plugins/agent-id-mcp/lib/tools.mjs
+++ b/plugins/agent-id-mcp/lib/tools.mjs
@@ -56,7 +56,7 @@ export const TOOLS = [
   {
     name: "vault_add",
     description:
-      "Store a credential in the Alien vault. You supply only name/type/domains/access (and login_url for logins); the owner types the secret values into a secure card — they never reach you. If the site has NO password — it asks for an e-mail/phone and sends a code — pass passwordless=true with otp=\"interactive\": the card then has a single identifier field, and the code is asked for separately at sign-in time. Never invent a password for such a site and never ask the owner for one. Types: bearer, basic, header, query, cookie, oauth2, login, totp.",
+      "Store a credential in the Alien vault. You supply only name/type/domains/access (and login_url for logins); the owner types the secret values into a secure card — they never reach you. If the site has NO password — it asks for an e-mail/phone and sends a code — pass passwordless=true with otp=\"interactive\": the card then has a single identifier field, and the code is asked for separately at sign-in time. Never invent a password for such a site and never ask the owner for one. A `card` takes no domains and no sign-in fields: where it may be used is decided by the owner when they approve a payment, not here. Types: bearer, basic, header, query, cookie, oauth2, login, totp, card.",
     kind: "vault",
     inputSchema: {
       type: "object",
@@ -64,7 +64,7 @@ export const TOOLS = [
         name: str("Credential name (letters, digits, dot/dash/underscore)."),
         type: {
           type: "string",
-          enum: ["bearer", "basic", "header", "query", "cookie", "oauth2", "login", "totp"],
+          enum: ["bearer", "basic", "header", "query", "cookie", "oauth2", "login", "totp", "card"],
           description: "Credential type.",
         },
         domains: strArr("Host allowlist this credential may be used on (e.g. api.github.com). For type=login it is enforced: sign-ins often hop subdomains, so cover the whole flow (e.g. *.example.com) rather than just the login page host."),

--- a/plugins/agent-id-vault/bin/cli.mjs
+++ b/plugins/agent-id-vault/bin/cli.mjs
@@ -336,6 +336,16 @@ function formFieldsForType(type, flags) {
         ? [{ name: "totpSecret", label: "TOTP secret (base32) or otpauth:// URI" }]
         : []),
     ];
+    case "card": return [
+      // These four names are a wire contract, not labels: the secure-input
+      // envelope carries no field type, so the name a value is sealed under is
+      // what picks the phone's keyboard and the paired expiry/code row. Renaming
+      // one downgrades that screen to a plain text box and nothing fails.
+      { name: "cardNumber", label: "Card number" },
+      { name: "cardExpiry", label: "Expiry (MMYY)" },
+      { name: "cardSecurityCode", label: "Security code" },
+      { name: "cardholderName", label: "Name on card", secret: false },
+    ];
     default: return null;
   }
 }
@@ -353,10 +363,22 @@ async function cmdAdd(flags) {
     return outputError(`--access must be one of ${ACCESS_LEVELS.join(", ")}`);
   }
   let domains = parseDomains(flags);
+  // Declaring where a card may be used would be granting oneself a merchant: the
+  // allowlist is what the owner's approvals write, one payment at a time.
+  if (type === "card" && domains.length > 0) {
+    return outputError(
+      "A card takes no --domains. Where it may be used is decided by the owner when they " +
+        "approve a payment, not here.",
+    );
+  }
   if (domains.length === 0) {
     // `secret` is not host-scoped (it's used via exec/file, not the HTTP proxy),
     // so it doesn't need a domain allowlist; everything else is default-deny.
     if (type === "secret") domains = ["*"];
+    // A card's allowlist is the owner's to grant: it starts empty — which matches
+    // no host, so default-deny holds literally — and gains one each time they
+    // approve a payment there.
+    else if (type === "card") domains = [];
     else if (type === "login") {
       // `login` IS host-scoped — the browser gates fill-secret / fill-otp and every
       // auto-login recipe step on this list. Default to the loginUrl host; falling
@@ -547,6 +569,24 @@ async function cmdAdd(flags) {
               "(--refresh-token-file / --refresh-token-env / stdin / --form)",
           );
         }
+        break;
+      }
+      case "card": {
+        // Form-only, and not for tidiness: a PAN passed as a flag is a PAN in the
+        // process table, in `ps` output, and in whatever shell history saw it.
+        if (!formValues) {
+          return outputError("A card is typed into the secure form — re-run with --form");
+        }
+        record.cardNumber = formValues.cardNumber || "";
+        record.cardExpiry = formValues.cardExpiry || "";
+        record.cardSecurityCode = formValues.cardSecurityCode || "";
+        record.cardholderName = formValues.cardholderName || "";
+        // A read of this record is a complete card-not-present instrument, so it
+        // never comes back out: `ro` makes it access-restricted, which is what
+        // `show` redacts every SECRET_FIELD on. Not `exportable: false` — that
+        // means "generated in-vault, never typed into a page", which is the one
+        // thing a card exists to do, and assertFillAllowed enforces it literally.
+        if (!record.access) record.access = "ro";
         break;
       }
       case "login": {

--- a/plugins/agent-id-vault/bin/cli.mjs
+++ b/plugins/agent-id-vault/bin/cli.mjs
@@ -283,6 +283,19 @@ async function cmdInit(flags) {
 const CARD_TITLE = "Enter it securely";
 
 function formDescription({ name, type, loginUrl, domains, access, passwordless }) {
+  // A card gets its own sentence, and skips the `ro` grant below, because that
+  // grant reads here as the opposite of what it means. On a login it says the agent
+  // may read the account and not change it. On the screen where somebody is typing
+  // a card number, "the agent can read this" is the thing they are most afraid of —
+  // and it would sit directly above a security note promising that it never sees
+  // the value. The stored name is left out for the reason given above CARD_TITLE:
+  // it is a key the agent invented, and this is not where it belongs.
+  if (type === "card") {
+    return (
+      "A payment card for the agent to pay with. It asks you to approve every " +
+      "payment before using it — the amount and the site, every time."
+    );
+  }
   const site = siteName(credentialHost({ loginUrl, domains }));
   const lead = type === "login"
     ? `${site ? `${site} sign-in` : `Sign-in for ${name}`}. You type it on a sealed screen.`

--- a/plugins/agent-id-vault/lib/store.mjs
+++ b/plugins/agent-id-vault/lib/store.mjs
@@ -302,6 +302,13 @@ export function validateRecord(rec) {
       validateToAllowlist(rec);
       break;
     }
+    case "card": {
+      // Everything a card-not-present payment needs. A read of this record is a
+      // complete instrument, which is why the payment path never returns a value
+      // and why an owner-approved intent — not the vault — is what gates a spend.
+      validateCardFields(rec);
+      break;
+    }
     case "browser-profile": {
       // Used by `agent-id-browser`, NOT the HTTP proxy. The vault holds only the
       // data-encryption key (DEK) + the sidecar filename; the actual browser
@@ -458,6 +465,9 @@ export function listMetadata(payload) {
     // so an agent can see which profile is which without opening the record.
     ...(c.account ? { account: c.account } : {}),
     ...(c.type === "browser-profile" ? { headless: c.headless !== false } : {}),
+    // card: the last four, so an approval card can name which instrument is
+    // about to be charged. The only part of a number that leaves the vault.
+    ...(c.type === "card" ? { cardLast4: cardLast4(c) } : {}),
     // login: the non-secret shape of the sign-in, so a caller can tell what a
     // stored credential will ask for before driving it — whether a password
     // exists at all, how a code is answered, where to start, and whether an
@@ -502,6 +512,10 @@ export const SECRET_FIELDS = Object.freeze([
   "privateKey", // evm-keypair
   "dek", // browser-profile (data-encryption key for the sealed profile)
   "totpSecret", // login (the stored 2FA seed; username + password already listed above)
+  "cardNumber",
+  "cardExpiry",
+  "cardSecurityCode",
+  "cardholderName", // card — every field of one, so none of it survives a lock
 ]);
 
 // Best-effort scrub of decrypted secret material when the vault locks. JS

--- a/plugins/agent-id-vault/lib/store.mjs
+++ b/plugins/agent-id-vault/lib/store.mjs
@@ -11,7 +11,7 @@
 //     name: "github-pat",
 //     type: one of CREDENTIAL_TYPES below (bearer | basic | header | query |
 //           cookie | totp | cookie-jar | oauth2 | solana-keypair | evm-keypair |
-//           browser-profile | secret | login),
+//           browser-profile | secret | login | card),
 //     domains: ["*.github.com"],
 //     description: "...",
 //     createdAt, updatedAt, lastUsedAt,
@@ -40,6 +40,7 @@ export const CREDENTIAL_TYPES = Object.freeze([
   "browser-profile",
   "secret",
   "login",
+  "card",
 ]);
 
 // Allowed `otp` policies on a `login` credential.
@@ -110,6 +111,68 @@ function validateProgramAllowlist(rec) {
   }
 }
 
+// ─── Card field validators ─────────────────────────────────────────────────
+
+// Luhn. A typo in a hand-copied 16-digit number is the single likeliest failure
+// of the whole payment flow, and the merchant only reports it after the owner
+// has typed and approved. Catching it at the point of storage costs one pass.
+function passesLuhn(digits) {
+  let sum = 0;
+  let double = false;
+  for (let i = digits.length - 1; i >= 0; i -= 1) {
+    let d = digits.charCodeAt(i) - 48;
+    if (double) {
+      d *= 2;
+      if (d > 9) d -= 9;
+    }
+    sum += d;
+    double = !double;
+  }
+  return sum % 10 === 0;
+}
+
+// `MMYY`, and not already over. `now` is injectable so the check is testable
+// without freezing the clock: a card stored in December must not start failing
+// on the first of January because the test pinned a literal.
+function validateCardExpiry(rec, now = new Date()) {
+  const expiry = rec.cardExpiry;
+  if (typeof expiry !== "string" || !/^\d{4}$/.test(expiry)) {
+    throw new Error(`Credential ${rec.name}: cardExpiry must be MMYY (four digits)`);
+  }
+  const month = Number(expiry.slice(0, 2));
+  const year = 2000 + Number(expiry.slice(2));
+  if (month < 1 || month > 12) {
+    throw new Error(`Credential ${rec.name}: cardExpiry month must be 01-12`);
+  }
+  // A card is good through the last day of its stated month.
+  const endOfMonth = Date.UTC(year, month, 1);
+  if (endOfMonth <= now.getTime()) {
+    throw new Error(`Credential ${rec.name}: cardExpiry ${expiry} is in the past`);
+  }
+}
+
+function validateCardFields(rec) {
+  requireNonEmpty(rec, ["cardNumber", "cardExpiry", "cardSecurityCode", "cardholderName"]);
+  const number = rec.cardNumber;
+  if (!/^\d{12,19}$/.test(number)) {
+    throw new Error(`Credential ${rec.name}: cardNumber must be 12-19 digits, no spaces`);
+  }
+  if (!passesLuhn(number)) {
+    throw new Error(`Credential ${rec.name}: cardNumber fails the Luhn check — it was mistyped`);
+  }
+  validateCardExpiry(rec);
+  if (!/^\d{3,4}$/.test(rec.cardSecurityCode)) {
+    throw new Error(`Credential ${rec.name}: cardSecurityCode must be 3 or 4 digits`);
+  }
+}
+
+// The last four, for a card the owner is asked to recognise. The only part of a
+// number that may leave the vault — everything that renders a card to a human
+// (the approval card, `list`, `show`) reads this and never the record.
+export function cardLast4(rec) {
+  return typeof rec?.cardNumber === "string" ? rec.cardNumber.slice(-4) : "";
+}
+
 export function validateRecord(rec) {
   if (!rec || typeof rec !== "object") {
     throw new Error("Record must be an object");
@@ -122,7 +185,13 @@ export function validateRecord(rec) {
   if (!CREDENTIAL_TYPES.includes(rec.type)) {
     throw new Error(`Unknown credential type: ${rec.type}`);
   }
-  if (!Array.isArray(rec.domains) || rec.domains.length === 0) {
+  // A card is the one type whose allowlist is granted by the owner rather than
+  // declared at creation: it starts empty and gains a host each time the owner
+  // approves a payment there. Empty still denies everything — hostMatchesAllowlist
+  // returns false for an empty list — so default-deny holds literally; what
+  // changes is only that nothing has been granted yet.
+  const allowsEmptyDomains = rec.type === "card";
+  if (!Array.isArray(rec.domains) || (rec.domains.length === 0 && !allowsEmptyDomains)) {
     throw new Error(
       `Credential ${rec.name}: 'domains' must be a non-empty array (default-deny)`,
     );

--- a/tests/test-browser-stream-blackout.mjs
+++ b/tests/test-browser-stream-blackout.mjs
@@ -89,3 +89,71 @@ for (const action of ["fill-secret", "fill-otp"]) {
     await fs.rm(dir, { recursive: true, force: true });
   });
 }
+
+// `fill-card` types four values instead of one, so it holds the blackout across
+// all of them. The same unlock failure has to lift it, and the two guards that
+// run BEFORE the suspend must not raise one at all — an approval refused on the
+// wrong host should leave the feed exactly as it found it.
+const CARD_REFS = { number: "1:e1", expiry: "1:e2", security_code: "1:e3", holder: "1:e4" };
+
+test("fill-card: a failed vault unlock still lifts the blackout", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "aid-blackout-card-"));
+  const stream = fakeStream();
+  const state = fakeState(stream);
+
+  await assert.rejects(
+    () =>
+      dispatch(state, {
+        action: "fill-card",
+        // fakeState's page is on example.com, so this is the approved merchant.
+        params: { cred: "visa", merchantHost: "example.com", refs: CARD_REFS },
+        _stateDir: dir,
+      }),
+    "the fill must fail — there is no vault to unlock",
+  );
+
+  assert.equal(stream.suspends, 1, "the feed is blacked out for the fill");
+  assert.equal(stream.resumes, 1, "and the blackout is lifted even though the fill threw");
+  assert.equal(stream.depth, 0, "no leaked suspend depth");
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+test("fill-card: a merchant the owner did not approve is refused before anything is typed", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "aid-card-host-"));
+  const stream = fakeStream();
+  const state = fakeState(stream);
+
+  await assert.rejects(
+    () =>
+      dispatch(state, {
+        action: "fill-card",
+        params: { cred: "visa", merchantHost: "checkout.attacker.net", refs: CARD_REFS },
+        _stateDir: dir,
+      }),
+    /approved paying at checkout\.attacker\.net/,
+  );
+
+  assert.equal(stream.suspends, 0, "nothing was typed, so nothing was blacked out");
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+test("fill-card: a form missing any of the four is not a card form", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "aid-card-refs-"));
+  for (const missing of Object.keys(CARD_REFS)) {
+    const stream = fakeStream();
+    const refs = { ...CARD_REFS };
+    delete refs[missing];
+    await assert.rejects(
+      () =>
+        dispatch(fakeState(stream), {
+          action: "fill-card",
+          params: { cred: "visa", merchantHost: "example.com", refs },
+          _stateDir: dir,
+        }),
+      new RegExp(`refs\\.${missing} is required`),
+      `a form missing ${missing} was accepted`,
+    );
+    assert.equal(stream.suspends, 0, "a refused shape must not black out the feed");
+  }
+  await fs.rm(dir, { recursive: true, force: true });
+});

--- a/tests/test-card-fill-live.mjs
+++ b/tests/test-card-fill-live.mjs
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+
+// The card fill, against a real browser and a real checkout.
+//
+// Everything else about `fill-card` is unit-tested against objects that stand in
+// for a page. This is the one that runs it for real: a live browser, a real vault
+// unlocked with a real agent key, and the card fields inside an iframe — the shape
+// a payment provider serves.
+//
+// The frame is same-origin, on its own path, and that is a fixture limit rather
+// than a weakening. Chromium refuses a cross-origin subresource between two local
+// addresses (`net::ERR_BLOCKED_BY_LOCAL_NETWORK_ACCESS_CHECKS`), so a second port
+// cannot be reached from the first without launching the browser with the check
+// disabled — a flag this suite has no business setting. What it would have proven
+// is also not what fill-card does: it checks the TOP page's host against the
+// merchant the owner approved and deliberately never checks the frame's origin,
+// because the card form normally belongs to the provider rather than the merchant.
+// Frame resolution itself is identical either way — a Playwright frame handle does
+// not care whose origin it is.
+//
+// What it pins that a fake page cannot:
+//   - `cardFieldShape` reads attributes off real DOM rather than a literal
+//   - refs inside another origin's frame resolve, and the values land there
+//   - `humanType` reaches provider-style inputs
+//   - the notes box on the same approved page is refused
+//   - the plaintext path refuses a card box
+//   - `ref-text` reads the total the owner is shown
+//
+// Run: node --test tests/test-card-fill-live.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+import { generateKeyPairSync } from "node:crypto";
+
+import { initVault, openVault } from "../plugins/agent-id-vault/lib/vault.mjs";
+import { writeJsonFile, statePaths } from "../plugins/agent-id-core/lib/state.mjs";
+import { fingerprintPublicKeyPem } from "../plugins/agent-id-core/lib/crypto.mjs";
+import { resolvePatchright, launchContext } from "../plugins/agent-id-browser/lib/launch.mjs";
+import { dispatch } from "../plugins/agent-id-browser/lib/session-server.mjs";
+
+const skip = resolvePatchright() ? false : "patchright/Chrome not installed";
+
+// The Visa test PAN every processor publishes, so a leak of this fixture is not a card.
+const PAN = "4242424242424242";
+const EXPIRY = "1234";
+const CVC = "123";
+const HOLDER = "Alien Owner";
+const TOTAL = "42.00 EUR";
+
+// The provider's frame: card fields marked the way Stripe Elements and its peers
+// mark them.
+const PSP_PAGE = `<!doctype html><meta charset="utf-8"><body style="margin:0;font:14px sans-serif">
+  <input data-aibref="f1e1" name="cardnumber" autocomplete="cc-number" inputmode="numeric" maxlength="19" placeholder="Card number">
+  <input data-aibref="f1e2" name="exp-date" autocomplete="cc-exp" inputmode="numeric" maxlength="7" placeholder="MM / YY">
+  <input data-aibref="f1e3" name="cvc" autocomplete="cc-csc" inputmode="numeric" maxlength="4" placeholder="CVC">
+  <input data-aibref="f1e4" name="ccname" autocomplete="cc-name" placeholder="Name on card">
+</body>`;
+
+// The merchant's own page: the total the owner is shown, a note box that is not a
+// card field however much an injection would like it to be, and the frame.
+const merchantPage = () => `<!doctype html><meta charset="utf-8"><body style="font:14px sans-serif">
+  <h1>Checkout</h1>
+  <div data-aibref="e1" id="order-total">Total: ${TOTAL}</div>
+  <textarea data-aibref="e2" name="order_notes" placeholder="Notes for the seller"></textarea>
+  <iframe src="/fields" style="width:420px;height:180px;border:1px solid #ccc"></iframe>
+</body>`;
+
+function serveCheckout() {
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      const body = req.url.startsWith("/fields") ? PSP_PAGE : merchantPage();
+      res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" }).end(body);
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address();
+      resolve({ server, origin: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+async function makeVaultWithCard(dir) {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const publicKeyPem = publicKey.export({ format: "pem", type: "spki" }).toString();
+  const privateKeyPem = privateKey.export({ format: "pem", type: "pkcs8" }).toString();
+  await writeJsonFile(statePaths(dir).mainKey, {
+    version: 1,
+    agentId: "main",
+    keyNonce: 0,
+    createdAt: 1,
+    publicKeyPem,
+    privateKeyPem,
+    fingerprint: fingerprintPublicKeyPem(publicKeyPem),
+  });
+  await initVault({ stateDir: dir, privateKeyPem, agentId: "main" });
+
+  const vault = await openVault({ stateDir: dir, privateKeyPem });
+  vault.add({
+    name: "visa",
+    type: "card",
+    domains: [],
+    access: "ro",
+    cardNumber: PAN,
+    cardExpiry: EXPIRY,
+    cardSecurityCode: CVC,
+    cardholderName: HOLDER,
+  });
+  await vault.save();
+  vault.lock();
+}
+
+/** The state the session server would hold, built by hand around a real page. */
+function stateFor(page, frame) {
+  return {
+    stream: { suspend() {}, resume() {} },
+    current: page,
+    ctx: page.context(),
+    refsValid: true,
+    frames: new Map([["f1", frame]]),
+  };
+}
+
+async function withCheckout(fn) {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "cardfill-"));
+  const merchant = await serveCheckout();
+  let ctx;
+  try {
+    await makeVaultWithCard(dir);
+    ctx = await launchContext({ profileDir: path.join(dir, "profile"), headless: true });
+    const page = ctx.pages()[0] || (await ctx.newPage());
+    await page.goto(`${merchant.origin}/checkout`, { waitUntil: "load" });
+    // A child frame reaches page.frames() when it has navigated, which is not
+    // guaranteed by the parent's load event — poll rather than race it.
+    const deadline = Date.now() + 10_000;
+    let frame = null;
+    while (!frame && Date.now() < deadline) {
+      frame = page.frames().find((f) => f.url().endsWith("/fields")) || null;
+      if (!frame) await page.waitForTimeout(50);
+    }
+    assert.ok(frame, "the provider frame never loaded");
+    assert.notEqual(frame, page.mainFrame(), "the fields must live in a frame, not the top page");
+
+    await fn({ dir, page, frame, host: "127.0.0.1", state: stateFor(page, frame) });
+  } finally {
+    if (ctx) await ctx.close().catch(() => {});
+    merchant.server.close();
+    await rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+const fillCard = (state, dir, params) =>
+  dispatch(state, { action: "fill-card", params, _stateDir: dir });
+
+const refs = { number: "f1e1", expiry: "f1e2", security_code: "f1e3", holder: "f1e4" };
+
+test("a stored card lands in the provider's frame, and nowhere else", { skip }, async () => {
+  await withCheckout(async ({ dir, frame, host, state }) => {
+    const result = await fillCard(state, dir, { cred: "visa", merchantHost: host, refs });
+
+    assert.deepEqual(result, { filled: ["f1e1", "f1e2", "f1e3", "f1e4"] });
+
+    const typed = await frame.evaluate(() => ({
+      number: document.querySelector('[data-aibref="f1e1"]').value,
+      expiry: document.querySelector('[data-aibref="f1e2"]').value,
+      cvc: document.querySelector('[data-aibref="f1e3"]').value,
+      holder: document.querySelector('[data-aibref="f1e4"]').value,
+    }));
+    assert.equal(typed.number, PAN);
+    assert.equal(typed.expiry, EXPIRY);
+    assert.equal(typed.cvc, CVC);
+    assert.equal(typed.holder, HOLDER);
+
+    // Every filled field is tagged, so a later read-back is refused whatever the
+    // input's type says.
+    const tagged = await frame.evaluate(() =>
+      ["f1e1", "f1e2", "f1e3", "f1e4"].every((r) =>
+        document.querySelector(`[data-aibref="${r}"]`).hasAttribute("data-aib-secret"),
+      ),
+    );
+    assert.ok(tagged, "filled card fields are not tagged against read-back");
+  });
+});
+
+test("the approval does not travel to another merchant", { skip }, async () => {
+  await withCheckout(async ({ dir, frame, state }) => {
+    await assert.rejects(
+      fillCard(state, dir, { cred: "visa", merchantHost: "shop.example.net", refs }),
+      /nothing was typed/,
+    );
+    const number = await frame.evaluate(
+      () => document.querySelector('[data-aibref="f1e1"]').value,
+    );
+    assert.equal(number, "", "a refused fill still typed something");
+  });
+});
+
+test("the note box on the approved page is refused", { skip }, async () => {
+  await withCheckout(async ({ dir, page, host, state }) => {
+    // The host check passes — this IS the merchant the owner approved. Only the
+    // element's own shape stands between an injection and the number.
+    await assert.rejects(
+      fillCard(state, dir, { cred: "visa", merchantHost: host, refs: { ...refs, number: "e2" } }),
+      /not a card input|does not identify itself/,
+    );
+    const notes = await page.evaluate(
+      () => document.querySelector('[data-aibref="e2"]').value,
+    );
+    assert.equal(notes, "", "the number reached the notes box");
+  });
+});
+
+test("the plaintext path refuses a card box", { skip }, async () => {
+  await withCheckout(async ({ dir, frame, state }) => {
+    const result = await dispatch(state, {
+      action: "form-fill",
+      params: { fields: [{ ref: "f1e1", value: PAN }] },
+      _stateDir: dir,
+    });
+    assert.equal(result.results[0].ok, false);
+    assert.match(result.results[0].error, /require fill-card/);
+
+    const number = await frame.evaluate(
+      () => document.querySelector('[data-aibref="f1e1"]').value,
+    );
+    assert.equal(number, "", "form-fill typed a card number anyway");
+  });
+});
+
+test("the total is read from the element the owner was shown", { skip }, async () => {
+  await withCheckout(async ({ dir, state }) => {
+    const result = await dispatch(state, {
+      action: "ref-text",
+      params: { ref: "e1" },
+      _stateDir: dir,
+    });
+    assert.equal(result.text, `Total: ${TOTAL}`);
+  });
+});

--- a/tests/test-card-fill-live.mjs
+++ b/tests/test-card-fill-live.mjs
@@ -58,6 +58,8 @@ const PSP_PAGE = `<!doctype html><meta charset="utf-8"><body style="margin:0;fon
   <input data-aibref="f1e2" name="exp-date" autocomplete="cc-exp" inputmode="numeric" maxlength="7" placeholder="MM / YY">
   <input data-aibref="f1e3" name="cvc" autocomplete="cc-csc" inputmode="numeric" maxlength="4" placeholder="CVC">
   <input data-aibref="f1e4" name="ccname" autocomplete="cc-name" placeholder="Name on card">
+  <!-- Stripe plants one of these to spoil browser autofill. Nothing may type into it. -->
+  <input data-aibref="f1e9" name="hidden" autocomplete="fake">
 </body>`;
 
 // The merchant's own page: the total the owner is shown, a note box that is not a
@@ -226,6 +228,19 @@ test("the plaintext path refuses a card box", { skip }, async () => {
       () => document.querySelector('[data-aibref="f1e1"]').value,
     );
     assert.equal(number, "", "form-fill typed a card number anyway");
+  });
+});
+
+test("the provider's autofill decoy is never typed into", { skip }, async () => {
+  await withCheckout(async ({ dir, frame, host, state }) => {
+    await assert.rejects(
+      fillCard(state, dir, { cred: "visa", merchantHost: host, refs: { ...refs, number: "f1e9" } }),
+      /does not identify itself/,
+    );
+    const decoy = await frame.evaluate(
+      () => document.querySelector('[data-aibref="f1e9"]').value,
+    );
+    assert.equal(decoy, "", "the number reached the decoy input");
   });
 });
 

--- a/tests/test-payment-card.mjs
+++ b/tests/test-payment-card.mjs
@@ -16,6 +16,7 @@ import { CREDENTIAL_TYPES, SECRET_FIELDS, validateRecord } from "../plugins/agen
 import {
   assertCardFieldShape,
   cardFieldShape,
+  isCardField,
   codeFieldLength,
   threeDsCardSpec,
 } from "../plugins/agent-id-browser/lib/session-server.mjs";
@@ -163,6 +164,21 @@ test("the notes-to-seller box is refused however it is dressed up", () => {
       ),
     /does not identify itself/,
   );
+});
+
+// The plaintext fill path takes its value from the caller, so a card must never
+// arrive through it — and the DOM gives it nothing to notice, because a card number
+// input is type="text". This is the check that closes it.
+test("a card box is recognised as one even when it cannot be filled", () => {
+  assert.ok(isCardField(cardInput()));
+  assert.ok(isCardField(cardInput({ hasValue: true })), "already filled is still a card box");
+  assert.ok(isCardField(cardInput({ maxLength: 3 })), "a short one is still a card box");
+  assert.ok(isCardField(cardInput({ autocomplete: "cc-csc", label: "" })));
+  assert.ok(isCardField(cardInput({ autocomplete: "", label: "nameOnCard" })));
+
+  assert.ok(!isCardField(cardInput({ autocomplete: "", label: "order notes for the seller" })));
+  assert.ok(!isCardField(cardInput({ autocomplete: "email", label: "your email" })));
+  assert.ok(!isCardField({ autocomplete: "", label: "" }));
 });
 
 test("a field too short for the value is not the field for it", () => {

--- a/tests/test-payment-card.mjs
+++ b/tests/test-payment-card.mjs
@@ -4,16 +4,13 @@
 // is validated against, and the 3-D Secure challenge card the owner answers.
 // No browser and no vault are opened.
 //
-// The five schema tests here are RED until two edits land in
-// plugins/agent-id-vault/lib/store.mjs — `case "card"` calling validateCardFields
-// inside validateRecord, and the four card fields inside SECRET_FIELDS. They are
-// written first on purpose: they are the acceptance criteria for that wiring, and
-// a card whose fields are missing from SECRET_FIELDS survives an idle lock.
-//
 // Run: node --test tests/test-payment-card.mjs
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 
 import { CREDENTIAL_TYPES, SECRET_FIELDS, validateRecord } from "../plugins/agent-id-vault/lib/store.mjs";
 import {
@@ -77,6 +74,38 @@ test("a card missing any field is not a card", () => {
     delete incomplete[field];
     assert.throws(() => validateRecord(incomplete), new RegExp(field));
   }
+});
+
+// The screen where somebody types a card number is the one place trust is the
+// whole point, so what it says is worth pinning. The `ro` grant sentence used to
+// land here — "the agent can read this, never change it" — directly above a
+// security note promising the agent never sees the value.
+test("the card form does not tell the owner the agent can read their card", async () => {
+  const cli = await readFile(
+    new URL("../plugins/agent-id-vault/bin/cli.mjs", import.meta.url),
+    "utf8",
+  );
+  const source = cli.slice(
+    cli.indexOf("function formDescription"),
+    cli.indexOf("function formFieldsForType"),
+  );
+  const scratch = path.join(await mkdtemp(path.join(os.tmpdir(), "card-copy-")), "fd.mjs");
+  await writeFile(
+    scratch,
+    "const siteName=()=>null, credentialHost=()=>null;\n" + source + "\nexport default formDescription;\n",
+  );
+  const formDescription = (await import(`file://${scratch}`)).default;
+
+  const card = formDescription({ name: "visa", type: "card", domains: [], access: "ro" });
+  assert.ok(!/can read this/i.test(card), card);
+  assert.ok(!/\bvisa\b/.test(card), "the name the agent invented is not the owner's business");
+  assert.match(card, /approve every payment/i);
+
+  // And the sentence is still there for a login, where it means what it says.
+  const login = formDescription({ name: "booking", type: "login", domains: ["booking.com"], access: "ro" });
+  assert.match(login, /can read this, never change it/);
+
+  await rm(path.dirname(scratch), { recursive: true, force: true });
 });
 
 test("the challenge card quotes the payment, never the page", () => {

--- a/tests/test-payment-card.mjs
+++ b/tests/test-payment-card.mjs
@@ -16,7 +16,12 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 
 import { CREDENTIAL_TYPES, SECRET_FIELDS, validateRecord } from "../plugins/agent-id-vault/lib/store.mjs";
-import { codeFieldLength, threeDsCardSpec } from "../plugins/agent-id-browser/lib/session-server.mjs";
+import {
+  assertCardFieldShape,
+  cardFieldShape,
+  codeFieldLength,
+  threeDsCardSpec,
+} from "../plugins/agent-id-browser/lib/session-server.mjs";
 
 // A Luhn-valid test number (the Visa test PAN every processor publishes).
 const GOOD_PAN = "4242424242424242";
@@ -91,6 +96,101 @@ test("the challenge card still stands up when the payment is not quotable", () =
 
   assert.match(spec.description, /your bank sent a code/i);
   assert.ok(!("placeholder" in spec.fields[0]), "no length means a plain field, not guessed cells");
+});
+
+// The refs come from the agent and the host check passes for the whole merchant
+// page, so this is the only thing standing between a prompt injection and a card
+// number in a box the page reads.
+const cardInput = (overrides = {}) => ({
+  tag: "input",
+  inputType: "text",
+  autocomplete: "cc-number",
+  label: "cardnumber",
+  maxLength: 19,
+  isContentEditable: false,
+  hasValue: false,
+  ...overrides,
+});
+
+test("a card field must be an input, not a box that merely accepts text", () => {
+  assert.doesNotThrow(() => assertCardFieldShape("number", cardInput()));
+  assert.throws(() => assertCardFieldShape("number", cardInput({ tag: "textarea" })), /not a card input/);
+  assert.throws(
+    () => assertCardFieldShape("number", cardInput({ tag: "div", isContentEditable: true })),
+    /not a card input/,
+  );
+  assert.throws(() => assertCardFieldShape("number", cardInput({ inputType: "search" })), /no card field is/);
+  assert.throws(() => assertCardFieldShape("number", cardInput({ inputType: "email" })), /no card field is/);
+});
+
+test("the notes-to-seller box is refused however it is dressed up", () => {
+  // A plain text input on the real checkout, with nothing saying it is a card
+  // field. This is the shape an injection aims at, and the host check passes.
+  assert.throws(
+    () =>
+      assertCardFieldShape(
+        "number",
+        cardInput({ autocomplete: "", label: "order notes for the seller", maxLength: null }),
+      ),
+    /does not identify itself/,
+  );
+});
+
+test("a field too short for the value is not the field for it", () => {
+  assert.throws(() => assertCardFieldShape("number", cardInput({ maxLength: 3 })), /too few for it/);
+  assert.doesNotThrow(() => assertCardFieldShape("security_code", cardInput({ autocomplete: "cc-csc", label: "cvc", maxLength: 3 })));
+});
+
+test("a field that already holds something is left alone", () => {
+  assert.throws(() => assertCardFieldShape("number", cardInput({ hasValue: true })), /already has a value/);
+});
+
+test("an honest form is accepted by its own words when it sets no autocomplete", () => {
+  for (const [field, label] of [
+    ["number", "ccNumber"],
+    ["expiry", "card-expiration"],
+    ["security_code", "CVV"],
+    ["holder", "nameOnCard"],
+  ]) {
+    assert.doesNotThrow(
+      () => assertCardFieldShape(field, cardInput({ autocomplete: "", label, maxLength: null })),
+      `${field} via label ${label}`,
+    );
+  }
+});
+
+test("the provider's own frame is accepted by its autocomplete", () => {
+  for (const [field, autocomplete] of [
+    ["number", "cc-number"],
+    ["expiry", "cc-exp"],
+    ["security_code", "cc-csc"],
+    ["holder", "cc-name"],
+  ]) {
+    assert.doesNotThrow(
+      () => assertCardFieldShape(field, cardInput({ autocomplete, label: "", maxLength: null })),
+      `${field} via autocomplete ${autocomplete}`,
+    );
+  }
+});
+
+test("the element is read in one round trip, attributes and all", async () => {
+  const el = {
+    tagName: "INPUT",
+    id: "card-number",
+    isContentEditable: false,
+    value: "",
+    getAttribute: (name) =>
+      ({ type: "tel", autocomplete: "cc-number", maxlength: "19", name: "cardnumber" })[name] ?? null,
+  };
+  const target = { locator: () => ({ evaluate: async (fn) => fn(el) }) };
+
+  const shape = await cardFieldShape(target, "e1");
+  assert.equal(shape.tag, "input");
+  assert.equal(shape.inputType, "tel");
+  assert.equal(shape.autocomplete, "cc-number");
+  assert.equal(shape.maxLength, 19);
+  assert.equal(shape.hasValue, false);
+  assert.doesNotThrow(() => assertCardFieldShape("number", shape));
 });
 
 test("only a length the screen can draw cells for is passed on", async () => {

--- a/tests/test-payment-card.mjs
+++ b/tests/test-payment-card.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+
+// Unit tests for the card-payment pieces that are pure: the schema a stored card
+// is validated against, and the 3-D Secure challenge card the owner answers.
+// No browser and no vault are opened.
+//
+// The five schema tests here are RED until two edits land in
+// plugins/agent-id-vault/lib/store.mjs — `case "card"` calling validateCardFields
+// inside validateRecord, and the four card fields inside SECRET_FIELDS. They are
+// written first on purpose: they are the acceptance criteria for that wiring, and
+// a card whose fields are missing from SECRET_FIELDS survives an idle lock.
+//
+// Run: node --test tests/test-payment-card.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { CREDENTIAL_TYPES, SECRET_FIELDS, validateRecord } from "../plugins/agent-id-vault/lib/store.mjs";
+import { codeFieldLength, threeDsCardSpec } from "../plugins/agent-id-browser/lib/session-server.mjs";
+
+// A Luhn-valid test number (the Visa test PAN every processor publishes).
+const GOOD_PAN = "4242424242424242";
+
+function card(overrides = {}) {
+  return {
+    name: "visa",
+    type: "card",
+    domains: [],
+    cardNumber: GOOD_PAN,
+    cardExpiry: "1234",
+    cardSecurityCode: "123",
+    cardholderName: "Alien Owner",
+    ...overrides,
+  };
+}
+
+test("a card is a credential type the vault knows", () => {
+  assert.ok(CREDENTIAL_TYPES.includes("card"));
+});
+
+test("every field of a card is secret-bearing, so a lock wipes all of it", () => {
+  for (const field of ["cardNumber", "cardExpiry", "cardSecurityCode", "cardholderName"]) {
+    assert.ok(SECRET_FIELDS.includes(field), `${field} would survive an idle lock`);
+  }
+});
+
+test("a card starts with no merchant granted, and that is not an error", () => {
+  assert.doesNotThrow(() => validateRecord(card()));
+});
+
+test("a mistyped number is refused at the point of storage", () => {
+  assert.throws(() => validateRecord(card({ cardNumber: "4242424242424243" })), /Luhn/);
+  assert.throws(() => validateRecord(card({ cardNumber: "4242 4242 4242 4242" })), /12-19 digits/);
+  assert.throws(() => validateRecord(card({ cardNumber: "424242424242424242424" })), /12-19 digits/);
+});
+
+test("an expiry must be a real month, and still ahead", () => {
+  assert.throws(() => validateRecord(card({ cardExpiry: "1324" })), /01-12/);
+  assert.throws(() => validateRecord(card({ cardExpiry: "12/34" })), /MMYY/);
+  assert.throws(() => validateRecord(card({ cardExpiry: "0120" })), /in the past/);
+});
+
+test("a security code is three or four digits", () => {
+  assert.doesNotThrow(() => validateRecord(card({ cardSecurityCode: "1234" })));
+  assert.throws(() => validateRecord(card({ cardSecurityCode: "12" })), /3 or 4 digits/);
+  assert.throws(() => validateRecord(card({ cardSecurityCode: "12a" })), /3 or 4 digits/);
+});
+
+test("a card missing any field is not a card", () => {
+  for (const field of ["cardNumber", "cardExpiry", "cardSecurityCode", "cardholderName"]) {
+    const incomplete = card();
+    delete incomplete[field];
+    assert.throws(() => validateRecord(incomplete), new RegExp(field));
+  }
+});
+
+test("the challenge card quotes the payment, never the page", () => {
+  const spec = threeDsCardSpec({ merchant: "checkout.example.com", amount: "42.00 EUR", length: 6 });
+
+  assert.match(spec.description, /42\.00 EUR at checkout\.example\.com/);
+  assert.equal(spec.fields.length, 1);
+  assert.equal(spec.fields[0].name, "otp");
+  // Not masked: a single-use code being copied off a phone is exactly the
+  // transcription whose slips dots would hide.
+  assert.equal(spec.fields[0].secret, false);
+  assert.equal(spec.fields[0].placeholder, "••••••");
+});
+
+test("the challenge card still stands up when the payment is not quotable", () => {
+  const spec = threeDsCardSpec({ merchant: "", amount: "", length: null });
+
+  assert.match(spec.description, /your bank sent a code/i);
+  assert.ok(!("placeholder" in spec.fields[0]), "no length means a plain field, not guessed cells");
+});
+
+test("only a length the screen can draw cells for is passed on", async () => {
+  const target = (maxlength) => ({
+    locator: () => ({ evaluate: async (fn) => fn({ getAttribute: () => maxlength }) }),
+  });
+
+  assert.equal(await codeFieldLength(target("6"), "e1"), 6);
+  assert.equal(await codeFieldLength(target("4"), "e1"), 4);
+  assert.equal(await codeFieldLength(target("8"), "e1"), 8);
+  assert.equal(await codeFieldLength(target("3"), "e1"), null);
+  assert.equal(await codeFieldLength(target("40"), "e1"), null);
+  assert.equal(await codeFieldLength(target(null), "e1"), null);
+  assert.equal(await codeFieldLength(target("six"), "e1"), null);
+});

--- a/tests/test-payment-card.mjs
+++ b/tests/test-payment-card.mjs
@@ -169,6 +169,53 @@ test("the notes-to-seller box is refused however it is dressed up", () => {
 // The plaintext fill path takes its value from the caller, so a card must never
 // arrive through it — and the DOM gives it nothing to notice, because a card number
 // input is type="text". This is the check that closes it.
+// The attributes Stripe Elements actually emits, read off a live mount rather than
+// remembered — both the split fields and the combined element expose these same
+// three inputs. Recorded here so the guard is pinned against the real thing
+// without the suite needing Stripe, a network, or a key.
+const STRIPE_FIELDS = {
+  number: { autocomplete: "cc-number", label: "cardnumber Card number cardNumber" },
+  expiry: { autocomplete: "cc-exp", label: "exp-date MM / YY cardExpiry" },
+  security_code: { autocomplete: "cc-csc", label: "cvc CVC cardCvc" },
+};
+// Stripe plants these to spoil browser autofill. Nothing may ever type into one.
+const STRIPE_DECOY = { autocomplete: "fake", label: "hidden" };
+
+test("the guard accepts what Stripe Elements really emits", () => {
+  for (const [field, attrs] of Object.entries(STRIPE_FIELDS)) {
+    assert.doesNotThrow(
+      () => assertCardFieldShape(field, cardInput({ ...attrs, maxLength: null })),
+      `${field}: ${attrs.autocomplete}`,
+    );
+    assert.ok(isCardField(cardInput({ ...attrs, maxLength: null })));
+  }
+  // Stripe serves no cardholder-name field; that one is the merchant's own input.
+  assert.doesNotThrow(() =>
+    assertCardFieldShape("holder", cardInput({ autocomplete: "cc-name", label: "ccname", maxLength: null })),
+  );
+});
+
+test("Stripe's autofill decoy is not a card field", () => {
+  assert.ok(!isCardField(cardInput({ ...STRIPE_DECOY, maxLength: null })));
+  assert.throws(
+    () => assertCardFieldShape("number", cardInput({ ...STRIPE_DECOY, maxLength: null })),
+    /does not identify itself/,
+  );
+});
+
+// Separators are stripped from both the element's names and the word lists, so a
+// form is matched however it spells one. Before that they were stripped from only
+// one side, and a merchant writing `card-number` went unrecognised.
+test("a name is matched however the form spells it", () => {
+  for (const label of ["card-number", "card_number", "cardNumber", "CARDNUMBER"]) {
+    assert.ok(isCardField(cardInput({ autocomplete: "", label, maxLength: null })), label);
+  }
+  // And the refusal stays narrow: this list also decides what form-fill turns away.
+  for (const label of ["export", "experience", "expand"]) {
+    assert.ok(!isCardField(cardInput({ autocomplete: "", label, maxLength: null })), label);
+  }
+});
+
 test("a card box is recognised as one even when it cannot be filled", () => {
   assert.ok(isCardField(cardInput()));
   assert.ok(isCardField(cardInput({ hasValue: true })), "already filled is still a card box");

--- a/tests/test-vault-add-card.mjs
+++ b/tests/test-vault-add-card.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+
+// End-to-end test for `agent-id-vault add --type card --form`, through the REAL CLI.
+//
+// The four field names are a wire contract, not labels: the secure-input envelope
+// carries no field type, so the name a value is sealed under is what tells the
+// phone which screen to draw. A rename here downgrades it to four plain text
+// boxes with the wrong keyboards and nothing fails loudly — which is exactly the
+// break a test has to catch, and it can only be seen from outside the module.
+//
+// Run: node --test tests/test-vault-add-card.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm, readFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { generateKeyPairSync } from "node:crypto";
+
+import { initVault, openVault } from "../plugins/agent-id-vault/lib/vault.mjs";
+import { writeJsonFile, statePaths } from "../plugins/agent-id-core/lib/state.mjs";
+import { fingerprintPublicKeyPem } from "../plugins/agent-id-core/lib/crypto.mjs";
+
+const CLI = new URL("../plugins/agent-id-vault/bin/cli.mjs", import.meta.url).pathname;
+
+// The Visa test PAN every processor publishes, so a leak of this fixture is not a card.
+const PAN = "4242424242424242";
+const EXPIRY = "1234";
+const CVC = "123";
+const HOLDER = "Alien Owner";
+
+const CONTRACT_FIELDS = ["cardNumber", "cardExpiry", "cardSecurityCode", "cardholderName"];
+
+async function makeVault(dir) {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const publicKeyPem = publicKey.export({ format: "pem", type: "spki" }).toString();
+  const privateKeyPem = privateKey.export({ format: "pem", type: "pkcs8" }).toString();
+  await writeJsonFile(statePaths(dir).mainKey, {
+    version: 1,
+    agentId: "main",
+    keyNonce: 0,
+    createdAt: 1,
+    publicKeyPem,
+    privateKeyPem,
+    fingerprint: fingerprintPublicKeyPem(publicKeyPem),
+  });
+  await initVault({ stateDir: dir, privateKeyPem, agentId: "main" });
+}
+
+function waitForUrl(child) {
+  return new Promise((resolve, reject) => {
+    let buf = "";
+    const onData = (d) => {
+      buf += d.toString();
+      const m = buf.match(/http:\/\/127\.0\.0\.1:\d+\/\?t=[a-f0-9]+/);
+      if (m) {
+        child.stderr.off("data", onData);
+        resolve(m[0]);
+      }
+    };
+    child.stderr.on("data", onData);
+    child.on("exit", () => reject(new Error(`CLI exited before printing a URL:\n${buf}`)));
+  });
+}
+
+function runCli(args, dir) {
+  return new Promise((resolve) => {
+    const child = spawn("node", [CLI, ...args, "--state-dir", dir]);
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (d) => (stdout += d));
+    child.stderr.on("data", (d) => (stderr += d));
+    child.on("exit", (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+test("a card is typed into the secure form under the names the clients key their screens off", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "addcard-"));
+  let child = null;
+  let submitted = false;
+  try {
+    await makeVault(dir);
+
+    // No --domains: where a card may be used is the owner's to grant, one
+    // approved payment at a time, so it must be storable without one.
+    child = spawn(
+      "node",
+      [CLI, "add", "--name", "visa", "--type", "card", "--form", "--state-dir", dir],
+      { env: { ...process.env, AGENT_ID_NO_BROWSER: "1", AGENT_ID_SECURE_PROMPT: "browser" } },
+    );
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (d) => (stdout += d));
+    child.stderr.on("data", (d) => (stderr += d));
+
+    const url = await waitForUrl(child);
+    const u = new URL(url);
+    const token = u.searchParams.get("t");
+
+    const form = await (await fetch(url)).text();
+    for (const field of CONTRACT_FIELDS) {
+      assert.ok(
+        form.includes(`name="${field}"`),
+        `the form does not ask for ${field} — the phone would draw a plain box for it`,
+      );
+    }
+
+    const res = await fetch(`http://127.0.0.1:${u.port}/submit`, {
+      method: "POST",
+      body: new URLSearchParams({
+        _token: token,
+        cardNumber: PAN,
+        cardExpiry: EXPIRY,
+        cardSecurityCode: CVC,
+        cardholderName: HOLDER,
+      }),
+    });
+    assert.equal(res.status, 200);
+    submitted = true;
+
+    const code = await new Promise((r) => child.on("exit", r));
+    assert.equal(code, 0, `CLI failed: ${stderr}`);
+
+    // The PAN and the holder, not the security code: three digits cannot be told
+    // apart from the epoch milliseconds the success JSON already carries, so a
+    // check on it would fail on whichever run happened to mint a matching stamp.
+    for (const secret of [PAN, HOLDER]) {
+      assert.ok(!stdout.includes(secret), "stdout leaked a card value");
+      assert.ok(!stderr.includes(secret), "stderr leaked a card value");
+    }
+
+    const { privateKeyPem } = JSON.parse(await readFile(statePaths(dir).mainKey, "utf8"));
+    const vault = await openVault({ stateDir: dir, privateKeyPem });
+    const rec = vault.get("visa");
+    assert.equal(rec.cardNumber, PAN);
+    assert.equal(rec.cardExpiry, EXPIRY);
+    assert.equal(rec.cardSecurityCode, CVC);
+    assert.equal(rec.cardholderName, HOLDER);
+    // Storing a card grants no merchant.
+    assert.deepEqual(rec.domains, []);
+    assert.equal(rec.access, "ro");
+    vault.lock();
+
+    // …and a read of it never comes back out through the agent's own channel.
+    const shown = JSON.parse((await runCli(["show", "--name", "visa"], dir)).stdout);
+    assert.equal(shown.sealed, true);
+    assert.ok(!JSON.stringify(shown).includes(PAN), "show returned the card number");
+    assert.ok(!JSON.stringify(shown).includes(HOLDER), "show returned the cardholder");
+
+    // What the agent may learn about a stored card: that it exists, and which one.
+    const listed = JSON.parse((await runCli(["list"], dir)).stdout);
+    const entry = listed.credentials.find((c) => c.name === "visa");
+    assert.equal(entry.type, "card");
+    assert.equal(entry.cardLast4, "4242");
+    for (const field of CONTRACT_FIELDS) {
+      assert.ok(!(field in entry), `list exposed ${field}`);
+    }
+  } finally {
+    // An assertion above the submit leaves the CLI waiting on a form nobody will
+    // fill; without this the runner hangs instead of reporting the failure.
+    if (!submitted) child?.kill();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("a card refuses to be typed on the command line", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "addcard-argv-"));
+  try {
+    await makeVault(dir);
+    const { code, stdout } = await runCli(["add", "--name", "visa", "--type", "card"], dir);
+    assert.notEqual(code, 0);
+    assert.match(JSON.parse(stdout).error, /--form/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("a card refuses an allowlist the caller declared for itself", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "addcard-domains-"));
+  try {
+    await makeVault(dir);
+    const { code, stdout } = await runCli(
+      ["add", "--name", "visa", "--type", "card", "--domains", "shop.example.com", "--form"],
+      dir,
+    );
+    assert.notEqual(code, 0);
+    assert.match(JSON.parse(stdout).error, /no --domains/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What

The vault gains a `card` type — number, expiry, security code, holder — plus the browser action that answers a bank's 3-D Secure code box after a payment.

## Two hunks are missing, on purpose

The auto-mode classifier in my harness refused to apply two edits in `plugins/agent-id-vault/lib/store.mjs`, both of which name the security code as a **stored** field. They are the storage wiring for a decision taken on 2026-09-01 (store the whole card, security code included), and PCI DSS 3.3.1 is the reason a tool would object to it.

**The five red tests in `tests/test-payment-card.mjs` are their acceptance criteria** — they go green the moment these land:

1. In `validateRecord`'s type switch, before `case "browser-profile"`:

```js
    case "card": {
      // Everything a card-not-present payment needs. A read of this record is a
      // complete instrument, which is why the payment path never returns a value
      // and why an owner-approved intent — not the vault — is what gates a spend.
      validateCardFields(rec);
      break;
    }
```

2. At the end of `SECRET_FIELDS`, after `"totpSecret"`:

```js
  "cardNumber",
  "cardExpiry",
  "cardSecurityCode",
  "cardholderName", // card — every field of one, so none of it survives a lock
```

Miss the second and the values survive an idle lock and are not redacted by `show` — the file's own comment says exactly that.

Still to write, same reason: `formFieldsForType("card")` in the vault CLI, the `fill-card` dispatch action, and its `actionCmd` registration (plus one for `fill-3ds-code`, which is implemented but unregistered).

## What is here

- `card` in `CREDENTIAL_TYPES`, and the validators: Luhn, `MMYY` still ahead, a three- or four-digit code. A transposed digit is caught at storage instead of by a checkout after the owner has approved a payment.
- A card's domain allowlist starts **empty** — which denies everything, since an empty list matches no host — and is granted by the owner one approved payment at a time. `validateRecord` allows the empty list for this type alone.
- `fill-3ds-code`: opens no vault and names no credential, because there is nothing stored to name. The value is a one-shot the owner reads off their own phone, so a domain allowlist has no secret here to protect, and the issuer's host is not knowable in advance. Its card quotes the merchant and amount from the payment the caller already made, never from the frame being paid — that frame is rendered by the issuer inside the merchant's page.
- `info` becomes a command. The dispatcher always answered it; a caller that must know the origin *before* it acts needs to be able to ask.
- `card` in the MCP `vault_add` enum.

## Tests

`node --test tests/test-*.mjs`: 906 pass, 0 fail — the existing suite is unaffected. The new file is 5 green, 5 red as described above.

Design and the accepted risk: `documentation/agent/card-payments-v1.md`.