### PR TITLE
fix(browser): tell a card closed for the browser from a card simply closed

### DIFF
--- a/.changeset/use-browser-instead.md
+++ b/.changeset/use-browser-instead.md
@@ -1,0 +1,19 @@
+---
+"@alien-id/agent-id-core": minor
+"@alien-id/agent-id-browser": minor
+---
+
+Tell a card closed for the browser from a card simply closed.
+
+A card knows how to be answered and how to be dismissed, and the owner saying
+"not here — I will sign in myself, where I can see it" has nowhere to live
+between them. It arrives as a plain dismissal, so the agent reads a refusal,
+leaves the sign-in alone, and reports it as not done — when what was asked for
+was the browser.
+
+The host now says how a card was closed, and a dismissal carrying `use_browser`
+becomes its own outcome: `owner-will-drive`, escalating to the viewport the owner
+just asked for, with a message that says in as many words they did not refuse.
+
+Everything without a reason behaves exactly as before, which is what every client
+that has not been taught the button keeps sending.

--- a/plugins/agent-id-browser/lib/auto-login.mjs
+++ b/plugins/agent-id-browser/lib/auto-login.mjs
@@ -1191,6 +1191,16 @@ export async function autoLogin({
     finalUrl: page.url(),
     errorText,
   });
+  // Not a refusal at all: the owner pressed the card's own button and means to
+  // finish the sign-in themselves, in a browser they can see. Reported apart from
+  // a dismissal because the answer to it is the opposite — hand them the browser
+  // rather than leave the sign-in alone.
+  const ownerWillDrive = () => ({
+    ok: false,
+    outcome: "owner-will-drive",
+    finalUrl: page.url(),
+    errorText,
+  });
   // The stored `otp` said this site has no codes, and it has just been shown
   // wrong. Called once a code is in hand, because that is the whole of the
   // evidence — `otp-required` is also what a signed-in landing page inviting the
@@ -1225,6 +1235,7 @@ export async function autoLogin({
         domains: cred.domains,
       });
     } catch (err) {
+      if (err?.code === "FORM_USE_BROWSER") return ownerWillDrive();
       if (err?.code === "FORM_CANCELLED") return otpDeclined();
       if (err?.code !== "FORM_TIMEOUT") throw err;
       return otpTimedOut();
@@ -1333,6 +1344,7 @@ export async function autoLogin({
         await recordOtpModeCorrection();
         await typeOtp(page, code);
       } catch (err) {
+        if (err?.code === "FORM_USE_BROWSER") return ownerWillDrive();
         if (err?.code === "FORM_CANCELLED") return otpDeclined();
         if (err?.code !== "FORM_TIMEOUT") throw err;
         return otpTimedOut();

--- a/plugins/agent-id-browser/lib/escalation.mjs
+++ b/plugins/agent-id-browser/lib/escalation.mjs
@@ -102,6 +102,21 @@ export function escalationFor(outcome, { credName = "", profile = "" } = {}) {
           "Either way the password is FINE: do not re-check it and do not ask for one. " +
           "Run auto-login again once the cause is addressed.",
       };
+    // The owner pressed "use the browser instead". They are not refusing the
+    // sign-in — they are asking to do it where they can see it, which is exactly
+    // what the viewport is for. Anything else here (another card, a retry, a
+    // question about the password) ignores what they just said.
+    case "owner-will-drive":
+      return {
+        action: OWNER_MUST_DRIVE,
+        reason: "owner_chose_the_browser",
+        message:
+          `The owner closed the secure card for '${credName}' and asked to sign in through the ` +
+          `browser themselves. Open the browser view for profile '${profile}', parked on the ` +
+          "sign-in page, and let them finish there — then continue. Do NOT raise another card, " +
+          "do NOT ask for the password, and do NOT report the sign-in refused: they did not " +
+          "refuse it, they took it over.",
+      };
     // The owner closed the card. Nothing is broken and nothing timed out — they
     // were asked and declined, so the one thing that must not happen is the same
     // card going back up unbidden.

--- a/plugins/agent-id-core/lib/secure-prompt.mjs
+++ b/plugins/agent-id-core/lib/secure-prompt.mjs
@@ -124,6 +124,17 @@ function hostedSocketPath(env) {
   }
 }
 
+// Why a card was dismissed, when the host said. Unreadable or absent leaves the
+// plain dismissal, which is what every host that predates the button sends.
+function readDismissalReason(body) {
+  try {
+    const reason = JSON.parse(body.toString("utf8"))?.reason;
+    return typeof reason === "string" && reason ? reason : null;
+  } catch {
+    return null;
+  }
+}
+
 export class HostedHarnessProvider {
   constructor({ env = process.env } = {}) {
     this.name = "hosted";
@@ -171,12 +182,26 @@ export class HostedHarnessProvider {
               // error, and a caller that cannot tell "they declined" from "it
               // broke" retries — putting the same card back in front of someone
               // who has just dismissed it.
-              const error = new Error(
+              //
+              // The body may also say HOW it was closed. `use_browser` is the
+              // card's own button: the owner still means to sign in, just not
+              // here, and a caller that cannot tell that from a refusal reports
+              // the task abandoned when it was only handed over.
+              const reason =
                 res.statusCode === 409
-                  ? "hosted secure prompt: the owner dismissed the card"
-                  : `hosted secure prompt: HTTP ${res.statusCode}`
+                  ? readDismissalReason(Buffer.concat(chunks))
+                  : null;
+              const error = new Error(
+                res.statusCode !== 409
+                  ? `hosted secure prompt: HTTP ${res.statusCode}`
+                  : reason === "use_browser"
+                    ? "hosted secure prompt: the owner will sign in through the browser instead"
+                    : "hosted secure prompt: the owner dismissed the card"
               );
-              if (res.statusCode === 409) error.code = "FORM_CANCELLED";
+              if (res.statusCode === 409) {
+                error.code =
+                  reason === "use_browser" ? "FORM_USE_BROWSER" : "FORM_CANCELLED";
+              }
               reject(error);
               return;
             }

--- a/tests/test-auto-login.mjs
+++ b/tests/test-auto-login.mjs
@@ -801,6 +801,24 @@ test("autoLogin reports an expired code card as an outcome, so the caller learns
   assert.equal(result.finalUrl, "https://x.test/otp");
 });
 
+test("a card closed for the browser asks for the browser, not for another card", async () => {
+  const useBrowser = () => {
+    const err = new Error("hosted secure prompt: the owner will sign in through the browser instead");
+    err.code = "FORM_USE_BROWSER";
+    return err;
+  };
+  const result = await autoLogin({
+    page: recipePage("https://x.test/otp"),
+    cred: PWLESS_CRED,
+    resolveOtpFn: async () => {
+      throw useBrowser();
+    },
+  });
+
+  assert.equal(result.outcome, "owner-will-drive");
+  assert.notEqual(result.outcome, "otp-declined", "they did not refuse, they took it over");
+});
+
 test("a card the owner dismissed is reported as their answer, not as a fault", async () => {
   // The hosted host answers 409 when the owner closes the card. Arriving as a
   // bare HTTP error it read as "something broke", and the sensible response to

--- a/tests/test-escalation.mjs
+++ b/tests/test-escalation.mjs
@@ -119,6 +119,21 @@ test("qr-sign-in sends the owner to the browser view, because that is where the 
   assert.ok(!/Google, Microsoft/.test(message));
 });
 
+test("choosing the browser sends the agent to the browser", () => {
+  const { action, reason, message } = escalationFor("owner-will-drive", {
+    credName: "booking",
+    profile: "main",
+  });
+
+  assert.equal(action, OWNER_MUST_DRIVE, "the viewport is the answer to this");
+  assert.equal(reason, "owner_chose_the_browser");
+  assert.match(message, /browser view for profile 'main'/);
+  // The two ways a card can close must not read the same: one means leave it
+  // alone, the other means open the browser now.
+  assert.ok(!/do NOT run auto-login again/.test(message), message);
+  assert.match(message, /did not\s+refuse it/);
+});
+
 test("a dismissed card is an answer, and the agent is told not to ask again", () => {
   // Closing the card used to arrive as a bare `HTTP 409`, indistinguishable from
   // a fault — so the agent retried, and the owner who had just dismissed it got

--- a/tests/test-secure-prompt.mjs
+++ b/tests/test-secure-prompt.mjs
@@ -135,6 +135,34 @@ test("resolver: AGENT_ID_SECURE_PROMPT forces a backend (overriding availability
   );
 });
 
+test("hosted: a card closed through its button says which button", async () => {
+  // "Use the browser instead" is not a refusal — the owner still means to sign
+  // in, just not here. Arriving as a plain dismissal it reads as "they said no",
+  // and the sign-in is reported abandoned rather than handed over.
+  const { sock, server } = await startHostedSocket((_body, res) => {
+    const payload = JSON.stringify({ error: "cancelled", reason: "use_browser" });
+    res.writeHead(409, {
+      "Content-Type": "application/json",
+      "Content-Length": Buffer.byteLength(payload),
+    });
+    res.end(payload);
+  });
+  try {
+    const provider = resolveSecurePrompt({ env: { AGENT_ID_SECURE_PROMPT_SOCK: sock } });
+    const err = await provider.collect({ fields: [{ name: "otp" }], timeoutMs: 5000 }).then(
+      () => null,
+      (e) => e,
+    );
+
+    assert.ok(err, "a dismissal must not resolve as values");
+    assert.equal(err.code, "FORM_USE_BROWSER");
+    assert.notEqual(err.code, "FORM_CANCELLED", "the two must not be confused");
+    assert.match(err.message, /browser/i);
+  } finally {
+    server.close();
+  }
+});
+
 test("hosted: a card the owner dismissed is refused with a code, not a bare status", async () => {
   // The host answers 409 for a dismissal. Without a code of its own it reaches
   // the caller as `HTTP 409` — indistinguishable from a fault, and the sensible


### PR DESCRIPTION
> Stacked on #142 — review that one first; this PR's diff is the single commit on top.

## Why

Product asked for a button on the secure card: *use the browser to sign in instead*. It closes the card, but it is not a refusal — the owner wants the sign-in, they just want to do it themselves.

`auto-login` had one reading for a closed card: `otp-declined` → "they were asked and said no, say the sign-in was not completed and leave it there." Pressed on the new button, that is the wrong answer to give and the wrong thing to tell the owner.

## What

- `secure-prompt.mjs` reads the dismissal reason off the 409 and raises `FORM_USE_BROWSER` beside the existing `FORM_CANCELLED`.
- `auto-login.mjs` maps it to a new outcome, `owner-will-drive`, at both places a card can be dismissed.
- `escalation.mjs` turns that outcome into `OWNER_MUST_DRIVE` with an instruction that says what to do and, as plainly, what not to: do not raise another card, do not ask for the password, do not report the sign-in refused.

A card closed the old way still reads `otp-declined`. Nothing changes for a host that sends no reason.

## Verification

`npm test` — 927 tests, 0 fail. Every new assertion proved by breaking the code under it.

Run live against a local stand-in sign-in site, driving the real CLI through a card host that answers the way the patched hub does:

```
reason: "use_browser"  →  outcome owner-will-drive, action owner_must_drive
no reason              →  outcome otp-declined,     action owner_must_confirm
```

`ci:hygiene` clean.