### PR TITLE
fix(browser): ask the owner from the process that is actually asking

### DIFF
--- a/.changeset/a-code-that-reaches-the-owner.md
+++ b/.changeset/a-code-that-reaches-the-owner.md
@@ -1,0 +1,6 @@
+---
+"@alien-id/agent-id-browser": minor
+"@alien-id/agent-id-core": minor
+---
+
+Reach the owner from the daemon, and spread a code across every box that asks for one.

--- a/plugins/agent-id-browser/bin/cli.mjs
+++ b/plugins/agent-id-browser/bin/cli.mjs
@@ -1047,7 +1047,20 @@ runCli({
     // Must outlast the secure-prompt card this can raise (10 min): a shorter
     // budget kills the child while the owner is still fetching the code from
     // their mail, dropping a secret that was on its way back.
-    "fill-otp": actionCmd("fill-otp", (f) => ({ ref: f.ref, cred: f.cred, submit: f.submit !== false }), 11 * 60 * 1000),
+    "fill-otp": actionCmd(
+      "fill-otp",
+      // `--prompt-sock` travels to the daemon because the card is raised THERE,
+      // not in this process: this command forwards one line and exits, so the
+      // hosted-prompt environment the runtime gave it would otherwise be spent
+      // on a process that never asks anyone anything.
+      (f) => ({
+        ref: f.ref,
+        cred: f.cred,
+        submit: f.submit !== false,
+        promptSock: f["prompt-sock"] || undefined,
+      }),
+      11 * 60 * 1000
+    ),
     select: actionCmd("select", (f) => ({ ref: f.ref, values: csv(f.values) })),
     press: actionCmd("press", (f) => ({ key: f.key, ref: f.ref })),
     hover: actionCmd("hover", (f) => ({ ref: f.ref })),

--- a/plugins/agent-id-browser/lib/auto-login.mjs
+++ b/plugins/agent-id-browser/lib/auto-login.mjs
@@ -1317,6 +1317,17 @@ export async function autoLogin({
         // characters is a fact, "6-digit code" is copy that may describe the last
         // step rather than this one.
         const hints = await otpCardHints(page);
+        // What the card is about to be built from, and the page it was read off.
+        // The screen draws cells only for a length that was stated, so a card that
+        // arrives as a plain field has one of two histories — the row was not
+        // recognised, or this ran before the code screen existed — and the URL is
+        // what tells them apart. `fill_otp` has logged its hints since it was
+        // written; this path, which raises most of the cards, logged nothing.
+        log(
+          `auto-login: code hints length=${hints.length ?? "?"} destination=${
+            hints.destination ?? "?"
+          } at ${page.url()}`
+        );
         const code = await getOtp(retry, hints.destination, hints.length);
         await recordOtpModeCorrection();
         await typeOtp(page, code);

--- a/plugins/agent-id-browser/lib/auto-login.mjs
+++ b/plugins/agent-id-browser/lib/auto-login.mjs
@@ -50,7 +50,13 @@ import {
   codeLengthFromText,
   OTP_BODY_RE,
 } from "./login-detect.mjs";
-import { humanClick, humanDriver, humanType } from "./human-input.mjs";
+import {
+  humanClick,
+  humanDriver,
+  humanType,
+  typeCodeAcrossBoxes,
+} from "./human-input.mjs";
+import { markSecretBoxes } from "./secret-taint.mjs";
 
 // Type a secret (password / OTP) with human cadence, guarding against a
 // keyboard/fill error that could echo the value — auto-login errors propagate to
@@ -170,10 +176,20 @@ function stepCarriesSecret(step) {
 // `driver` maps the action vocabulary to page interactions; it defaults to the
 // human-input driver (curved motion, key-by-key typing) and is injectable so the
 // mapping/{otp}-lazy-resolution logic unit-tests without a browser.
+// The recipe vocabulary, plus the one verb `humanDriver` cannot carry: writing a
+// one-time code. A row of one-character boxes takes the code spread across it,
+// and only the caller knows a value IS a code — the selector does not say so, so
+// teaching `fill` to guess would reshape ordinary fills too. Kept here rather
+// than in `human-input` because recognising the row is this layer's job.
+export const recipeDriver = {
+  ...humanDriver,
+  fillCode: (page, selector, value) => typeCodeInto(page, selector, value),
+};
+
 export async function runRecipe(
   page,
   steps,
-  { username, password, getOtp, domains, driver = humanDriver }
+  { username, password, getOtp, domains, driver = recipeDriver }
 ) {
   if (!Array.isArray(domains)) {
     throw new Error("runRecipe requires the credential's `domains` allowlist");
@@ -188,6 +204,7 @@ export async function runRecipe(
   // value in an error. Run it under a value-free catch.
   const carriesSecret = (tpl) =>
     typeof tpl === "string" && (tpl.includes("{password}") || tpl.includes("{otp}"));
+  const carriesOtp = (tpl) => typeof tpl === "string" && tpl.includes("{otp}");
   const guarded = async (tpl, run) => {
     if (!carriesSecret(tpl)) return run();
     try {
@@ -230,7 +247,11 @@ export async function runRecipe(
         const selector = await sub(step.selector);
         const value = await sub(step.value);
         gateSecret(step, "recipe fill");
-        await guarded(step.value, () => driver.fill(page, selector, value));
+        await guarded(step.value, () =>
+          carriesOtp(step.value)
+            ? driver.fillCode(page, selector, value)
+            : driver.fill(page, selector, value)
+        );
         break;
       }
       case "type": {
@@ -239,7 +260,11 @@ export async function runRecipe(
         const selector = await sub(step.selector);
         const text = await sub(step.text);
         gateSecret(step, "recipe type");
-        await guarded(step.text, () => driver.type(page, selector, text));
+        await guarded(step.text, () =>
+          carriesOtp(step.text)
+            ? driver.fillCode(page, selector, text)
+            : driver.type(page, selector, text)
+        );
         break;
       }
       case "click": {
@@ -786,15 +811,38 @@ function describeState(s) {
 }
 
 // Best-effort fill of the OTP field, then submit.
+// Write a one-time code, whatever shape the screen takes it in. A row of
+// one-character boxes gets the code spread across it; anything else gets the
+// ordinary typed fill. Typing the whole code into the first box and trusting the
+// page to move the focus is what left Booking.com's six-box screen holding one
+// character — `fill_otp` has spread since the row predicate existed, and the two
+// paths auto-login drives, its own OTP step and a recipe's `{otp}`, did not.
+export async function typeCodeInto(page, selector, code) {
+  const boxes = await otpBoxes(page);
+  if (boxes.length === 0) {
+    // The OTP code is low-sensitivity (single-use, seconds-lived) but still typed
+    // with human cadence and the value-free error guard, for consistency.
+    await typeSecret(page, selector, code);
+    return;
+  }
+
+  // Tainted before the code goes in: every way out of the typing below — a throw,
+  // a partial fill, a row that submits itself — leaves characters in these boxes,
+  // and the tag is the only thing that stops them being read back one at a time
+  // through `get --what value`.
+  await markSecretBoxes(boxes);
+  await typeCodeAcrossBoxes(page, boxes, code);
+}
+
 async function typeOtp(page, code) {
   const sel =
     'input[autocomplete="one-time-code"], input[name*="otp" i], input[id*="otp" i], ' +
     'input[name*="code" i], input[id*="code" i], input[name*="verif" i], input[id*="verif" i], ' +
     'input[inputmode="numeric"]';
-  // The OTP code is low-sensitivity (single-use, seconds-lived) but still typed
-  // with human cadence and the value-free error guard, for consistency.
   const before = page.url();
-  await typeSecret(page, sel, code);
+
+  await typeCodeInto(page, sel, code);
+
   // Many code screens submit themselves the moment the last box is filled. Then
   // there is nothing left to click, and hunting for a button on the page we just
   // landed on costs a full element-wait per candidate.

--- a/plugins/agent-id-browser/lib/human-input.mjs
+++ b/plugins/agent-id-browser/lib/human-input.mjs
@@ -208,6 +208,11 @@ export async function humanType(
 // it, which is the one outcome that cannot be verified by reading the boxes back
 // — they are gone. Keeping the two apart is the point: a bare `true` made "the
 // row holds the code" and "something navigated" the same answer.
+// How long a row gets to take the page with it after the last character lands.
+// Short: this is a navigation the page has already started, not one we are
+// waiting to see whether it wants to start.
+const SELF_SUBMIT_SETTLE = 2000;
+
 export async function typeCodeAcrossBoxes(
   page,
   boxes,
@@ -221,6 +226,19 @@ export async function typeCodeAcrossBoxes(
 
   const startedAt = page.url();
   const navigated = () => page.url() !== startedAt;
+  // A row that submits itself does so from the LAST character we write, so the
+  // navigation is always in flight at the moment we would check for it —
+  // `page.url()` still reads the old URL while the document is already being
+  // torn down, and the boxes we then read back answer "". That reported a
+  // sign-in that had just succeeded as a code that never landed. Give the
+  // navigation the beat it needs before concluding anything from the row.
+  const settledNavigation = async () => {
+    if (navigated()) return true;
+    await page
+      .waitForURL((url) => String(url) !== startedAt, { timeout: SELF_SUBMIT_SETTLE })
+      .catch(() => {});
+    return navigated();
+  };
   const values = async () =>
     Promise.all(boxes.map((box) => box.inputValue().catch(() => "")));
   // Each box must hold the character at its own index. A total character count
@@ -252,7 +270,7 @@ export async function typeCodeAcrossBoxes(
     await box.fill(character).catch(() => {});
   }
 
-  if (navigated()) return afterSelfSubmit(page);
+  if (await settledNavigation()) return afterSelfSubmit(page);
 
   return { complete: holdsCode(await values()), submitted: false };
 }

--- a/plugins/agent-id-browser/lib/secret-taint.mjs
+++ b/plugins/agent-id-browser/lib/secret-taint.mjs
@@ -1,0 +1,41 @@
+// The taint every path that injects a secret into a page must leave behind, and
+// that every read-back path checks. It lives on its own because both sides need
+// it: the session server writes secrets through its tools, and auto-login writes
+// them through its own typing — and the session server already imports auto-login,
+// so anything auto-login needs cannot live there.
+
+// A field the vault typed a secret into is tagged with this attribute (see
+// markSecretField). It rides on the DOM element, not the ref — a re-snapshot
+// invalidates refs but only clears "data-aibref", so the taint survives across
+// snapshots as long as the site keeps the node. Kept in sync with the literal
+// hard-coded inside snapshotInPage (page functions can't close over module scope).
+export const SECRET_TAINT_ATTR = "data-aib-secret";
+
+// Tag the element a fill-secret/fill-otp just wrote to, so every later read-back
+// (get --what value, get --what attr value, and the snapshot el.value name
+// fallback) refuses it — REGARDLESS of the input's `type`. This is what closes
+// the leak for non-password fields: OTP/2FA inputs are type=text/tel, and a
+// show-password toggle flips a password field to type=text, so a type-only test
+// misses them. Best-effort: if the site has already swapped the node out there
+// is nothing (and no value) left to tag.
+export async function markSecretField(target, selector) {
+  await target
+    .$eval(selector, (el, attr) => el.setAttribute(attr, "1"), SECRET_TAINT_ATTR)
+    .catch(() => {});
+}
+
+// The same tag, for a code spread across a row of boxes. `markSecretField` names
+// one element through the ref's selector, and a row holds one character of the
+// code in each of its boxes — so tagging the ref alone leaves the rest readable
+// through `get --what value`. Every box written to is tainted, including after a
+// partial fill, because a partial fill is exactly when those characters are still
+// sitting there.
+export async function markSecretBoxes(boxes) {
+  await Promise.all(
+    boxes.map((box) =>
+      box
+        .evaluate((el, attr) => el.setAttribute(attr, "1"), SECRET_TAINT_ATTR)
+        .catch(() => {})
+    )
+  );
+}

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -61,6 +61,11 @@ import {
   typeCodeAcrossBoxes,
   humanTypeFocused,
 } from "./human-input.mjs";
+// Re-exported: the readback tests and any future writer reach them from here,
+// where the taint has always lived, while the definitions sit low enough for
+// auto-login to reach too.
+export { SECRET_TAINT_ATTR, markSecretField, markSecretBoxes } from "./secret-taint.mjs";
+import { SECRET_TAINT_ATTR, markSecretField, markSecretBoxes } from "./secret-taint.mjs";
 
 function sessionsDir(stateDir) {
   return path.join(stateDir, "browser-sessions");
@@ -677,40 +682,16 @@ function activateRefs(state, generation) {
   return generation;
 }
 
-// A field the vault typed a secret into is tagged with this attribute (see
-// markSecretField). It rides on the DOM element, not the ref — a re-snapshot
-// invalidates refs but only clears "data-aibref", so the taint survives across
-// snapshots as long as the site keeps the node. Kept in sync with the literal
-// hard-coded inside snapshotInPage (page functions can't close over module scope).
-export const SECRET_TAINT_ATTR = "data-aib-secret";
+// The hosted secure-prompt socket for ONE action, off the request rather than the
+// daemon's environment. A daemon that carried it in `process.env` could raise a
+// card at any moment for the rest of its life; taking it per call keeps the right
+// to interrupt the owner with the caller that was granted it. Absent, the
+// resolver's own chain decides — which is correct for a local run with no hub.
+function promptEnv(params, msg) {
+  const sock = String(params.promptSock || msg._promptSock || "");
+  if (!sock) return process.env;
 
-// Tag the element a fill-secret/fill-otp just wrote to, so every later read-back
-// (get --what value, get --what attr value, and the snapshot el.value name
-// fallback) refuses it — REGARDLESS of the input's `type`. This is what closes
-// the leak for non-password fields: OTP/2FA inputs are type=text/tel, and a
-// show-password toggle flips a password field to type=text, so a type-only test
-// misses them. Best-effort: if the site has already swapped the node out there
-// is nothing (and no value) left to tag.
-export async function markSecretField(target, selector) {
-  await target
-    .$eval(selector, (el, attr) => el.setAttribute(attr, "1"), SECRET_TAINT_ATTR)
-    .catch(() => {});
-}
-
-// The same tag, for a code spread across a row of boxes. `markSecretField` names
-// one element through the ref's selector, and a row holds one character of the
-// code in each of its boxes — so tagging the ref alone leaves the rest readable
-// through `get --what value`. Every box written to is tainted, including after a
-// partial fill, because a partial fill is exactly when those characters are still
-// sitting there.
-export async function markSecretBoxes(boxes) {
-  await Promise.all(
-    boxes.map((box) =>
-      box
-        .evaluate((el, attr) => el.setAttribute(attr, "1"), SECRET_TAINT_ATTR)
-        .catch(() => {})
-    )
-  );
+  return { ...process.env, AGENT_ID_SECURE_PROMPT_SOCK: sock, AGENT_ID_SECURE_PROMPT: "hosted" };
 }
 
 // `get --what value|attr value` must not read back a field that holds an injected
@@ -1528,7 +1509,14 @@ export async function dispatch(state, msg, policy = null) {
           const correction = otpModeCorrection(rec);
 
           try {
-            code = await resolveOtp(otpCred, hints);
+            // The hosted card channel is wired to the CLI CHILD that forwarded
+            // this action, not to us — the child only speaks one line of JSON and
+            // exits, while the card is raised here. Without the socket the
+            // resolver falls back to a loopback browser form inside this machine,
+            // which on a fleet host nobody can ever open. The caller passes the
+            // path per call rather than per daemon, so the daemon holds no
+            // standing right to raise cards.
+            code = await resolveOtp(otpCred, { ...hints, env: promptEnv(p, msg) });
           } catch (err) {
             // The owner closed the card. Nothing broke and nothing timed out, so
             // the one thing that must not happen is the same card going straight

--- a/plugins/agent-id-core/lib/secure-prompt.mjs
+++ b/plugins/agent-id-core/lib/secure-prompt.mjs
@@ -277,9 +277,28 @@ export function resolveSecurePrompt({
     if (!p.isAvailable || !p.isAvailable()) continue;
     const caps = (p.capabilities && p.capabilities()) || {};
     if (need.multiline && !caps.multiline) continue;
-    return p;
+    return announce(p, env);
   }
-  return browser; // guaranteed last resort (prints the URL when it can't open)
+  return announce(browser, env); // guaranteed last resort (prints the URL when it can't open)
+}
+
+// Which backend the owner's card is about to be asked through, and — when it is
+// not the hosted one — why not. Silence here cost a production week: a card that
+// never left the machine and a card the owner ignored produced exactly the same
+// logs, so the only visible symptom was a tool that waited and asked nobody.
+function announce(provider, env) {
+  const name = provider && provider.name ? provider.name : "unknown";
+  if (name !== "hosted") {
+    const sock = env.AGENT_ID_SECURE_PROMPT_SOCK;
+    const why = !sock
+      ? "AGENT_ID_SECURE_PROMPT_SOCK is not set"
+      : `no socket at ${sock}`;
+    process.stderr.write(
+      `secure prompt: asking through '${name}', NOT the owner's device — ${why}\n`
+    );
+  }
+
+  return provider;
 }
 
 /**

--- a/tests/test-auto-login.mjs
+++ b/tests/test-auto-login.mjs
@@ -65,6 +65,9 @@ function recordingDriver(calls) {
     navigate: async (_p, url) => calls.push(["goto", url]),
     fill: async (_p, sel, val) => calls.push(["fill", sel, val]),
     type: async (_p, sel, val) => calls.push(["type", sel, val]),
+    // Separate from `fill` on purpose: a code goes to the row-aware verb, and a
+    // recipe that sent it through the ordinary one is the Booking.com failure.
+    fillCode: async (_p, sel, val) => calls.push(["fillCode", sel, val]),
     click: async (_p, sel) => calls.push(["click", sel]),
     press: async (_p, sel, key) => calls.push(["press", sel, key]),
     wait: async (_p, ms) => calls.push(["wait", ms]),
@@ -98,7 +101,7 @@ test("runRecipe maps steps to driver calls, substitutes vars, resolves {otp} onc
     ["fill", "#user", "alice"],
     ["fill", "#pass", "s3cret"],
     ["click", "#submit"],
-    ["fill", "#otp", "654321"],
+    ["fillCode", "#otp", "654321"],
     ["press", "#otp", "Enter"],
   ]);
   assert.equal(otpCalls, 1);
@@ -577,7 +580,7 @@ test("a wildcard covering the whole sign-in flow lets the hop through", async ()
     domains: ["*.example.com"],
     driver: recordingDriver(calls),
   });
-  assert.deepEqual(calls, [["fill", "#code", "654321"]]);
+  assert.deepEqual(calls, [["fillCode", "#code", "654321"]]);
 });
 
 test("the code-screen submit vocabulary never matches a control that discards the code", () => {
@@ -648,7 +651,7 @@ test("a step whose origin stays put is unaffected by the second check", async ()
       driver: recordingDriver(calls),
     }
   );
-  assert.deepEqual(calls, [["fill", "#code", "654321"]]);
+  assert.deepEqual(calls, [["fillCode", "#code", "654321"]]);
 });
 
 // ─── retrying a generated code only means something across a window ───────────────

--- a/tests/test-passwordless-live.mjs
+++ b/tests/test-passwordless-live.mjs
@@ -54,7 +54,7 @@ const CODE_BOXES = Array.from(
 // `submit` picks how the code screen accepts the code — the three ways real
 // services do it. "auto" fires on the last box, "button" needs a Verify click,
 // "enter" is a single wide field that submits implicitly.
-function fixtureServer({ submit = "button", acceptCode = true } = {}) {
+function fixtureServer({ submit = "button", acceptCode = true, stubborn = false } = {}) {
   const server = http.createServer((req, res) => {
     const url = new URL(req.url, "http://127.0.0.1");
     res.setHeader("content-type", "text/html; charset=utf-8");
@@ -75,7 +75,7 @@ function fixtureServer({ submit = "button", acceptCode = true } = {}) {
   const read = () => boxes.length ? boxes.map(b => b.value).join('') : document.getElementById('code').value;
   const go = () => { location.href = '/done?code=' + read(); };
   boxes.forEach((b, i) => b.addEventListener('input', () => {
-    if (b.value && boxes[i + 1]) boxes[i + 1].focus();
+    ${stubborn ? "" : "if (b.value && boxes[i + 1]) boxes[i + 1].focus();"}
     ${submit === "auto" ? "if (read().length === 6) go();" : ""}
   }));
   const btn = document.getElementById('go');
@@ -137,6 +137,29 @@ function fixtureServer({ submit = "button", acceptCode = true } = {}) {
         { length: 6 },
         (_, i) => `<input name=d${i} type=text inputmode=numeric maxlength=1>`
       ).join("")}</form>`);
+      return;
+    }
+    if (url.pathname === "/otp-boxes-stubborn-self-submitting") {
+      // Booking.com's shape, and the one that has neither of the two properties
+      // the other fixtures rely on: the row will not move the focus, AND it
+      // navigates the moment the last box is filled. The navigation therefore
+      // starts from OUR last write, so anything that reads `page.url()` or the
+      // boxes straight after sees the old URL and an emptying document — a
+      // sign-in that just succeeded, reported as a code that never landed.
+      res.end(`<!doctype html><meta charset=utf-8><title>code</title>
+<h1>Enter the code we sent you</h1>
+<form>${Array.from(
+        { length: 6 },
+        (_, i) => `<input name=d${i} type=text inputmode=numeric maxlength=1>`
+      ).join("")}</form>
+<script>
+ var boxes = Array.from(document.querySelectorAll("input"));
+ boxes.forEach(function (box) {
+   box.addEventListener("input", function () {
+     if (boxes.every(function (b) { return b.value; })) location.href = "/done";
+   });
+ });
+</script>`);
       return;
     }
     if (url.pathname === "/otp-declared-twice") {
@@ -390,6 +413,50 @@ for (const submit of ["button", "auto", "enter"]) {
         // for a reason that has nothing to do with what it is testing. Exact-code
         // equality is covered by the injectable-`now` test in test-auto-login.mjs.
         assert.match(result.finalUrl, /code=\d{6}$/);
+      } finally {
+        server.close();
+      }
+    }
+  );
+}
+
+// The shape auto-login had never been driven against, and the one Booking.com
+// draws: a row that will not move the focus. The cooperative fixtures above pass
+// on key-by-key typing alone, because the page distributes the characters for us
+// — so for as long as auto-login typed the whole code into the first box, every
+// end-to-end test here still went green while a live sign-in delivered one digit.
+for (const submit of ["button", "auto"]) {
+  test(
+    `a sign-in ends in a row that will not move the focus (submits by: ${submit})`,
+    { skip },
+    async () => {
+      const { server, port } = await fixtureServer({ submit, stubborn: true });
+      try {
+        const result = await withBrowser(async (context) => {
+          const page = await context.newPage();
+          return autoLogin({
+            page,
+            cred: {
+              name: "fixture",
+              type: "login",
+              username: IDENTIFIER,
+              passwordless: true,
+              otp: "totp",
+              totpSecret: SEED,
+              loginUrl: `http://127.0.0.1:${port}/`,
+              domains: ["127.0.0.1"],
+              warmup: false,
+            },
+            settleMs: 400,
+          });
+        });
+
+        assert.equal(result.ok, true, `auto-login failed: ${result.outcome}`);
+        assert.match(
+          result.finalUrl,
+          /code=\d{6}$/,
+          "six digits reached the site, so every box took its own character"
+        );
       } finally {
         server.close();
       }
@@ -967,6 +1034,37 @@ test(
           ["4", "2", "3", "1", "2", "4"],
           `no digit of the refused code survives: got ${values.join("|")}`
         );
+      });
+    } finally {
+      server.close();
+    }
+  }
+);
+
+test(
+  "a row that will not move the focus AND submits itself is a success, not a failure",
+  { skip },
+  async () => {
+    const { server, port } = await fixtureServer();
+    try {
+      await withBrowser(async (context) => {
+        const page = await context.newPage();
+        await page.goto(
+          `http://127.0.0.1:${port}/otp-boxes-stubborn-self-submitting`,
+          { waitUntil: "domcontentloaded" }
+        );
+
+        const boxes = await otpBoxes(page);
+        assert.equal(boxes.length, 6, "the row is recognised");
+
+        const typed = await typeCodeAcrossBoxes(page, boxes, "423124");
+
+        assert.deepEqual(
+          typed,
+          { complete: true, submitted: true },
+          "the row took the page with it, which is the code landing — not failing to land"
+        );
+        assert.match(page.url(), /\/done$/, "the sign-in actually went through");
       });
     } finally {
       server.close();


### PR DESCRIPTION
Pairs with alien-id/lethe#305 — neither half works alone.

Four faults in one sign-in, all found by driving the deployed build rather than reading it.

## The card had nowhere to come from

`fill-otp` is an `actionCmd`: it forwards one line to the browser daemon and exits. **The card is raised in the daemon**, and the daemon is spawned without the hosted socket — so `resolveSecurePrompt` fell through to the loopback browser form, started an HTTP server inside the machine, wrote *"Open this URL in a browser…"* to a log nobody reads, and blocked for ten minutes.

`auto_login` worked throughout because it is not an `actionCmd` — it runs the engine in the child that the socket was given to. That is exactly why one conversation showed cards for auto-login attempts and none for the hand-driven one.

The socket now arrives with the action (`--prompt-sock` → `promptSock`) and is used for that call only. A daemon that carried it in `process.env` could raise a card at any moment for the rest of its life.

## A code went into one box

`otpBoxes` and `typeCodeAcrossBoxes` existed, were correct, and only `fill-otp` used them. Auto-login's own OTP step and a recipe's `{otp}` both went through `humanType`, which clicks the **first** match and types the whole code there — fine on a row that advances its own focus, one character on Booking.com's, which does not.

Both now go through `typeCodeInto`. It also taints every box it writes: `markSecretBoxes` was never called from auto-login, so a code it typed stayed readable through `get --what value` — the leak that was closed for `fill-otp` alone.

The recipe path gets a verb of its own, `fillCode`, rather than teaching `fill` to guess: only the caller knows a value is a code.

## A sign-in that worked was reported as failed

A stubborn row submits itself from the last character **we** write, so the navigation is in flight exactly when the row is read back — `page.url()` still says the old URL and the emptying boxes answer `""`. That is `complete: false` on a code the site had just accepted, and the model then retries a sign-in that already happened.

## None of it was visible

`resolveSecurePrompt` said nothing about which backend it chose, so a card that never left the machine and a card the owner ignored produced identical logs. It now says which, and why hosted was skipped.

## Tests

- `a sign-in ends in a row that will not move the focus` (×2 submit styles) — drives **`autoLogin`** against a stubborn row. The existing end-to-end fixtures all advance the focus themselves, which is why every one of them stayed green while a live sign-in delivered one digit.
- `a row that will not move the focus AND submits itself is a success, not a failure` — the Booking shape, on a new fixture.
- the recipe unit tests now assert `fillCode`, which is the visible proof the path changed.

`npm test` — 930 tests, 0 fail; `ci:hygiene` clean. Every new assertion proved by breaking the code under it.

The taint primitives move to `secret-taint.mjs`: `session-server` already imports `auto-login`, so anything auto-login needs cannot live in `session-server`.