### PR TITLE
feat: "Save to vault" box on the credential card, and a credential kept for one sign-in

### DIFF
--- a/.changeset/save-to-vault-box-browser.md
+++ b/.changeset/save-to-vault-box-browser.md
@@ -1,0 +1,5 @@
+---
+"@alien-id/agent-id-browser": minor
+---
+
+`auto-login` removes a credential the owner chose not to keep (`transient`) once the sign-in has completed, and reports `credentialRemoved: true`.

--- a/.changeset/save-to-vault-box-core.md
+++ b/.changeset/save-to-vault-box-core.md
@@ -1,0 +1,5 @@
+---
+"@alien-id/agent-id-core": minor
+---
+
+Secure-input fields may declare `kind: "checkbox"` with a `default`; the local browser form and the tty prompt render it and answer with the string `"true"` / `"false"` (an unticked box posts nothing and reads as `"false"`, never as an absent field).

--- a/.changeset/save-to-vault-box-vault.md
+++ b/.changeset/save-to-vault-box-vault.md
@@ -1,0 +1,5 @@
+---
+"@alien-id/agent-id-vault": minor
+---
+
+The credential card carries a "Save to vault" box, ticked by default. Unticked, `vault add --form` keeps the record for this sign-in only — marked `transient`, listed as such, and swept on the next open once its 30-minute window passes — and the result says `transient: true` so the caller knows not to plan a later sign-in around it.

--- a/.changeset/save-to-vault-box-vault.md
+++ b/.changeset/save-to-vault-box-vault.md
@@ -2,4 +2,4 @@
 "@alien-id/agent-id-vault": minor
 ---
 
-The credential card carries a "Save to vault" box, ticked by default. Unticked, `vault add --form` keeps the record for this sign-in only — marked `transient`, listed as such, and swept on the next open once its 30-minute window passes — and the result says `transient: true` so the caller knows not to plan a later sign-in around it.
+The credential card carries a "Save to vault" box, on by default, behind `AGENT_ID_SAVE_TO_VAULT_BOX=1` until the phone app that draws it has shipped. Turned off, `vault add --form` keeps the record for this sign-in only — marked `transient`, listed as such, dropped from every open once its 30-minute window passes and from disk on the next save — and the result says `transient: true` so the caller knows not to plan a later sign-in around it. Turning it off on a re-add of a credential the owner already keeps leaves that credential kept.

--- a/plugins/agent-id-browser/bin/cli.mjs
+++ b/plugins/agent-id-browser/bin/cli.mjs
@@ -266,10 +266,10 @@ async function cmdAutoLogin(flags) {
     }
 
     vault.touchLastUsed(credName);
-    // The owner unticked "Save to vault" when this credential was collected: it
-    // was kept for the sign-in that just completed and no longer. The session
-    // in the browser's profile is what outlives it.
-    const credentialRemoved = Boolean(cred.transient) && vault.remove(credName) != null;
+    // A credential the owner chose not to keep was kept for the sign-in that
+    // just completed and no longer; the session in the browser's profile is
+    // what outlives it.
+    const credentialRemoved = vault.consumeTransient(credName);
     await vault.save();
     const recipeFailed = result.recipeFailed || null;
     outputJson({

--- a/plugins/agent-id-browser/bin/cli.mjs
+++ b/plugins/agent-id-browser/bin/cli.mjs
@@ -266,6 +266,10 @@ async function cmdAutoLogin(flags) {
     }
 
     vault.touchLastUsed(credName);
+    // The owner unticked "Save to vault" when this credential was collected: it
+    // was kept for the sign-in that just completed and no longer. The session
+    // in the browser's profile is what outlives it.
+    const credentialRemoved = Boolean(cred.transient) && vault.remove(credName) != null;
     await vault.save();
     const recipeFailed = result.recipeFailed || null;
     outputJson({
@@ -274,12 +278,16 @@ async function cmdAutoLogin(flags) {
       outcome: result.outcome,
       finalUrl: result.finalUrl,
       ...(recipeFailed ? { recipeFailed } : {}),
+      credentialRemoved,
       message:
         `Signed in as '${credName}'. The browser holds the session; its own profile keeps the ` +
         "cookies (close it, or flush it, to be sure they are on disk)." +
         (recipeFailed
-          ? ` The stored recipe failed at '${recipeFailed.step ?? "?"}' and was bypassed; clear it ` +
+          ? ` The stored recipe failed at '${recipeFailed.step ?? "?"}' and was bypassed; clear ` +
             `the stored recipe on '${credName}' so the next sign-in does not try it.`
+          : "") +
+        (credentialRemoved
+          ? ` The credential '${credName}' was kept for this sign-in only and has been removed.`
           : ""),
     });
   } catch (err) {

--- a/plugins/agent-id-core/lib/secure-form.mjs
+++ b/plugins/agent-id-core/lib/secure-form.mjs
@@ -164,9 +164,23 @@ function openForWebauthn(url, size) {
 // Tight initial size; the page's resize script then shrinks the window to the
 // content's true size once rendered (app windows are script-resizable).
 function windowSizeFor(fields) {
-  const rows = Array.isArray(fields) ? fields.length : 1;
-  const multiline = Array.isArray(fields) && fields.some((f) => f.multiline);
-  return { width: 360, height: 250 + 66 * rows + (multiline ? 130 : 0) };
+  const list = Array.isArray(fields) ? fields : [];
+  const checks = list.filter(isCheckbox).length;
+  const rows = Math.max(1, list.length - checks);
+  const multiline = list.some((f) => f.multiline);
+  return { width: 360, height: 250 + 66 * rows + 36 * checks + (multiline ? 130 : 0) };
+}
+
+function isCheckbox(f) {
+  return f && f.kind === "checkbox";
+}
+
+// An unticked HTML checkbox posts nothing, so the answer is read against the
+// field, not the body: present means on, absent means off. That keeps "off"
+// apart from "this form never had the box", which the consumer reads as the
+// default.
+function checkboxValue(params, f) {
+  return params.get(f.name) === "true" ? "true" : "false";
 }
 
 // Inline padlock — the "secure" logo. Stroke follows currentColor.
@@ -195,6 +209,8 @@ const SECURE_CSS = `
  .why code{font-family:ui-monospace,Menlo,Consolas,monospace}
  label{display:block;margin:.5rem 0 .16rem;font-weight:600;font-size:.84rem}
  .opt{font-weight:400;color:#9ca3af}
+ label.check{display:flex;align-items:center;gap:.5rem;margin:.75rem 0 0;font-weight:500;cursor:pointer}
+ label.check input{width:1rem;height:1rem;margin:0;padding:0;accent-color:#16a34a}
  input,textarea{width:100%;padding:.46rem .52rem;font:inherit;border:1px solid #16a34a66;
    background:Field;color:FieldText}
  textarea{resize:vertical;min-height:4.2rem}
@@ -272,6 +288,10 @@ function renderForm({ token, title, description, fields, security, submitLabel, 
         const label = htmlEscape(f.label || f.name);
         const req = f.required === false ? "" : "required";
         const ph = f.placeholder ? `placeholder="${htmlEscape(f.placeholder)}"` : "";
+        if (isCheckbox(f)) {
+          const on = String(f.default ?? "false") === "true" ? " checked" : "";
+          return `<label class="check"><input id="${id}" name="${id}" type="checkbox" value="true"${on}>${label}</label>`;
+        }
         const input = f.multiline
           ? `<textarea id="${id}" name="${id}" rows="5" ${req} ${ph} autocomplete="off"></textarea>`
           : `<input id="${id}" name="${id}" type="${f.secret === false ? "text" : "password"}" ${req} ${ph} autocomplete="off" autocapitalize="off" spellcheck="false">`;
@@ -313,7 +333,10 @@ const DONE_PAGE = `<!doctype html><html><head><meta charset="utf-8"><title>Done<
  * Serve a one-shot secure form and resolve with the submitted field values.
  *
  *   title, description — shown on the page
- *   fields   — [{ name, label?, secret?=true, required?=true, multiline?, placeholder? }]
+ *   fields   — [{ name, label?, secret?=true, required?=true, multiline?, placeholder?,
+ *                kind?="text"|"checkbox", default? }]
+ *              a checkbox posts "true" / "false" (absent in the submit = "false");
+ *              `default` is its initial state, as the same string
  *   label    — short phrase for the waiting notice ("unlock the vault", …)
  *   timeoutMs — default 5 min; rejects (code FORM_TIMEOUT) if no submit
  *   open      — auto-open the browser (default true)
@@ -394,7 +417,9 @@ export function collectViaForm({
             return;
           }
           const values = {};
-          for (const f of effFields) values[f.name] = params.get(f.name) ?? "";
+          for (const f of effFields) {
+            values[f.name] = isCheckbox(f) ? checkboxValue(params, f) : params.get(f.name) ?? "";
+          }
           res.writeHead(200, PAGE_HEADERS);
           // Resolve only once the done-page has flushed to the browser.
           res.end(DONE_PAGE, () => finish(() => resolve({ values })));

--- a/plugins/agent-id-core/lib/secure-prompt.mjs
+++ b/plugins/agent-id-core/lib/secure-prompt.mjs
@@ -21,7 +21,11 @@
 //
 // `spec` is exactly the shape collectViaForm already accepts:
 //   { title, description, fields, label, security, submitLabel, timeoutMs }
-//   fields: [{ name, label?, secret?=true, required?=true, multiline?, placeholder? }]
+//   fields: [{ name, label?, secret?=true, required?=true, multiline?, placeholder?,
+//              kind?="text"|"checkbox", default? }]
+//   A checkbox field answers with the string "true" / "false"; `default` is its
+//   initial state in the same domain. A host that never rendered the box sends
+//   nothing, and the caller reads absence as its default.
 //
 // resolveSecurePrompt() picks the first available provider whose capabilities
 // satisfy the spec, in order: hosted → …extraProviders (e.g. mobile) → browser → tty.
@@ -87,6 +91,12 @@ export class TtyProvider {
     const values = {};
     for (const f of fields) {
       const label = f.label || f.name;
+      if (f.kind === "checkbox") {
+        const on = String(f.default ?? "false") === "true";
+        const answer = promptText(`  ${label} [${on ? "Y/n" : "y/N"}]: `).trim().toLowerCase();
+        values[f.name] = answer === "" ? String(on) : String(answer === "y" || answer === "yes");
+        continue;
+      }
       const opt = f.required === false ? " (optional)" : "";
       const prompt = `  ${label}${opt}: `;
       values[f.name] = f.secret === false ? promptText(prompt) : promptSecret(prompt);

--- a/plugins/agent-id-core/lib/secure-prompt.mjs
+++ b/plugins/agent-id-core/lib/secure-prompt.mjs
@@ -38,8 +38,8 @@ import http from "node:http";
 
 import { collectViaForm } from "./secure-form.mjs";
 import {
-  promptSecret,
-  promptText,
+  promptSecret as promptSecretOnTty,
+  promptText as promptTextOnTty,
   hasTty,
   notifyTty,
 } from "./trusted-input.mjs";
@@ -72,8 +72,10 @@ export class BrowserFormProvider {
 // ─── /dev/tty prompt (the no-GUI fallback) ───────────────────────────────────────
 
 export class TtyProvider {
-  constructor() {
+  constructor({ promptText = promptTextOnTty, promptSecret = promptSecretOnTty } = {}) {
     this.name = "tty";
+    this._promptText = promptText;
+    this._promptSecret = promptSecret;
   }
   isAvailable() {
     return hasTty();
@@ -93,13 +95,13 @@ export class TtyProvider {
       const label = f.label || f.name;
       if (f.kind === "checkbox") {
         const on = String(f.default ?? "false") === "true";
-        const answer = promptText(`  ${label} [${on ? "Y/n" : "y/N"}]: `).trim().toLowerCase();
+        const answer = this._promptText(`  ${label} [${on ? "Y/n" : "y/N"}]: `).trim().toLowerCase();
         values[f.name] = answer === "" ? String(on) : String(answer === "y" || answer === "yes");
         continue;
       }
       const opt = f.required === false ? " (optional)" : "";
       const prompt = `  ${label}${opt}: `;
-      values[f.name] = f.secret === false ? promptText(prompt) : promptSecret(prompt);
+      values[f.name] = f.secret === false ? this._promptText(prompt) : this._promptSecret(prompt);
     }
     return { values };
   }

--- a/plugins/agent-id-vault/bin/cli.mjs
+++ b/plugins/agent-id-vault/bin/cli.mjs
@@ -326,8 +326,9 @@ function formDescription({
   // `ro` is a grant being made in the moment of typing, so it stays on the card
   // even though the rest of the metadata does not.
   const grant = access === "ro" ? " The agent can read this, never change it." : "";
+  const once = type === "login" ? " Untick Save to vault to use it once." : "";
 
-  return `${lead}${step}${grant}`;
+  return `${lead}${step}${grant}${once}`;
 }
 
 
@@ -402,10 +403,42 @@ function formFieldsForType(type, flags) {
               },
             ]
           : []),
+        // The owner's say over whether the credential outlives this sign-in. On
+        // by default; unticked, the record is kept only until the sign-in that
+        // asked for it completes (see `transient` below). It rides the same
+        // sealed form as the values, so nothing between here and the phone sees
+        // the choice — the value comes back as the string "true" / "false", and
+        // a client that never rendered the row sends nothing, which is "true".
+        SAVE_TO_VAULT_FIELD,
       ];
     default:
       return null;
   }
+}
+
+const SAVE_TO_VAULT_FIELD = Object.freeze({
+  name: "saveToVault",
+  label: "Save to vault",
+  kind: "checkbox",
+  default: "true",
+  secret: false,
+  required: false,
+});
+
+// A credential the owner chose not to keep lives this long at most: longer than
+// the card's own 15-minute budget plus one auto-login, so a sign-in that is
+// under way never loses its credential mid-run, and short enough that "not
+// saved" stays true when nothing consumes it.
+const TRANSIENT_TTL_MS = 30 * 60 * 1000;
+
+// The owner's answer to the "Save to vault" box, taken OUT of the form values
+// so it can never be written into a record as if it were a field. Absent means
+// kept — the card of an older client has no box.
+function takeSaveToVault(formValues) {
+  if (!formValues || !(SAVE_TO_VAULT_FIELD.name in formValues)) return true;
+  const raw = formValues[SAVE_TO_VAULT_FIELD.name];
+  delete formValues[SAVE_TO_VAULT_FIELD.name];
+  return String(raw) !== "false";
 }
 
 // A card the OWNER ended, told apart from a card that broke. All three are
@@ -568,6 +601,8 @@ async function cmdAdd(flags) {
       return outputError(`secure form: ${err.message}`);
     }
   }
+
+  const keep = takeSaveToVault(formValues);
 
   // Read a secret either from the form (--form) or the existing file/env/stdin/tty
   // channels — never from argv.
@@ -742,11 +777,14 @@ async function cmdAdd(flags) {
       }
     }
 
+    if (!keep) record.transient = { until: Date.now() + TRANSIENT_TTL_MS };
+
     const stored = vault.add(record);
     await vault.save();
     stderr(
       `Added credential '${name}' (${type}) for ${domains.join(", ")}` +
-        `${stored.access ? ` — access: ${stored.access}` : ""}.`
+        `${stored.access ? ` — access: ${stored.access}` : ""}` +
+        `${keep ? "" : " — for this sign-in only"}.`
     );
     outputJson({
       ok: true,
@@ -756,6 +794,14 @@ async function cmdAdd(flags) {
       access: effectiveAccess(stored),
       createdAt: stored.createdAt,
       updatedAt: stored.updatedAt,
+      ...(keep
+        ? {}
+        : {
+            transient: true,
+            note:
+              "The owner chose not to keep this credential. It exists for this sign-in only " +
+              "and is removed when the sign-in completes (or after 30 minutes).",
+          }),
     });
   } finally {
     vault.lock();

--- a/plugins/agent-id-vault/bin/cli.mjs
+++ b/plugins/agent-id-vault/bin/cli.mjs
@@ -82,6 +82,7 @@ import {
   loginOtpMode,
   LOGIN_OTP_MODES,
   SECRET_FIELDS,
+  isTransient,
   validateRecord,
 } from "../lib/store.mjs";
 import {
@@ -326,7 +327,8 @@ function formDescription({
   // `ro` is a grant being made in the moment of typing, so it stays on the card
   // even though the rest of the metadata does not.
   const grant = access === "ro" ? " The agent can read this, never change it." : "";
-  const once = type === "login" ? " Untick Save to vault to use it once." : "";
+  const once =
+    type === "login" && saveToVaultBoxEnabled() ? " Turn off Save to vault to use it once." : "";
 
   return `${lead}${step}${grant}${once}`;
 }
@@ -409,11 +411,19 @@ function formFieldsForType(type, flags) {
         // sealed form as the values, so nothing between here and the phone sees
         // the choice — the value comes back as the string "true" / "false", and
         // a client that never rendered the row sends nothing, which is "true".
-        SAVE_TO_VAULT_FIELD,
+        ...(saveToVaultBoxEnabled() ? [SAVE_TO_VAULT_FIELD] : []),
       ];
     default:
       return null;
   }
+}
+
+// Off until the phone draws the box: a client that predates it renders a
+// checkbox field as an empty text box under a line telling the owner to turn it
+// off. Set AGENT_ID_SAVE_TO_VAULT_BOX=1 once the iOS build carrying the switch
+// has shipped; the gate itself goes in the release after that.
+function saveToVaultBoxEnabled(env = process.env) {
+  return env.AGENT_ID_SAVE_TO_VAULT_BOX === "1";
 }
 
 const SAVE_TO_VAULT_FIELD = Object.freeze({
@@ -433,7 +443,7 @@ const TRANSIENT_TTL_MS = 30 * 60 * 1000;
 
 // The owner's answer to the "Save to vault" box, taken OUT of the form values
 // so it can never be written into a record as if it were a field. Absent means
-// kept — the card of an older client has no box.
+// kept — the card of an older client, or one raised with the box off, has none.
 function takeSaveToVault(formValues) {
   if (!formValues || !(SAVE_TO_VAULT_FIELD.name in formValues)) return true;
   const raw = formValues[SAVE_TO_VAULT_FIELD.name];
@@ -640,6 +650,11 @@ async function cmdAdd(flags) {
         );
       }
     }
+    // A credential the owner already keeps stays kept: turning the box off on a
+    // re-add would otherwise swap a saved record for one that is deleted after
+    // the next sign-in, which is not what a card about THIS sign-in asked.
+    const keepsExisting = existing != null && !isTransient(existing);
+    const transient = !keep && !keepsExisting;
 
     switch (type) {
       case "bearer":
@@ -777,14 +792,14 @@ async function cmdAdd(flags) {
       }
     }
 
-    if (!keep) record.transient = { until: Date.now() + TRANSIENT_TTL_MS };
+    if (transient) record.transient = { until: Date.now() + TRANSIENT_TTL_MS };
 
     const stored = vault.add(record);
     await vault.save();
     stderr(
       `Added credential '${name}' (${type}) for ${domains.join(", ")}` +
         `${stored.access ? ` — access: ${stored.access}` : ""}` +
-        `${keep ? "" : " — for this sign-in only"}.`
+        `${transient ? " — for this sign-in only" : ""}.`
     );
     outputJson({
       ok: true,
@@ -794,14 +809,22 @@ async function cmdAdd(flags) {
       access: effectiveAccess(stored),
       createdAt: stored.createdAt,
       updatedAt: stored.updatedAt,
-      ...(keep
-        ? {}
-        : {
+      ...(transient
+        ? {
             transient: true,
             note:
-              "The owner chose not to keep this credential. It exists for this sign-in only " +
-              "and is removed when the sign-in completes (or after 30 minutes).",
-          }),
+              "The owner chose not to keep this credential. It exists for this sign-in only: " +
+              "auto-login removes it once the sign-in completes, and otherwise it is dropped " +
+              "on the next vault open after 30 minutes.",
+          }
+        : {}),
+      ...(!keep && keepsExisting
+        ? {
+            note:
+              `The owner turned off Save to vault, but '${name}' was already saved; ` +
+              "the stored credential was updated and kept.",
+          }
+        : {}),
     });
   } finally {
     vault.lock();

--- a/plugins/agent-id-vault/lib/store.mjs
+++ b/plugins/agent-id-vault/lib/store.mjs
@@ -421,6 +421,10 @@ export function listMetadata(payload) {
           hasRecipe: Array.isArray(c.recipe) && c.recipe.length > 0,
         }
       : {}),
+    // The owner unticked "Save to vault": this record is here for one sign-in
+    // and goes when it completes (or when `transient.until` passes). A caller
+    // planning a later sign-in must not count on it.
+    ...(isTransient(c) ? { transient: true } : {}),
     createdAt: c.createdAt,
     updatedAt: c.updatedAt,
     lastUsedAt: c.lastUsedAt || null,
@@ -430,6 +434,23 @@ export function listMetadata(payload) {
 export function touchLastUsed(payload, name) {
   const rec = getCredential(payload, name);
   if (rec) rec.lastUsedAt = nowMs();
+}
+
+export function isTransient(rec) {
+  return Boolean(rec && rec.transient && typeof rec.transient === "object");
+}
+
+// Drop every transient record whose time is up. Runs on every open, so a
+// credential the owner chose not to keep is never returned past its window
+// even when the sign-in that asked for it never came back to remove it.
+// Returns the names removed; a non-empty list is the caller's cue to save.
+export function sweepTransient(payload, now = nowMs()) {
+  if (!payload || !Array.isArray(payload.credentials)) return [];
+  const expired = payload.credentials.filter(
+    (c) => isTransient(c) && typeof c.transient.until === "number" && c.transient.until <= now,
+  );
+  for (const c of expired) removeCredential(payload, c.name);
+  return expired.map((c) => c.name);
 }
 
 // Every per-type field that holds secret material — the single source of truth.

--- a/plugins/agent-id-vault/lib/store.mjs
+++ b/plugins/agent-id-vault/lib/store.mjs
@@ -440,6 +440,15 @@ export function isTransient(rec) {
   return Boolean(rec && rec.transient && typeof rec.transient === "object");
 }
 
+// The sign-in a transient record was kept for has completed: drop it. True when
+// a record went, false when there was none or it is a kept one.
+export function consumeTransient(payload, name) {
+  const rec = getCredential(payload, name);
+  if (!isTransient(rec)) return false;
+  removeCredential(payload, name);
+  return true;
+}
+
 // Drop every transient record whose time is up. Runs on every open, so a
 // credential the owner chose not to keep is never returned past its window
 // even when the sign-in that asked for it never came back to remove it.

--- a/plugins/agent-id-vault/lib/vault.mjs
+++ b/plugins/agent-id-vault/lib/vault.mjs
@@ -47,6 +47,7 @@ import {
   emptyPayload,
   getCredential,
   listMetadata,
+  sweepTransient,
   parsePayload,
   removeCredential,
   serializePayload,
@@ -182,7 +183,7 @@ export async function openVault({
   const payloadJson = decryptPayload(masterKey, file.payload);
   const payload = parsePayload(payloadJson);
 
-  return buildVaultHandle({ stateDir, file, masterKey, payload });
+  return openedHandle({ stateDir, file, masterKey, payload });
 }
 
 // Open the vault when the master key was recovered out-of-band — e.g. the
@@ -215,7 +216,17 @@ export async function openVaultWithMasterKey({ stateDir, masterKey }) {
   }
   verifyModeTag(file, masterKey);
 
-  return buildVaultHandle({ stateDir, file, masterKey, payload });
+  return openedHandle({ stateDir, file, masterKey, payload });
+}
+
+// Every open sweeps the transient records whose window has closed and writes
+// the vault back when it dropped any, so "not saved" is true on disk and not
+// only in the answer to `list`.
+async function openedHandle({ stateDir, file, masterKey, payload }) {
+  const swept = sweepTransient(payload);
+  const handle = buildVaultHandle({ stateDir, file, masterKey, payload });
+  if (swept.length > 0) await handle.save();
+  return handle;
 }
 
 // Read the mobile-slot challenges without unlocking. The proxy hands these to

--- a/plugins/agent-id-vault/lib/vault.mjs
+++ b/plugins/agent-id-vault/lib/vault.mjs
@@ -46,6 +46,7 @@ import {
   addCredential,
   emptyPayload,
   getCredential,
+  consumeTransient,
   listMetadata,
   sweepTransient,
   parsePayload,
@@ -219,14 +220,13 @@ export async function openVaultWithMasterKey({ stateDir, masterKey }) {
   return openedHandle({ stateDir, file, masterKey, payload });
 }
 
-// Every open sweeps the transient records whose window has closed and writes
-// the vault back when it dropped any, so "not saved" is true on disk and not
-// only in the answer to `list`.
-async function openedHandle({ stateDir, file, masterKey, payload }) {
-  const swept = sweepTransient(payload);
-  const handle = buildVaultHandle({ stateDir, file, masterKey, payload });
-  if (swept.length > 0) await handle.save();
-  return handle;
+// Every open drops the transient records whose window has closed, so no reader
+// sees one past its time. The sweep is in memory only: an open that also wrote
+// would turn `list` and `show` into writers racing whoever is mid-`add`. The
+// disk catches up with the next real save, which carries the swept payload.
+function openedHandle({ stateDir, file, masterKey, payload }) {
+  sweepTransient(payload);
+  return buildVaultHandle({ stateDir, file, masterKey, payload });
 }
 
 // Read the mobile-slot challenges without unlocking. The proxy hands these to
@@ -332,6 +332,10 @@ function buildVaultHandle({ stateDir, file, masterKey, payload }) {
     remove(name) {
       assertOpen();
       return removeCredential(state.payload, name);
+    },
+    consumeTransient(name) {
+      assertOpen();
+      return consumeTransient(state.payload, name);
     },
     touchLastUsed(name) {
       assertOpen();

--- a/tests/test-secure-form.mjs
+++ b/tests/test-secure-form.mjs
@@ -67,6 +67,33 @@ test("collects multiple fields (e.g. basic auth) in one submit", async () => {
   assert.deepEqual(values, { username: "admin", password: "s3cr3t" });
 });
 
+test("a checkbox field renders ticked per its default and answers \"true\" / \"false\"", async () => {
+  const fields = [
+    { name: "username", secret: false },
+    { name: "saveToVault", label: "Save to vault", kind: "checkbox", default: "true", required: false },
+  ];
+  const ticked = startForm({ fields });
+  const u = new URL(await ticked.urlReady);
+  const html = await (await fetch(u)).text();
+  assert.match(html, /<input id="saveToVault" name="saveToVault" type="checkbox" value="true" checked>/);
+  assert.doesNotMatch(html, /name="saveToVault"[^>]*type="text"/, "a checkbox is not a text box");
+  const token = u.searchParams.get("t");
+  await fetch(`http://127.0.0.1:${u.port}/submit`, {
+    method: "POST",
+    body: new URLSearchParams({ _token: token, username: "d@example.com", saveToVault: "true" }),
+  });
+  assert.deepEqual((await ticked.done).values, { username: "d@example.com", saveToVault: "true" });
+
+  // An unticked box posts nothing; the answer is still "false", never "".
+  const unticked = startForm({ fields });
+  const u2 = new URL(await unticked.urlReady);
+  await fetch(`http://127.0.0.1:${u2.port}/submit`, {
+    method: "POST",
+    body: new URLSearchParams({ _token: u2.searchParams.get("t"), username: "d@example.com" }),
+  });
+  assert.deepEqual((await unticked.done).values, { username: "d@example.com", saveToVault: "false" });
+});
+
 test("rejects a submit with the wrong token and keeps waiting (then times out)", async () => {
   const { urlReady, done } = startForm({
     fields: [{ name: "value" }],

--- a/tests/test-secure-prompt.mjs
+++ b/tests/test-secure-prompt.mjs
@@ -148,6 +148,37 @@ test("TtyProvider is single-line only (multiline:false)", () => {
   assert.equal(new TtyProvider().capabilities().multiline, false);
 });
 
+test("TtyProvider asks a checkbox as [Y/n] and answers \"true\" / \"false\", empty meaning the default", async () => {
+  const box = { name: "saveToVault", label: "Save to vault", kind: "checkbox", default: "true", required: false };
+  const ask = async (fields, typed) => {
+    const prompts = [];
+    const tty = new TtyProvider({
+      promptText: (p) => {
+        prompts.push(p);
+        return typed;
+      },
+      promptSecret: () => {
+        throw new Error("a checkbox is never read as a secret");
+      },
+    });
+    const { values } = await tty.collect({ fields });
+    return { values, prompts };
+  };
+
+  const on = await ask([box], "");
+  assert.deepEqual(on.values, { saveToVault: "true" });
+  assert.match(on.prompts[0], /Save to vault \[Y\/n\]/);
+
+  assert.deepEqual((await ask([box], "n")).values, { saveToVault: "false" });
+  assert.deepEqual((await ask([box], "No")).values, { saveToVault: "false" });
+  assert.deepEqual((await ask([box], "yes")).values, { saveToVault: "true" });
+
+  const off = await ask([{ ...box, default: "false" }], "");
+  assert.deepEqual(off.values, { saveToVault: "false" });
+  assert.match(off.prompts[0], /\[y\/N\]/);
+  assert.deepEqual((await ask([{ ...box, default: "false" }], "y")).values, { saveToVault: "true" });
+});
+
 test("resolver: AGENT_ID_SECURE_PROMPT forces a backend (overriding availability + order)", () => {
   // Forces tty even though a browser is available…
   assert.equal(resolveSecurePrompt({ env: { AGENT_ID_SECURE_PROMPT: "tty" } }).name, "tty");

--- a/tests/test-vault-login.mjs
+++ b/tests/test-vault-login.mjs
@@ -301,6 +301,7 @@ test("add --type login --passwordless --form shows a single identifier field, an
           ...process.env,
           AGENT_ID_NO_BROWSER: "1",
           AGENT_ID_SECURE_PROMPT: "browser",
+          AGENT_ID_SAVE_TO_VAULT_BOX: "1",
         },
       }
     );
@@ -715,7 +716,7 @@ test("a card simply dismissed is not the browser, and is not retryable either", 
 
 // ─── the "Save to vault" box ─────────────────────────────────────────────────────
 
-async function addLoginThroughTheForm(dir, submitFields) {
+async function addLoginThroughTheForm(dir, submitFields, { box = "1" } = {}) {
   const child = spawn(
     "node",
     [
@@ -724,13 +725,21 @@ async function addLoginThroughTheForm(dir, submitFields) {
       "--login-url", "https://account.example.com/sign-in",
       "--form", "--state-dir", dir,
     ],
-    { env: { ...process.env, AGENT_ID_NO_BROWSER: "1", AGENT_ID_SECURE_PROMPT: "browser" } },
+    {
+      env: {
+        ...process.env,
+        AGENT_ID_NO_BROWSER: "1",
+        AGENT_ID_SECURE_PROMPT: "browser",
+        AGENT_ID_SAVE_TO_VAULT_BOX: box,
+      },
+    },
   );
   let stdout = "";
   let stderr = "";
   child.stdout.on("data", (d) => (stdout += d));
   child.stderr.on("data", (d) => (stderr += d));
   const u = new URL(await waitForUrl(child));
+  const html = await (await fetch(u)).text();
   const res = await fetch(`http://127.0.0.1:${u.port}/submit`, {
     method: "POST",
     body: new URLSearchParams({ _token: u.searchParams.get("t"), ...submitFields }),
@@ -738,8 +747,26 @@ async function addLoginThroughTheForm(dir, submitFields) {
   assert.equal(res.status, 200);
   const code = await new Promise((r) => child.on("exit", r));
   assert.equal(code, 0, `CLI failed: ${stderr}`);
-  return JSON.parse(stdout);
+  return { ...JSON.parse(stdout), html };
 }
+
+test("with the box off (the default), the card has no Save to vault row and the credential is kept", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "vault-login-"));
+  try {
+    const privateKeyPem = await makeVault(dir);
+    const out = await addLoginThroughTheForm(dir, { username: "d@example.com" }, { box: "" });
+    assert.equal(out.ok, true);
+    assert.equal("transient" in out, false);
+    assert.doesNotMatch(out.html, /name="saveToVault"/, "no box until the phone can draw one");
+    assert.doesNotMatch(out.html, /Save to vault to use it once/, "and no line telling the owner to turn it off");
+
+    const vault = await openVault({ stateDir: dir, privateKeyPem });
+    assert.equal("transient" in vault.get("booking"), false);
+    vault.lock();
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
 
 test("an unticked Save to vault box stores the credential for this sign-in only", async () => {
   const dir = await mkdtemp(path.join(os.tmpdir(), "vault-login-"));
@@ -751,6 +778,7 @@ test("an unticked Save to vault box stores the credential for this sign-in only"
     assert.equal(out.ok, true);
     assert.equal(out.transient, true);
     assert.match(out.note, /this sign-in only/);
+    assert.match(out.html, /Turn off Save to vault to use it once/);
 
     const vault = await openVault({ stateDir: dir, privateKeyPem });
     const rec = vault.get("booking");
@@ -783,7 +811,29 @@ test("a ticked Save to vault box — or a card without one — keeps the credent
   }
 });
 
-test("a transient credential past its window is swept on the next open, and the vault is saved", async () => {
+test("turning the box off on a re-add keeps a credential the owner already saved", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "vault-login-"));
+  try {
+    const privateKeyPem = await makeVault(dir);
+    const first = await addLoginThroughTheForm(dir, { username: "old@example.com", saveToVault: "true" });
+    assert.equal("transient" in first, false);
+
+    const again = await addLoginThroughTheForm(dir, { username: "new@example.com" });
+    assert.equal(again.ok, true);
+    assert.equal("transient" in again, false);
+    assert.match(again.note, /already saved/);
+
+    const vault = await openVault({ stateDir: dir, privateKeyPem });
+    const rec = vault.get("booking");
+    assert.equal(rec.username, "new@example.com", "the re-add still updates the record");
+    assert.equal("transient" in rec, false, "and leaves it a kept one");
+    vault.lock();
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("a transient credential past its window is gone on the next open, without that open writing the vault", async () => {
   const dir = await mkdtemp(path.join(os.tmpdir(), "vault-login-"));
   try {
     const privateKeyPem = await makeVault(dir);
@@ -793,15 +843,48 @@ test("a transient credential past its window is swept on the next open, and the 
     vault.add(loginRec({ name: "kept" }));
     await vault.save();
     vault.lock();
+    const vaultFile = statePaths(dir).vaultFile;
+    const onDiskBefore = await readFile(vaultFile, "utf8");
 
+    // Every reader sees it gone, and a read-only open is still read-only: `list`
+    // racing an `add` must never write a payload of its own over the new record.
     const reopened = await openVault({ stateDir: dir, privateKeyPem });
     assert.deepEqual(reopened.list().map((c) => c.name).sort(), ["kept", "live"]);
-    reopened.lock();
+    assert.equal(reopened.get("expired"), null);
+    assert.equal(await readFile(vaultFile, "utf8"), onDiskBefore, "an open alone does not write");
 
-    // Swept from disk, not only from this handle's view of it.
+    // The next real save carries the swept payload, so the disk catches up then.
+    await reopened.save();
+    reopened.lock();
     const again = await openVault({ stateDir: dir, privateKeyPem });
     assert.equal(again.get("expired"), null);
+    assert.notEqual(await readFile(vaultFile, "utf8"), onDiskBefore);
     again.lock();
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("consumeTransient removes a transient credential once, and never a kept one", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "vault-login-"));
+  try {
+    const privateKeyPem = await makeVault(dir);
+    const vault = await openVault({ stateDir: dir, privateKeyPem });
+    vault.add(loginRec({ name: "once", transient: { until: Date.now() + 60_000 } }));
+    vault.add(loginRec({ name: "kept" }));
+
+    assert.equal(vault.consumeTransient("once"), true);
+    assert.equal(vault.get("once"), null);
+    assert.equal(vault.consumeTransient("once"), false, "already gone");
+    assert.equal(vault.consumeTransient("kept"), false);
+    assert.ok(vault.get("kept"), "a kept credential is not the sign-in's to remove");
+    assert.equal(vault.consumeTransient("nobody"), false);
+    await vault.save();
+    vault.lock();
+
+    const reopened = await openVault({ stateDir: dir, privateKeyPem });
+    assert.deepEqual(reopened.list().map((c) => c.name), ["kept"]);
+    reopened.lock();
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/tests/test-vault-login.mjs
+++ b/tests/test-vault-login.mjs
@@ -312,13 +312,19 @@ test("add --type login --passwordless --form shows a single identifier field, an
     const u = new URL(await waitForUrl(child));
     const token = u.searchParams.get("t");
 
-    // The card itself is the contract: one field, and it is the identifier.
+    // The card itself is the contract: one field to type, the identifier — and
+    // the owner's say over keeping it, which is a box, not a field.
     const html = await (await fetch(u)).text();
     const names = [...html.matchAll(/<input[^>]*\bname="([^"]+)"/g)]
       .map((m) => m[1])
       .filter((n) => n !== "_token");
-    assert.deepEqual(names, ["username"], `expected one identifier field, got ${names.join(", ")}`);
+    assert.deepEqual(
+      names,
+      ["username", "saveToVault"],
+      `expected the identifier and the Save to vault box, got ${names.join(", ")}`,
+    );
     assert.ok(!/type="password"/.test(html), "a passwordless card must render no password input");
+    assert.match(html, /name="saveToVault" type="checkbox" value="true" checked/, "the box starts ticked");
 
     const res = await fetch(`http://127.0.0.1:${u.port}/submit`, {
       method: "POST",
@@ -702,6 +708,100 @@ test("a card simply dismissed is not the browser, and is not retryable either", 
     assert.equal(out.reason, "owner_dismissed_the_card");
     assert.equal(out.retryable, false);
     assert.equal(out.action, undefined, "a dismissal asks for nothing to happen instead");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// ─── the "Save to vault" box ─────────────────────────────────────────────────────
+
+async function addLoginThroughTheForm(dir, submitFields) {
+  const child = spawn(
+    "node",
+    [
+      CLI, "add", "--name", "booking", "--type", "login",
+      "--passwordless", "--otp", "interactive",
+      "--login-url", "https://account.example.com/sign-in",
+      "--form", "--state-dir", dir,
+    ],
+    { env: { ...process.env, AGENT_ID_NO_BROWSER: "1", AGENT_ID_SECURE_PROMPT: "browser" } },
+  );
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (d) => (stdout += d));
+  child.stderr.on("data", (d) => (stderr += d));
+  const u = new URL(await waitForUrl(child));
+  const res = await fetch(`http://127.0.0.1:${u.port}/submit`, {
+    method: "POST",
+    body: new URLSearchParams({ _token: u.searchParams.get("t"), ...submitFields }),
+  });
+  assert.equal(res.status, 200);
+  const code = await new Promise((r) => child.on("exit", r));
+  assert.equal(code, 0, `CLI failed: ${stderr}`);
+  return JSON.parse(stdout);
+}
+
+test("an unticked Save to vault box stores the credential for this sign-in only", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "vault-login-"));
+  try {
+    const privateKeyPem = await makeVault(dir);
+    const before = Date.now();
+    const out = await addLoginThroughTheForm(dir, { username: "d@example.com" });
+    // An unchecked HTML checkbox posts nothing, and that is the "no" the card means.
+    assert.equal(out.ok, true);
+    assert.equal(out.transient, true);
+    assert.match(out.note, /this sign-in only/);
+
+    const vault = await openVault({ stateDir: dir, privateKeyPem });
+    const rec = vault.get("booking");
+    assert.equal(rec.username, "d@example.com");
+    assert.ok(!("saveToVault" in rec), "the box is the owner's answer, never a field of the record");
+    assert.ok(rec.transient.until > before + 25 * 60 * 1000, "kept long enough for one sign-in");
+    assert.equal(vault.list().find((c) => c.name === "booking").transient, true);
+    vault.lock();
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("a ticked Save to vault box — or a card without one — keeps the credential", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "vault-login-"));
+  try {
+    const privateKeyPem = await makeVault(dir);
+    const out = await addLoginThroughTheForm(dir, { username: "d@example.com", saveToVault: "true" });
+    assert.equal(out.ok, true);
+    assert.equal("transient" in out, false);
+
+    const vault = await openVault({ stateDir: dir, privateKeyPem });
+    const rec = vault.get("booking");
+    assert.equal("transient" in rec, false);
+    assert.ok(!("saveToVault" in rec));
+    assert.equal("transient" in vault.list().find((c) => c.name === "booking"), false);
+    vault.lock();
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("a transient credential past its window is swept on the next open, and the vault is saved", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "vault-login-"));
+  try {
+    const privateKeyPem = await makeVault(dir);
+    const vault = await openVault({ stateDir: dir, privateKeyPem });
+    vault.add(loginRec({ name: "expired", transient: { until: Date.now() - 1 } }));
+    vault.add(loginRec({ name: "live", transient: { until: Date.now() + 60_000 } }));
+    vault.add(loginRec({ name: "kept" }));
+    await vault.save();
+    vault.lock();
+
+    const reopened = await openVault({ stateDir: dir, privateKeyPem });
+    assert.deepEqual(reopened.list().map((c) => c.name).sort(), ["kept", "live"]);
+    reopened.lock();
+
+    // Swept from disk, not only from this handle's view of it.
+    const again = await openVault({ stateDir: dir, privateKeyPem });
+    assert.equal(again.get("expired"), null);
+    again.lock();
   } finally {
     await rm(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## What

The credential card (`vault add --form`, type `login`) ends with a **"Save to vault"** box, ticked by default — behind `AGENT_ID_SAVE_TO_VAULT_BOX=1` until the phone app that draws it has shipped (see Rollout).

- **Ticked, or a card without the box**: exactly today's behaviour.
- **Unticked**: the record is stored for this sign-in only. It carries `transient: { until }`, `vault list` reports `transient: true`, `vault add` answers `transient: true` plus a note. `agent-id-browser auto-login` removes it once the sign-in has completed (`vault.consumeTransient(name)`) and reports `credentialRemoved: true`. A transient record nobody consumed is dropped, in memory, by every vault open after its 30-minute window, and from disk by the next real save. An open never writes on its own: that would make `list` and `show` writers racing whoever is mid-`add`.
- **Unticked on a re-add of a credential the owner already keeps**: the record is updated and stays kept; the answer says so in a `note`. A card about this sign-in does not delete a credential saved earlier.

The value still passes through the vault: every fill path (`auto-login`, `fill-secret`) addresses a credential by vault name, so a one-shot credential is a vault record with a short life, not a value typed straight from the card.

## The field

```js
{ name: "saveToVault", label: "Save to vault", kind: "checkbox", default: "true", secret: false, required: false }
```

`kind` and `default` are new on the field spec (documented in `secure-prompt.mjs` and `secure-form.mjs`). The answer travels in the sealed plaintext as the string `"true"` / `"false"`; **absent means kept**, so an older card — or one raised with the flag off — changes nothing. The local browser form renders a real checkbox (an unticked one posts nothing, and the server reads that against the field as `"false"`, never as an absent field); the tty provider asks `[Y/n]`. The box is popped out of `formValues` before any record field is read, so it can never land in a record.

## Rollout

A phone that predates agent-ios#144 draws a checkbox field as an empty text box under a line telling the owner to turn it off. So the field and the line appear only with `AGENT_ID_SAVE_TO_VAULT_BOX=1`. Order: ship the iOS build, set the flag on the fleet, then a follow-up PR drops the gate.

## Downstream

lethe copies `kind`/`default` through its projection and adjusts the notes the model reads (alien-id/lethe#342); iOS renders the box (agent-ios#144); the wire contract is in lethe-mux#345 and documentation#131.

## Verified

`node --test` over `test-vault-*`, `test-secure-*`, `test-auto-login`, `test-escalation`, `test-mcp-server`, `test-totp`: 166 passed. New: the card renders the box ticked; with the flag off it has no box and no line about it; an unticked submit stores a `transient` record with a `note` and no `saveToVault` field; a ticked or absent answer stores a plain record; unticking on a re-add keeps a saved credential; a transient record past its window is gone on the next open without that open writing the file (proved red with the write restored), and gone from disk after the next save; `consumeTransient` removes a transient record once and never a kept one; the tty provider answers `"true"`/`"false"` from `[Y/n]`; the local form answers `"true"`/`"false"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
