### PR TITLE
fix(vault): say how a card ended, not just that it did

### DIFF
--- a/.changeset/a-card-that-says-which-ending.md
+++ b/.changeset/a-card-that-says-which-ending.md
@@ -1,0 +1,6 @@
+---
+"@alien-id/agent-id-browser": patch
+"@alien-id/agent-id-vault": patch
+---
+
+Name all three endings a code card can have, not one of them, and say plainly when a browser cannot finish the job it was handed.

--- a/.changeset/a-card-the-owner-can-hand-over.md
+++ b/.changeset/a-card-the-owner-can-hand-over.md
@@ -1,0 +1,6 @@
+---
+"@alien-id/agent-id-browser": minor
+"@alien-id/agent-id-vault": minor
+---
+
+Tell a card the owner ended from a card that broke, and say which ending it was.

--- a/.changeset/the-code-goes-where-the-caller-pointed.md
+++ b/.changeset/the-code-goes-where-the-caller-pointed.md
@@ -1,0 +1,6 @@
+---
+"@alien-id/agent-id-browser": minor
+"@alien-id/agent-id-core": minor
+---
+
+Send a one-time code where the caller's selector points rather than into whichever row the predicate found first, tag every field auto-login types a secret into against read-back (passwords included), and say which backend a card is going through on every path, the operator override included.

--- a/plugins/agent-id-browser/lib/auto-login.mjs
+++ b/plugins/agent-id-browser/lib/auto-login.mjs
@@ -48,26 +48,43 @@ import {
   classifyLogin,
   codeDestination,
   codeLengthFromText,
+  maskDestination,
   OTP_BODY_RE,
 } from "./login-detect.mjs";
 import {
+  firstVisible,
   humanClick,
   humanDriver,
   humanType,
   typeCodeAcrossBoxes,
 } from "./human-input.mjs";
-import { markSecretBoxes } from "./secret-taint.mjs";
+import { markSecretBoxes, markSecretLocator } from "./secret-taint.mjs";
 
 // Type a secret (password / OTP) with human cadence, guarding against a
 // keyboard/fill error that could echo the value — auto-login errors propagate to
 // the agent, so the raw error must never carry the secret. Mirrors the
 // session-server fill-secret guard.
+//
+// The taint belongs here rather than at the call sites because this function IS
+// the definition of "auto-login typed a secret into this field": the code screen's
+// single field, the Entra/ADFS password, the heuristic password. `fill-secret` and
+// `fill-otp` have tagged their fields since the read-back guard existed; every
+// field auto-login typed stayed readable through `get --what value`, passwords
+// included.
+//
+// Tagged through the same `firstVisible` the typing resolved through, not through
+// the selector again: where a site renders a hidden copy of the form first, those
+// two name different elements, and the one left readable would be the filled one.
 async function typeSecret(page, selector, value, opts = {}) {
+  const { root = page, timeout = 15000 } = opts;
+
   try {
     await humanType(page, selector, value, opts);
   } catch {
     throw new Error(`could not type into "${selector}" — element not visible/editable`);
   }
+
+  await markSecretLocator(await firstVisible(root, selector, timeout));
 }
 
 const PLACEHOLDER_FIELDS = ["url", "value", "text", "selector", "key"];
@@ -183,7 +200,7 @@ function stepCarriesSecret(step) {
 // than in `human-input` because recognising the row is this layer's job.
 export const recipeDriver = {
   ...humanDriver,
-  fillCode: (page, selector, value) => typeCodeInto(page, selector, value),
+  fillCode: typeCodeInto,
 };
 
 export async function runRecipe(
@@ -204,7 +221,11 @@ export async function runRecipe(
   // value in an error. Run it under a value-free catch.
   const carriesSecret = (tpl) =>
     typeof tpl === "string" && (tpl.includes("{password}") || tpl.includes("{otp}"));
-  const carriesOtp = (tpl) => typeof tpl === "string" && tpl.includes("{otp}");
+  // The WHOLE value, not a value containing one. `fillCode` spreads what it is
+  // given one character per box, so a template like "code: {otp}" routed here
+  // would put "c", "o", "d"… across the row. A code embedded in a longer string
+  // is not a code screen's row; it goes through the ordinary verbs.
+  const carriesOtp = (tpl) => typeof tpl === "string" && tpl.trim() === "{otp}";
   const guarded = async (tpl, run) => {
     if (!carriesSecret(tpl)) return run();
     try {
@@ -661,6 +682,41 @@ export async function otpBoxes(target) {
   return Array.from({ length: count }, (_, index) => all.nth(index));
 }
 
+// The row a CALLER'S selector is asking about, which is not always the row on the
+// page. `otpBoxes` searches the whole document and takes the first group that
+// looks like a code row — right for a heuristic selector, wrong for an explicit
+// one: a recipe naming `#email-code` beside an SMS row, or a `fill_otp` whose ref
+// points at the second of two code fields, would have its instruction silently
+// replaced by whatever the predicate found first.
+//
+// Three answers, because the selector is not always an instruction:
+//   in the row  → the row (the caller and the predicate agree)
+//   elsewhere   → no row (the caller named something else, and meant it)
+//   no match    → the row (a heuristic net that catches nothing cannot outvote it)
+//
+// The last case is what keeps `typeOtp` working: its selector is a wide net that
+// does not cover a row of bare `<input type=text maxlength=1>`, and reading a
+// no-match as "the caller meant elsewhere" would strand exactly the shape this
+// whole path exists for. `$$eval` and not `$eval` for the same reason — a wide
+// net matches many elements, and any one of them landing in the row is agreement.
+export async function otpBoxesFor(target, selector) {
+  const boxes = await otpBoxes(target);
+  if (boxes.length === 0) return [];
+
+  const fit = await target
+    .$$eval(
+      selector,
+      (elements, attr) => {
+        if (elements.length === 0) return "no-match";
+        return elements.some((el) => el.hasAttribute(attr)) ? "in-row" : "elsewhere";
+      },
+      OTP_ROW_ATTR
+    )
+    .catch(() => "no-match");
+
+  return fit === "elsewhere" ? [] : boxes;
+}
+
 export async function otpCardHints(target) {
   // Only an exact count. A row of boxes is one — there are as many as the code
   // has characters. A single field's maxlength is NOT: it says "no more than",
@@ -818,12 +874,16 @@ function describeState(s) {
 // character — `fill_otp` has spread since the row predicate existed, and the two
 // paths auto-login drives, its own OTP step and a recipe's `{otp}`, did not.
 export async function typeCodeInto(page, selector, code) {
-  const boxes = await otpBoxes(page);
+  // A second row detection, after the one `otpCardHints` ran to build the card.
+  // Deliberate: minutes pass between them while the owner reads their mail, and
+  // a row carried over from before that wait describes a page that may already
+  // have re-rendered. The saving would be one `evaluate`; the cost would be
+  // typing into locators that no longer point anywhere.
+  const boxes = await otpBoxesFor(page, selector);
   if (boxes.length === 0) {
     // The OTP code is low-sensitivity (single-use, seconds-lived) but still typed
     // with human cadence and the value-free error guard, for consistency.
-    await typeSecret(page, selector, code);
-    return;
+    return typeSecret(page, selector, code);
   }
 
   // Tainted before the code goes in: every way out of the typing below — a throw,
@@ -831,7 +891,8 @@ export async function typeCodeInto(page, selector, code) {
   // and the tag is the only thing that stops them being read back one at a time
   // through `get --what value`.
   await markSecretBoxes(boxes);
-  await typeCodeAcrossBoxes(page, boxes, code);
+
+  return typeCodeAcrossBoxes(page, boxes, code);
 }
 
 async function typeOtp(page, code) {
@@ -1325,7 +1386,7 @@ export async function autoLogin({
         // written; this path, which raises most of the cards, logged nothing.
         log(
           `auto-login: code hints length=${hints.length ?? "?"} destination=${
-            hints.destination ?? "?"
+            maskDestination(hints.destination) ?? "?"
           } at ${page.url()}`
         );
         const code = await getOtp(retry, hints.destination, hints.length);

--- a/plugins/agent-id-browser/lib/human-input.mjs
+++ b/plugins/agent-id-browser/lib/human-input.mjs
@@ -109,7 +109,7 @@ export async function humanMove(page, x, y, { rng = Math.random } = {}) {
 // which is exactly how an auto-login silently fails to fill anything. Poll for a
 // visible match; fall back to `.first()` if none turns up so `locate`'s own
 // waitFor still yields a normal "not visible" timeout. `root` is a Page OR Frame.
-async function firstVisible(root, selector, timeout) {
+export async function firstVisible(root, selector, timeout) {
   // An already-narrowed Locator passes through. A caller that walked the DOM
   // itself — picking a button by its visible label, say — should not have to
   // invent a selector string to get human-shaped input, and inventing one is how

--- a/plugins/agent-id-browser/lib/login-detect.mjs
+++ b/plugins/agent-id-browser/lib/login-detect.mjs
@@ -301,4 +301,23 @@ export function codeDestination(bodyText) {
   return `${(article || "your").toLowerCase()} ${kind.toLowerCase()} ending in ${tail}`;
 }
 
+// The destination for a LOG line. `codeDestination` returns what the page said,
+// and a page is free to say it in full — the owner's whole e-mail address or
+// phone number. That belongs on the card, which is being shown to the owner
+// anyway, and not in a log that outlives the sign-in. Sites that already
+// masked it ("your email ending in 42") pass through: there is nothing left to
+// hide, and cutting them further would destroy the only useful part.
+export function maskDestination(destination) {
+  const value = String(destination || "").trim();
+  if (!value) return null;
+
+  const email = /^([^\s@]+)@([^\s@]+)$/.exec(value);
+  if (email) return `${email[1].slice(0, 1)}***@${email[2]}`;
+
+  const digits = value.replace(/\D/g, "");
+  if (digits.length >= 5) return `***${digits.slice(-4)}`;
+
+  return value;
+}
+
 export { OTP_FIELD_RE, OTP_BODY_RE, CONFIRM_BODY_RE, MAGIC_LINK_RE, QR_SIGN_IN_RE, ERROR_RE, BLOCK_RE };

--- a/plugins/agent-id-browser/lib/secret-taint.mjs
+++ b/plugins/agent-id-browser/lib/secret-taint.mjs
@@ -24,6 +24,17 @@ export async function markSecretField(target, selector) {
     .catch(() => {});
 }
 
+// The same tag on an element a caller has ALREADY resolved. Preferred over
+// `markSecretField` wherever the writer resolved its own target: a site may render
+// a hidden duplicate of a field before the visible one (see `firstVisible`), and
+// then the selector's first match and the field the value went into are two
+// different elements — tagging by selector would leave the filled one readable.
+export async function markSecretLocator(locator) {
+  await locator
+    .evaluate((el, attr) => el.setAttribute(attr, "1"), SECRET_TAINT_ATTR)
+    .catch(() => {});
+}
+
 // The same tag, for a code spread across a row of boxes. `markSecretField` names
 // one element through the ref's selector, and a row holds one character of the
 // code in each of its boxes — so tagging the ref alone leaves the rest readable
@@ -31,11 +42,5 @@ export async function markSecretField(target, selector) {
 // partial fill, because a partial fill is exactly when those characters are still
 // sitting there.
 export async function markSecretBoxes(boxes) {
-  await Promise.all(
-    boxes.map((box) =>
-      box
-        .evaluate((el, attr) => el.setAttribute(attr, "1"), SECRET_TAINT_ATTR)
-        .catch(() => {})
-    )
-  );
+  await Promise.all(boxes.map(markSecretLocator));
 }

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -39,8 +39,9 @@ import {
   SECRET_FIELDS,
   assertHostAllowed,
 } from "@alien-id/agent-id-vault/lib/store.mjs";
+import { maskDestination } from "./login-detect.mjs";
 import {
-  otpBoxes,
+  otpBoxesFor,
   otpCardHints,
   otpModeCorrection,
   resolveOtp,
@@ -64,7 +65,7 @@ import {
 // Re-exported: the readback tests and any future writer reach them from here,
 // where the taint has always lived, while the definitions sit low enough for
 // auto-login to reach too.
-export { SECRET_TAINT_ATTR, markSecretField, markSecretBoxes } from "./secret-taint.mjs";
+export * from "./secret-taint.mjs";
 import { SECRET_TAINT_ATTR, markSecretField, markSecretBoxes } from "./secret-taint.mjs";
 
 function sessionsDir(stateDir) {
@@ -698,8 +699,12 @@ export function errorReply(err) {
 // card at any moment for the rest of its life; taking it per call keeps the right
 // to interrupt the owner with the caller that was granted it. Absent, the
 // resolver's own chain decides — which is correct for a local run with no hub.
-function promptEnv(params, msg) {
-  const sock = String(params.promptSock || msg._promptSock || "");
+// It arrives in `params`, which is the caller speaking, not in an `_`-prefixed
+// field, which by convention here is the server injecting a fact of its own
+// (`msg._stateDir`). The session token is the trust boundary that makes that
+// acceptable: whoever can send this action can already drive the browser.
+function promptEnv(params) {
+  const sock = String(params.promptSock || "");
   if (!sock) return process.env;
 
   return { ...process.env, AGENT_ID_SECURE_PROMPT_SOCK: sock, AGENT_ID_SECURE_PROMPT: "hosted" };
@@ -1510,7 +1515,7 @@ export async function dispatch(state, msg, policy = null) {
           process.stderr.write(`fill-otp: row shape ${shape}\n`);
           process.stderr.write(
             `fill-otp: code hints length=${hints.length ?? "?"} destination=${
-              hints.destination ?? "?"
+              maskDestination(hints.destination) ?? "?"
             }\n`
           );
           // Reaching this line means a code is being asked for, which settles what
@@ -1527,7 +1532,7 @@ export async function dispatch(state, msg, policy = null) {
             // which on a fleet host nobody can ever open. The caller passes the
             // path per call rather than per daemon, so the daemon holds no
             // standing right to raise cards.
-            code = await resolveOtp(otpCred, { ...hints, env: promptEnv(p, msg) });
+            code = await resolveOtp(otpCred, { ...hints, env: promptEnv(p) });
           } catch (err) {
             // The owner closed the card. Nothing broke and nothing timed out, so
             // the one thing that must not happen is the same card going straight
@@ -1590,7 +1595,9 @@ export async function dispatch(state, msg, policy = null) {
           // A row of boxes needs the code spread across it, and the ref names only
           // the first one. Typing into that one and trusting the page to advance
           // the focus is what leaves the row half-entered and the submit dead.
-          const boxes = await otpBoxes(target);
+          // Anchored on the ref, because a page can hold two code fields (an
+          // e-mail one and an SMS one) and the ref is the caller saying which.
+          const boxes = await otpBoxesFor(target, sel(p.ref));
           if (boxes.length > 0) {
             // Tainted before the code goes in, not after: every path out of the
             // typing below — a throw mid-row, a partial fill, a row that submits

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -691,8 +691,36 @@ function activateRefs(state, generation) {
 export function errorReply(err) {
   const detail = err && typeof err.detail === "object" && err.detail ? err.detail : {};
 
-  return { ok: false, error: (err && err.message) || String(err), ...detail };
+  // Detail first: it adds fields, it does not get to rewrite the two that say
+  // this is a failure. A thrower carrying `ok` in its detail would otherwise
+  // turn its own error into a success, and this is now the one funnel every
+  // failure leaves the daemon through.
+  return { ...detail, ok: false, error: (err && err.message) || String(err) };
 }
+
+// How the OWNER ended the card, as fields the caller can match on rather than a
+// sentence it has to parse. None of the three is a fault, and a model reads a
+// fault as something to retry — which on this path means the same card going
+// straight back up. Only the browser ending carries an `action`, because it is
+// the only one where something else should happen instead.
+export const CARD_ENDINGS = {
+  FORM_USE_BROWSER: {
+    message: "fill-otp: the owner closed the code card and asked to sign in from the browser.",
+    detail: { action: "owner_must_drive", reason: "owner_chose_the_browser" },
+  },
+  FORM_CANCELLED: {
+    message:
+      "fill-otp: the owner dismissed the code card — they were asked and said no. " +
+      "Do not raise it again unless they ask for it.",
+    detail: { reason: "owner_dismissed_the_card" },
+  },
+  FORM_TIMEOUT: {
+    message:
+      "fill-otp: the code card expired before the owner answered. " +
+      "Ask them to be ready, then run this again.",
+    detail: { reason: "card_timed_out" },
+  },
+};
 
 // The hosted secure-prompt socket for ONE action, off the request rather than the
 // daemon's environment. A daemon that carried it in `process.env` could raise a
@@ -1534,33 +1562,17 @@ export async function dispatch(state, msg, policy = null) {
             // standing right to raise cards.
             code = await resolveOtp(otpCred, { ...hints, env: promptEnv(p) });
           } catch (err) {
-            // The owner closed the card. Nothing broke and nothing timed out, so
-            // the one thing that must not happen is the same card going straight
-            // back up — which is what a bare fault invites, because the sensible
-            // reply to a fault is a retry.
-            if (err?.code === "FORM_CANCELLED") {
-              throw new Error(
-                "fill-otp: the owner dismissed the code card — they were asked and said no. " +
-                  "Do not raise it again unless they ask for it."
-              );
-            }
-            // Not a refusal: they want the sign-in, they just want to finish it
-            // themselves. The caller hands the browser over on this pair, so it
-            // travels as fields rather than prose — the socket reply is all it
-            // sees, and a sentence is not something it can match on.
-            if (err?.code === "FORM_USE_BROWSER") {
-              const handover = new Error(
-                "fill-otp: the owner closed the code card and asked to sign in from the browser."
-              );
-              handover.detail = {
-                action: "owner_must_drive",
-                reason: "owner_chose_the_browser",
-                profile: state.name,
-                url: page.url(),
-              };
-              throw handover;
-            }
-            throw err;
+            const ending = CARD_ENDINGS[err?.code];
+            if (!ending) throw err;
+
+            const ended = new Error(ending.message);
+            ended.detail = {
+              ...ending.detail,
+              retryable: false,
+              profile: state.name,
+              url: page.url(),
+            };
+            throw ended;
           }
 
           // Written only now, and only if the owner answered. `fill_otp` inspects

--- a/plugins/agent-id-browser/lib/session-server.mjs
+++ b/plugins/agent-id-browser/lib/session-server.mjs
@@ -682,6 +682,17 @@ function activateRefs(state, generation) {
   return generation;
 }
 
+// A failure the caller can act on rather than only read. An action that ends
+// because the OWNER chose something — closed the card, asked for the browser —
+// is not the same fault as a page that would not load, and the difference has to
+// survive the socket: this reply is all the caller sees, and a flattened message left
+// it guessing from prose. Anything a thrower puts on `err.detail` rides along.
+export function errorReply(err) {
+  const detail = err && typeof err.detail === "object" && err.detail ? err.detail : {};
+
+  return { ok: false, error: (err && err.message) || String(err), ...detail };
+}
+
 // The hosted secure-prompt socket for ONE action, off the request rather than the
 // daemon's environment. A daemon that carried it in `process.env` could raise a
 // card at any moment for the rest of its life; taking it per call keeps the right
@@ -1528,6 +1539,22 @@ export async function dispatch(state, msg, policy = null) {
                   "Do not raise it again unless they ask for it."
               );
             }
+            // Not a refusal: they want the sign-in, they just want to finish it
+            // themselves. The caller hands the browser over on this pair, so it
+            // travels as fields rather than prose — the socket reply is all it
+            // sees, and a sentence is not something it can match on.
+            if (err?.code === "FORM_USE_BROWSER") {
+              const handover = new Error(
+                "fill-otp: the owner closed the code card and asked to sign in from the browser."
+              );
+              handover.detail = {
+                action: "owner_must_drive",
+                reason: "owner_chose_the_browser",
+                profile: state.name,
+                url: page.url(),
+              };
+              throw handover;
+            }
             throw err;
           }
 
@@ -2104,6 +2131,10 @@ export async function runSession({
   const state = {
     ctx,
     stateDir,
+    // The session this daemon IS. An action that hands the browser back to the
+    // owner has to name the session they are being handed, and only the daemon
+    // knows it — the caller's `--name` reached the client that forwarded here.
+    name,
     current: page,
     frames: new Map(),
     refsValid: false,
@@ -2238,7 +2269,7 @@ export async function runSession({
         const result = await dispatch(state, msg, policy);
         sock.end(JSON.stringify({ ok: true, ...result }) + "\n");
       } catch (err) {
-        sock.end(JSON.stringify({ ok: false, error: err.message || String(err) }) + "\n");
+        sock.end(JSON.stringify(errorReply(err)) + "\n");
       }
     });
     sock.on("error", () => {});

--- a/plugins/agent-id-core/lib/secure-prompt.mjs
+++ b/plugins/agent-id-core/lib/secure-prompt.mjs
@@ -262,10 +262,10 @@ export function resolveSecurePrompt({
   const forced = env.AGENT_ID_SECURE_PROMPT;
   if (forced) {
     const extra = extraProviders.find((p) => p && p.name === forced);
-    if (extra) return extra;
-    if (forced === "browser") return browser;
-    if (forced === "tty") return new TtyProvider();
-    if (forced === "hosted") return new HostedHarnessProvider({ env });
+    if (extra) return announce(extra, env, forced);
+    if (forced === "browser") return announce(browser, env, forced);
+    if (forced === "tty") return announce(new TtyProvider(), env, forced);
+    if (forced === "hosted") return announce(new HostedHarnessProvider({ env }), env, forced);
   }
   const chain = [
     new HostedHarnessProvider({ env }),
@@ -286,17 +286,40 @@ export function resolveSecurePrompt({
 // not the hosted one — why not. Silence here cost a production week: a card that
 // never left the machine and a card the owner ignored produced exactly the same
 // logs, so the only visible symptom was a tool that waited and asked nobody.
-function announce(provider, env) {
+//
+// Every return goes through here, the operator override included. That branch is
+// not the rare one: the runtime sets AGENT_ID_SECURE_PROMPT=hosted on every child
+// it spawns, so a version of this that only spoke for the ordinary chain would be
+// silent on the exact path it was written for. The hosted line is worth its space
+// too — "the card went to the device" is otherwise unprovable from the logs.
+function announce(provider, env, forced = null) {
   const name = provider && provider.name ? provider.name : "unknown";
-  if (name !== "hosted") {
-    const sock = env.AGENT_ID_SECURE_PROMPT_SOCK;
-    const why = !sock
+  const sock = env.AGENT_ID_SECURE_PROMPT_SOCK;
+  const available = provider && provider.isAvailable ? provider.isAvailable() : true;
+
+  if (name === "hosted") {
+    // The override skips the availability check on purpose — it is documented as
+    // forcing a backend "regardless of the usual ordering". Say what that is
+    // about to cost, because `collect()` will only reject with a generic line.
+    if (!available) {
+      process.stderr.write(
+        `secure prompt: forced to 'hosted' with no usable socket (${sock || "unset"}) — this will fail\n`
+      );
+    } else {
+      process.stderr.write("secure prompt: asking the owner's device through 'hosted'\n");
+    }
+
+    return provider;
+  }
+
+  const why = forced
+    ? `forced by AGENT_ID_SECURE_PROMPT=${forced}`
+    : !sock
       ? "AGENT_ID_SECURE_PROMPT_SOCK is not set"
       : `no socket at ${sock}`;
-    process.stderr.write(
-      `secure prompt: asking through '${name}', NOT the owner's device — ${why}\n`
-    );
-  }
+  process.stderr.write(
+    `secure prompt: asking through '${name}', NOT the owner's device — ${why}\n`
+  );
 
   return provider;
 }

--- a/plugins/agent-id-vault/bin/cli.mjs
+++ b/plugins/agent-id-vault/bin/cli.mjs
@@ -786,12 +786,22 @@ async function cmdSetTotp(flags) {
       });
       seedInput = out.values.seed;
     } catch (err) {
-      // No `action` even for `use_browser`: a seed lives behind the site's own
-      // 2FA settings, and a browser view can show it to the owner but cannot put
-      // it in the vault. Handing one over would land them back on this card.
       const ended = ownerEndedTheCard(err, { name });
       if (ended) {
-        outputJson({ ok: false, stored: false, ...ended, action: undefined });
+        // A seed lives behind the site's own 2FA settings: a browser view can
+        // show it to the owner but cannot put it in the vault, so handing one
+        // over would land them back on this card. Dropping the `action` stops
+        // the caller acting — but the model can open a viewport itself, and the
+        // stock wording invites exactly that. So the message has to say it.
+        if (ended.error === "FORM_USE_BROWSER") {
+          delete ended.action;
+          ended.message =
+            "The owner closed the card and asked for the browser, but a browser cannot finish " +
+            "this one: the seed lives behind the site's own two-factor settings and nothing in " +
+            "a view can put it in the vault. Do not raise this card again, do not open a " +
+            "browser for it, and do not ask for the seed in the chat.";
+        }
+        outputJson({ ok: false, stored: false, ...ended });
         process.exitCode = 1;
         return;
       }

--- a/plugins/agent-id-vault/bin/cli.mjs
+++ b/plugins/agent-id-vault/bin/cli.mjs
@@ -408,6 +408,49 @@ function formFieldsForType(type, flags) {
   }
 }
 
+// A card the OWNER ended, told apart from a card that broke. All three are
+// `ok:false`, and the difference is what the caller does next: a fault invites a
+// retry, and a decision must not — re-raising a card someone just closed is the
+// loop this exists to stop. `use_browser` is the one that carries an `action`,
+// because it is the only one where something else should happen instead.
+function ownerEndedTheCard(err, extra = {}) {
+  if (err?.code === "FORM_USE_BROWSER") {
+    return {
+      error: "FORM_USE_BROWSER",
+      action: "owner_must_drive",
+      reason: "owner_chose_the_browser",
+      retryable: false,
+      message:
+        "The owner closed the card and asked to sign in from the browser themselves. " +
+        "That is not a refusal. Do not raise this card again and do not ask for the value here.",
+      ...extra,
+    };
+  }
+  if (err?.code === "FORM_CANCELLED") {
+    return {
+      error: "FORM_CANCELLED",
+      reason: "owner_dismissed_the_card",
+      retryable: false,
+      message:
+        "The owner dismissed the card — they were asked and said no. " +
+        "Do not raise it again unless they ask for it.",
+      ...extra,
+    };
+  }
+  if (err?.code === "FORM_TIMEOUT") {
+    return {
+      error: "FORM_TIMEOUT",
+      reason: "card_timed_out",
+      retryable: false,
+      message:
+        "The card expired before the owner answered. Ask them to be ready, then run this again.",
+      ...extra,
+    };
+  }
+
+  return null;
+}
+
 async function cmdAdd(flags) {
   const name = flags.name;
   const type = flags.type;
@@ -512,6 +555,16 @@ async function cmdAdd(flags) {
       });
       formValues = out.values;
     } catch (err) {
+      const ended = ownerEndedTheCard(err, {
+        name,
+        type,
+        url: flags["login-url"] || null,
+      });
+      if (ended) {
+        outputJson({ ok: false, stored: false, ...ended });
+        process.exitCode = 1;
+        return;
+      }
       return outputError(`secure form: ${err.message}`);
     }
   }
@@ -733,6 +786,15 @@ async function cmdSetTotp(flags) {
       });
       seedInput = out.values.seed;
     } catch (err) {
+      // No `action` even for `use_browser`: a seed lives behind the site's own
+      // 2FA settings, and a browser view can show it to the owner but cannot put
+      // it in the vault. Handing one over would land them back on this card.
+      const ended = ownerEndedTheCard(err, { name });
+      if (ended) {
+        outputJson({ ok: false, stored: false, ...ended, action: undefined });
+        process.exitCode = 1;
+        return;
+      }
       return outputError(`secure form: ${err.message}`);
     }
   } else {
@@ -1087,6 +1149,22 @@ async function cmdSetAccess(flags) {
           security: "Typed by you, out of the agent's sight. Mismatch = no change.",
         }));
       } catch (err) {
+        // This card is an APPROVAL, not a secret. Nothing in a browser can
+        // approve it, so any way the owner ends it leaves the access alone —
+        // and asking again in the same turn is the loop, not the recovery.
+        if (ownerEndedTheCard(err)) {
+          outputJson({
+            ok: false,
+            error: "OWNER_DID_NOT_APPROVE",
+            reason: "owner_ended_the_card",
+            retryable: false,
+            access: describeAccess(rec),
+            message:
+              "Access unchanged — the owner did not approve the widen. Do not ask again in this turn.",
+          });
+          process.exitCode = 1;
+          return;
+        }
         return outputError(`owner confirmation: ${err.message}`);
       }
       if (String(values.confirm || "").trim() !== name) {

--- a/tests/test-auto-login.mjs
+++ b/tests/test-auto-login.mjs
@@ -107,6 +107,33 @@ test("runRecipe maps steps to driver calls, substitutes vars, resolves {otp} onc
   assert.equal(otpCalls, 1);
 });
 
+// `fillCode` spreads what it is given one character per box. A template that
+// merely CONTAINS the code is not a code screen's row — routing it here would put
+// "c", "o", "d", "e" across six boxes and call it a sign-in.
+test("runRecipe sends only a bare {otp} to the row-aware verb", async () => {
+  const calls = [];
+  await runRecipe(
+    pageOn("https://x/login"),
+    [
+      { action: "fill", selector: "#otp", value: "{otp}" },
+      { action: "fill", selector: "#note", value: "code: {otp}" },
+      { action: "type", selector: "#other", text: "{otp} please" },
+    ],
+    {
+      username: "u",
+      password: "p",
+      getOtp: async () => "654321",
+      domains: ["x"],
+      driver: recordingDriver(calls),
+    }
+  );
+  assert.deepEqual(calls, [
+    ["fillCode", "#otp", "654321"],
+    ["fill", "#note", "code: 654321"],
+    ["type", "#other", "654321 please"],
+  ]);
+});
+
 test("runRecipe does not resolve OTP when no step needs it", async () => {
   let otpCalls = 0;
   await runRecipe(pageOn("https://x/login"), [{ action: "fill", selector: "#u", value: "{username}" }], {

--- a/tests/test-browser-secret-readback.mjs
+++ b/tests/test-browser-secret-readback.mjs
@@ -38,7 +38,7 @@ import {
   markSecretBoxes,
   SECRET_TAINT_ATTR,
 } from "../plugins/agent-id-browser/lib/session-server.mjs";
-import { otpBoxes } from "../plugins/agent-id-browser/lib/auto-login.mjs";
+import { otpBoxes, typeCodeInto } from "../plugins/agent-id-browser/lib/auto-login.mjs";
 import { typeCodeAcrossBoxes } from "../plugins/agent-id-browser/lib/human-input.mjs";
 
 const patchrightAvailable = !!resolvePatchright();
@@ -287,6 +287,90 @@ const CODE_ROW = `<!doctype html><meta charset=utf-8><title>code</title>
   ).join("")}</div>
   <input id="nickname" type="text" value="alice">
 </form>`;
+
+// Where the caller's selector and the row predicate disagree, the caller wins —
+// unless the caller's selector caught nothing at all. `otpBoxes` searches the
+// whole document and takes the first group that looks like a code row, which is
+// right for a heuristic net and wrong for an instruction: a recipe naming one of
+// two code fields, or a `fill_otp` ref pointing at the second one, would have had
+// its instruction silently replaced.
+test(
+  "a code goes where the selector says, not where the row predicate looked",
+  { skip },
+  async () => {
+    const onCodeRow = async (selector, code) => {
+      const page = await ctx.newPage();
+      try {
+        await page.setContent(CODE_ROW, { waitUntil: "domcontentloaded" });
+        await typeCodeInto(page, selector, code);
+
+        return {
+          row: (
+            await Promise.all(
+              Array.from({ length: 6 }, (_, i) => page.locator(`#d${i}`).inputValue())
+            )
+          ).join(""),
+          nickname: await page.locator("#nickname").inputValue(),
+        };
+      } finally {
+        await page.close().catch(() => {});
+      }
+    };
+
+    // In the row: the two agree, and the code is spread.
+    assert.deepEqual(await onCodeRow("#d0", "423124"), {
+      row: "423124",
+      nickname: "alice",
+    });
+
+    // Elsewhere: the selector named a field outside the row and meant it. The
+    // row must not be touched — writing a code into six boxes nobody asked about
+    // is a code typed into the wrong screen.
+    assert.deepEqual(await onCodeRow("#nickname", "423124"), {
+      row: "",
+      nickname: "423124",
+    });
+
+    // No match: a heuristic net that catches nothing cannot outvote the row.
+    // This is `typeOtp`'s own selector against a row of bare text inputs — the
+    // shape the whole spreading path exists for.
+    assert.deepEqual(
+      await onCodeRow('input[autocomplete="one-time-code"]', "423124"),
+      { row: "423124", nickname: "alice" }
+    );
+  }
+);
+
+// The other half of the row's taint. `fill-secret` and `fill-otp` have tagged
+// their fields since the read-back guard existed; every field AUTO-LOGIN typed —
+// the code screen's single field, and every password — stayed readable.
+test(
+  "a secret auto-login typed into a single field is refused a read-back",
+  { skip },
+  async () => {
+    const page = await ctx.newPage();
+    try {
+      await page.setContent(CODE_ROW, { waitUntil: "domcontentloaded" });
+
+      await assert.doesNotReject(
+        () => refusePasswordRead(page, "#nickname"),
+        "readable before anything was typed into it"
+      );
+
+      await typeCodeInto(page, "#nickname", "423124");
+
+      await assert.rejects(
+        () => refusePasswordRead(page, "#nickname"),
+        /secret/i,
+        "a field auto-login typed a secret into must not read back"
+      );
+      // The taint is the field's, not the form's.
+      await assert.doesNotReject(() => refusePasswordRead(page, "#d0"));
+    } finally {
+      await page.close().catch(() => {});
+    }
+  }
+);
 
 test(
   "a code spread across a row taints every box, not just the ref",

--- a/tests/test-browser-session-helpers.mjs
+++ b/tests/test-browser-session-helpers.mjs
@@ -27,6 +27,7 @@ import {
   sessionAlive,
   sessionRecord,
   errorReply,
+  CARD_ENDINGS,
 } from "../plugins/agent-id-browser/lib/session-server.mjs";
 
 test("refuseRef: a ref on a focus-typing action is refused, not dropped", () => {
@@ -239,6 +240,35 @@ test("pruneDeadSessions: drops orphans, keeps live sessions and young work dirs"
 
 // ─── a failure the caller can act on ──────────────────────────────────────────────
 
+// `fill-otp` used to give this shape to one ending out of three: a dismissal
+// travelled as prose and a timeout not at all, so the path most likely to want
+// the hand-off was the one that lost it.
+test("every way the owner can end a card is an ending fill-otp names", () => {
+  // The three `FORM_*` codes the secure-prompt layer mints. A fourth added
+  // without a line here falls through to a bare throw, which is the opaque
+  // string this whole change exists to stop.
+  assert.deepEqual(Object.keys(CARD_ENDINGS).sort(), [
+    "FORM_CANCELLED",
+    "FORM_TIMEOUT",
+    "FORM_USE_BROWSER",
+  ]);
+
+  for (const [code, ending] of Object.entries(CARD_ENDINGS)) {
+    assert.ok(ending.message, `${code} says nothing`);
+    assert.ok(ending.detail.reason, `${code} carries no machine reason`);
+  }
+
+  // Only the browser ending asks for something else to happen instead — and on
+  // exactly the pair the caller matches on. Nothing compiles across that
+  // boundary; this assertion is the contract.
+  const withAction = Object.entries(CARD_ENDINGS).filter(([, e]) => e.detail.action);
+  assert.equal(withAction.length, 1);
+  assert.deepEqual(CARD_ENDINGS.FORM_USE_BROWSER.detail, {
+    action: "owner_must_drive",
+    reason: "owner_chose_the_browser",
+  });
+});
+
 // The socket reply is everything the caller sees of an action. Flattening a throw to
 // its message left "the owner chose the browser" and "the page would not load"
 // indistinguishable, so whatever a thrower attaches as `detail` has to survive.
@@ -252,6 +282,19 @@ test("errorReply carries the thrower's detail beside the message", () => {
     action: "owner_must_drive",
     reason: "owner_chose_the_browser",
     profile: "main",
+  });
+});
+
+// The one funnel every daemon failure leaves through. A detail that could rewrite
+// `ok` would turn a thrower's own error into a success on the way out.
+test("errorReply does not let a detail rewrite ok or error", () => {
+  const err = new Error("real failure");
+  err.detail = { ok: true, error: "not this", reason: "owner_dismissed_the_card" };
+
+  assert.deepEqual(errorReply(err), {
+    ok: false,
+    error: "real failure",
+    reason: "owner_dismissed_the_card",
   });
 });
 

--- a/tests/test-browser-session-helpers.mjs
+++ b/tests/test-browser-session-helpers.mjs
@@ -26,6 +26,7 @@ import {
   safeFilename,
   sessionAlive,
   sessionRecord,
+  errorReply,
 } from "../plugins/agent-id-browser/lib/session-server.mjs";
 
 test("refuseRef: a ref on a focus-typing action is refused, not dropped", () => {
@@ -234,4 +235,34 @@ test("pruneDeadSessions: drops orphans, keeps live sessions and young work dirs"
   assert.ok(pruned.includes("dead"));
   assert.ok(pruned.includes("impostor"));
   assert.ok(pruned.includes("dead.work"));
+});
+
+// ─── a failure the caller can act on ──────────────────────────────────────────────
+
+// The socket reply is everything the caller sees of an action. Flattening a throw to
+// its message left "the owner chose the browser" and "the page would not load"
+// indistinguishable, so whatever a thrower attaches as `detail` has to survive.
+test("errorReply carries the thrower's detail beside the message", () => {
+  const err = new Error("fill-otp: the owner closed the code card");
+  err.detail = { action: "owner_must_drive", reason: "owner_chose_the_browser", profile: "main" };
+
+  assert.deepEqual(errorReply(err), {
+    ok: false,
+    error: "fill-otp: the owner closed the code card",
+    action: "owner_must_drive",
+    reason: "owner_chose_the_browser",
+    profile: "main",
+  });
+});
+
+test("errorReply is unchanged for an ordinary failure", () => {
+  assert.deepEqual(errorReply(new Error("boom")), { ok: false, error: "boom" });
+});
+
+test("errorReply ignores a detail that is not an object, and never loses the error", () => {
+  const err = new Error("boom");
+  err.detail = "not an object";
+
+  assert.deepEqual(errorReply(err), { ok: false, error: "boom" });
+  assert.equal(errorReply({}).error, "[object Object]");
 });

--- a/tests/test-escalation.mjs
+++ b/tests/test-escalation.mjs
@@ -125,7 +125,12 @@ test("choosing the browser sends the agent to the browser", () => {
     profile: "main",
   });
 
+  // This exact PAIR is what the caller's `owner_chose_the_browser` detector matches on
+  // to hand the browser over itself, instead of leaving that to a sentence the
+  // model may not act on. Nothing compiles across that boundary — changing either
+  // string here silently turns the hand-off back into a suggestion.
   assert.equal(action, OWNER_MUST_DRIVE, "the viewport is the answer to this");
+  assert.equal(action, "owner_must_drive", "the slug the caller matches on, spelled out");
   assert.equal(reason, "owner_chose_the_browser");
   assert.match(message, /browser view for profile 'main'/);
   // The two ways a card can close must not read the same: one means leave it

--- a/tests/test-secure-prompt.mjs
+++ b/tests/test-secure-prompt.mjs
@@ -44,6 +44,57 @@ function startHostedSocket(handler) {
   return new Promise((resolve) => server.listen(sock, () => resolve({ sock, server })));
 }
 
+// Capture what the resolver says about itself. Every resolution writes one line,
+// and the line is the whole point of the change: without it a card that never
+// left the machine and a card the owner ignored produced identical logs.
+function announced(resolve) {
+  const written = [];
+  const original = process.stderr.write;
+  process.stderr.write = (chunk) => {
+    written.push(String(chunk));
+    return true;
+  };
+  try {
+    resolve();
+  } finally {
+    process.stderr.write = original;
+  }
+  return written.join("");
+}
+
+test("resolver: a fallback to a local backend says so, and why", () => {
+  const said = announced(() => resolveSecurePrompt({ env: {} }));
+  assert.match(said, /NOT the owner's device/);
+  assert.match(said, /AGENT_ID_SECURE_PROMPT_SOCK is not set/);
+});
+
+// The override is not the rare path: the runtime sets AGENT_ID_SECURE_PROMPT on
+// every child it spawns, so a resolver that only spoke for the ordinary chain
+// would be silent on the exact path this diagnostic was written for.
+test("resolver: a forced backend is announced too, and names the force as the reason", () => {
+  const said = announced(() =>
+    resolveSecurePrompt({ env: { AGENT_ID_SECURE_PROMPT: "browser" } })
+  );
+  assert.match(said, /asking through 'browser'/);
+  assert.match(said, /forced by AGENT_ID_SECURE_PROMPT=browser/);
+});
+
+// Forcing hosted skips the availability check by design. That is exactly when a
+// dead socket needs saying out loud: `collect()` would only reject with a generic
+// "not configured", minutes after the card was supposed to appear.
+test("resolver: hosted forced onto a socket that isn't there is announced as doomed", () => {
+  const said = announced(() =>
+    resolveSecurePrompt({
+      env: {
+        AGENT_ID_SECURE_PROMPT: "hosted",
+        AGENT_ID_SECURE_PROMPT_SOCK: "/nonexistent/agentid.sock",
+      },
+    })
+  );
+  assert.match(said, /no usable socket/);
+  assert.match(said, /this will fail/);
+});
+
 test("resolver: default environment selects the browser form", () => {
   assert.equal(resolveSecurePrompt({ env: {} }).name, "browser");
 });

--- a/tests/test-vault-login.mjs
+++ b/tests/test-vault-login.mjs
@@ -14,6 +14,7 @@ import os from "node:os";
 import path from "node:path";
 import { mkdtemp, rm, readFile } from "node:fs/promises";
 import { spawn } from "node:child_process";
+import http from "node:http";
 import { generateKeyPairSync } from "node:crypto";
 
 import {
@@ -557,6 +558,94 @@ test("the card names the site, not the credential the agent invented", async () 
 
     child.kill();
     await new Promise((r) => child.on("exit", r));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// ─── a card the OWNER ended, told apart from a card that broke ────────────────────
+
+// Live incident: the owner pressed the card's "sign in from the browser" link on
+// a `vault_add` form. Every way of ending that card collapsed into one opaque
+// `secure form: …` string, which reads to a model like a transient fault — so it
+// called `vault_add` again and the owner got the same form a second time.
+function hostedSocket(reason) {
+  const sock = path.join(os.tmpdir(), `vault-card-${process.pid}-${Date.now()}.sock`);
+  const server = http.createServer((req, res) => {
+    req.on("data", () => {});
+    req.on("end", () => {
+      const body = JSON.stringify(reason ? { error: "cancelled", reason } : { error: "cancelled" });
+      res.writeHead(409, { "content-type": "application/json" });
+      res.end(body);
+    });
+  });
+
+  return new Promise((resolve) => server.listen(sock, () => resolve({ sock, server })));
+}
+
+async function addAgainstCard({ dir, reason }) {
+  const { sock, server } = await hostedSocket(reason);
+  try {
+    const child = spawn(
+      "node",
+      [
+        CLI, "add", "--name", "booking", "--type", "login",
+        "--passwordless", "--otp", "interactive",
+        "--login-url", "https://account.example.com/sign-in",
+        "--form", "--state-dir", dir,
+      ],
+      {
+        env: {
+          ...process.env,
+          AGENT_ID_SECURE_PROMPT: "hosted",
+          AGENT_ID_SECURE_PROMPT_SOCK: sock,
+        },
+      }
+    );
+    let stdout = "";
+    child.stdout.on("data", (d) => (stdout += d));
+    const code = await new Promise((r) => child.on("exit", r));
+
+    return { code, out: JSON.parse(stdout) };
+  } finally {
+    server.close();
+  }
+}
+
+test("a card closed for the browser says so, and stores nothing", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "vault-card-"));
+  try {
+    const privateKeyPem = await makeVault(dir);
+    const { code, out } = await addAgainstCard({ dir, reason: "use_browser" });
+
+    assert.equal(code, 1);
+    assert.equal(out.error, "FORM_USE_BROWSER");
+    // The pair the caller matches on. There is no compiler across that boundary —
+    // this assertion is the contract.
+    assert.equal(out.action, "owner_must_drive");
+    assert.equal(out.reason, "owner_chose_the_browser");
+    assert.equal(out.retryable, false);
+    assert.equal(out.url, "https://account.example.com/sign-in");
+    assert.equal(out.stored, false);
+
+    const vault = await openVault({ stateDir: dir, privateKeyPem });
+    assert.ok(!vault.get("booking"), "nothing was written");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("a card simply dismissed is not the browser, and is not retryable either", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "vault-card-"));
+  try {
+    await makeVault(dir);
+    const { code, out } = await addAgainstCard({ dir, reason: null });
+
+    assert.equal(code, 1);
+    assert.equal(out.error, "FORM_CANCELLED");
+    assert.equal(out.reason, "owner_dismissed_the_card");
+    assert.equal(out.retryable, false);
+    assert.equal(out.action, undefined, "a dismissal asks for nothing to happen instead");
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/tests/test-vault-login.mjs
+++ b/tests/test-vault-login.mjs
@@ -612,6 +612,62 @@ async function addAgainstCard({ dir, reason }) {
   }
 }
 
+// Same stubbed card host, driving `set-totp --form` instead. The credential has
+// to exist first, which `add` without `--form` does without raising anything.
+async function setTotpAgainstCard({ dir, reason }) {
+  const { sock, server } = await hostedSocket(reason);
+  try {
+    const child = spawn(
+      "node",
+      [CLI, "set-totp", "--name", "booking", "--form", "--state-dir", dir],
+      {
+        env: {
+          ...process.env,
+          AGENT_ID_SECURE_PROMPT: "hosted",
+          AGENT_ID_SECURE_PROMPT_SOCK: sock,
+        },
+      }
+    );
+    let stdout = "";
+    child.stdout.on("data", (d) => (stdout += d));
+    const code = await new Promise((r) => child.on("exit", r));
+
+    return { code, out: JSON.parse(stdout) };
+  } finally {
+    server.close();
+  }
+}
+
+// Stripping the `action` stops the CALLER handing a browser over. It does not
+// stop the model opening one itself — that tool is model-callable, and it is the
+// whole premise of the pair. So the decline has to say why, or it is the same
+// loop one step longer.
+test("a seed card closed for the browser declines, and says a browser cannot finish it", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "vault-card-"));
+  try {
+    await makeVault(dir);
+    // The credential has to exist before a seed can be set on it; plain `add`
+    // raises no card.
+    await new Promise((resolve) => {
+      const child = spawn("node", [
+        CLI, "add", "--name", "booking", "--type", "login",
+        "--domains", "account.example.com", "--state-dir", dir,
+      ]);
+      child.on("exit", resolve);
+    });
+    const { code, out } = await setTotpAgainstCard({ dir, reason: "use_browser" });
+
+    assert.equal(code, 1);
+    assert.equal(out.error, "FORM_USE_BROWSER");
+    assert.equal(out.stored, false);
+    assert.equal(out.action, undefined, "a browser cannot put a seed in the vault");
+    assert.match(out.message, /browser cannot finish this one/);
+    assert.match(out.message, /do not open a browser for it/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("a card closed for the browser says so, and stores nothing", async () => {
   const dir = await mkdtemp(path.join(os.tmpdir(), "vault-card-"));
   try {


### PR DESCRIPTION
Pairs with alien-id/lethe#315. This half tells the ending apart; that half acts on it.

## The incident

The owner pressed the card's "sign in from the browser" link on a `vault_add` form. Seven seconds later the same form was back. From the gateway log: two `vault_add` calls, two cards, nothing in between.

## Why

A card can end four ways — answered, dismissed, expired, handed to the browser — and three of them arrived as one opaque string:

```js
catch (err) { return outputError(`secure form: ${err.message}`); }
```

A model reads that as a fault, and the sensible reply to a fault is a retry. There was no "do not ask again" anywhere on this path: that instruction exists only for auto-login's outcomes in `escalation.mjs`.

## What

Each ending now says what it is, in **fields rather than prose** — the socket reply is all the caller sees, and a sentence is not something it can match on. Only the browser ending carries an `action`, because it is the only one where something else should happen instead. All three are `retryable: false`.

`fill_otp` finally handles it too: it caught a plain dismissal and let `FORM_USE_BROWSER` fall through a bare `throw`, so the path most likely to want the hand-off was the one that lost it. Its detail rides out through a new `errorReply`, which stops the socket flattening a throw to its message — the one structural change here, and it is generic.

**Where a browser cannot finish the job, the card is not handed over.** A seed lives behind the site's own 2FA settings and a viewport cannot put it in the vault; the access-widening card is an approval, and nothing in a browser can give one. Both decline without an `action`, and neither may be re-raised.

## Also on this branch

**The review fixes for #146, which merged before they were written.** A one-time code went into whichever row the predicate found first: `typeCodeInto` called `otpBoxes(page)` and dropped its `selector`, so a recipe naming `#email-code` beside an SMS row, or a `fill_otp` ref pointing at the second of two code fields, had its instruction silently replaced. `otpBoxesFor` asks the page whether the caller's selector and the row agree and lets the caller win — a selector matching nothing still yields to the row, which is what keeps `typeOtp`'s wide net working against bare text inputs.

The taint stopped at the row, so every field auto-login typed a secret into stayed readable through `get --what value` — the code screen's single field, and **both password paths**. It happens inside `typeSecret` now, through the same `firstVisible` the typing resolved through: where a site renders a hidden copy of its form first, tagging by selector again would leave the filled field readable and tag the decoy.

`carriesOtp` matched a substring, so `"code: {otp}"` would have been spread one character per box. And `resolveSecurePrompt` returned from the operator-override branch before announcing anything — the branch the runtime takes on every child it spawns, so the diagnostic was silent on the exact path it was written for.

**What review found in this PR.** `fill-otp` gave the new shape to one ending out of three (a dismissal travelled as prose, a timeout not at all); `errorReply` spread the thrower's detail last, so a detail carrying `ok` would turn its own error into a success; and `set-totp` dropped the `action` but kept wording that still reads "the owner asked to sign in from the browser" — which stops the caller handing a browser over but not the model opening one itself.

## Tests

- a card closed for the browser reports the pair, names the login url, and **stores nothing**;
- a card simply dismissed is not the browser, and is not retryable either;
- `errorReply` carries `detail`, ignores a non-object one, never loses the message.

In `test-escalation.mjs` the `(action, reason)` pair is now asserted as the cross-repo contract it is — nothing compiles across that boundary, so that assertion is the only thing holding it.

Plus: every way the owner can end a card is an ending `fill-otp` names, and only the browser one carries an `action`; `errorReply` will not let a detail rewrite `ok` or `error`; a seed card closed for the browser declines and says a browser cannot finish it; a code goes where the selector says rather than into the row the predicate found; a secret auto-login typed into a single field is refused a read-back.

Every new assertion proved by reverting the code under it. `npm test` — 944 tests, 0 fail. `ci:hygiene` clean.

Also verified live against a stubbed card host: the real CLI, a 409 carrying `use_browser`, and the marker on stdout with an empty vault behind it.
