### PR TITLE
fix: a recipe is a hint, and a failed sign-in keeps the credential

### DIFF
--- a/.changeset/a-recipe-is-a-hint.md
+++ b/.changeset/a-recipe-is-a-hint.md
@@ -14,7 +14,13 @@ deleted the credential the owner had typed a minute earlier.
   the redacted cause) sends the page back to the login URL and hands the run to
   the same form heuristics that sign a recipe-less credential in. The result
   carries `recipeFailed: { step, cause }` and the success message says to clear
-  the recipe. Card outcomes inside the recipe are unchanged.
+  the recipe. Card outcomes inside the recipe are unchanged. Once the owner has
+  answered a code card, a failing step no longer restarts the sign-in — the
+  round loop reads the page as it stands, so one sign-in raises one card.
+- A sign-in that reaches a host outside the credential's `domains` ends as
+  `domain-not-allowed` (`fix_credential`, `host_not_in_domains`) instead of a
+  crash: the fix is the allowlist, not a human at the page.
+- Error causes strike out the username as well as the password and the code.
 - A run that throws is reported as `AUTO_LOGIN_FAILED` with `outcome: "error"`,
   `action: owner_must_drive`, `pageError` and the `trace`, like every other
   ending.

--- a/.changeset/a-recipe-is-a-hint.md
+++ b/.changeset/a-recipe-is-a-hint.md
@@ -1,0 +1,26 @@
+---
+"@alien-id/agent-id-browser": minor
+---
+
+A recipe is a hint, and a failed sign-in never costs the owner their credential.
+
+`auto-login` used to die on the first recipe step that missed its element: the
+error left `runRecipe` with the cause dropped, `autoLogin` rethrew it, and the
+CLI printed a bare `{"ok":false,"error":…}` — no `outcome`, no `action`, no
+`trace`. Read cold, that looked like a verdict on the stored values, and an agent
+deleted the credential the owner had typed a minute earlier.
+
+- A step that fails against the page (`RECIPE_STEP_FAILED`, naming the step and
+  the redacted cause) sends the page back to the login URL and hands the run to
+  the same form heuristics that sign a recipe-less credential in. The result
+  carries `recipeFailed: { step, cause }` and the success message says to clear
+  the recipe. Card outcomes inside the recipe are unchanged.
+- A run that throws is reported as `AUTO_LOGIN_FAILED` with `outcome: "error"`,
+  `action: owner_must_drive`, `pageError` and the `trace`, like every other
+  ending.
+- Every escalation carries `credential: "intact" | "rejected"`, and the messages
+  for `failed` and the default no longer read as "re-add it": they say to
+  re-store in place with `overwrite` only if the owner confirms, and never to
+  remove.
+- The `otp` write-back the 9.0.0 rewrite dropped is back: a stored `otp: none`
+  corrected mid-run reaches the vault again.

--- a/.changeset/a-refusal-carries-a-code.md
+++ b/.changeset/a-refusal-carries-a-code.md
@@ -1,0 +1,7 @@
+---
+"@alien-id/agent-id-vault": patch
+---
+
+`assertHostAllowed` throws with `code: "HOST_NOT_ALLOWED"` (and the offending
+`host`), so a caller can tell a domain-allowlist refusal from a page fault
+without reading the sentence.

--- a/plugins/agent-id-browser/bin/cli.mjs
+++ b/plugins/agent-id-browser/bin/cli.mjs
@@ -194,12 +194,15 @@ async function cmdAutoLogin(flags) {
     // wrong password is distinguishable from a changed form or a redirect that
     // was never awaited. Never includes a secret.
     const trace = [];
-    // Any occurrence of the password in an error is struck out before it can
-    // reach stdout; the message class (a selector that never appeared, a
+    // Any occurrence of the stored values in an error is struck out before it
+    // can reach stdout; the message class (a selector that never appeared, a
     // browser that went away) is what the caller needs and is kept.
     const redacted = (text) => {
-      const out = String(text ?? "");
-      return cred.password ? out.split(cred.password).join("•••") : out;
+      let out = String(text ?? "");
+      for (const secret of [cred.password, cred.username]) {
+        if (typeof secret === "string" && secret.length > 0) out = out.split(secret).join("•••");
+      }
+      return out;
     };
     let result;
     try {
@@ -226,7 +229,13 @@ async function cmdAutoLogin(flags) {
       // `action` it gets for any other ending. Left as a bare error it once
       // read as a verdict on the credential, and the record the owner had just
       // typed was deleted for it.
-      result = { ok: false, outcome: "error", finalUrl: null, errorText: redacted(err?.message ?? err) };
+      result = {
+        ok: false,
+        outcome: "error",
+        finalUrl: null,
+        errorText: redacted(err?.message ?? err),
+        ...(err?.recipeFailed ? { recipeFailed: err.recipeFailed } : {}),
+      };
     }
 
     if (!result || !result.ok) {
@@ -270,7 +279,7 @@ async function cmdAutoLogin(flags) {
         "cookies (close it, or flush it, to be sure they are on disk)." +
         (recipeFailed
           ? ` The stored recipe failed at '${recipeFailed.step ?? "?"}' and was bypassed; clear it ` +
-            `(\`set-recipe --name ${credName} --clear\`) so the next sign-in does not try it.`
+            `the stored recipe on '${credName}' so the next sign-in does not try it.`
           : ""),
     });
   } catch (err) {

--- a/plugins/agent-id-browser/bin/cli.mjs
+++ b/plugins/agent-id-browser/bin/cli.mjs
@@ -194,29 +194,61 @@ async function cmdAutoLogin(flags) {
     // wrong password is distinguishable from a changed form or a redirect that
     // was never awaited. Never includes a secret.
     const trace = [];
-    const result = await autoLogin({
-      page,
-      cred,
-      env: process.env,
-      log: (m) => {
-        stderr(m);
-        trace.push(m);
-      },
-    });
+    // Any occurrence of the password in an error is struck out before it can
+    // reach stdout; the message class (a selector that never appeared, a
+    // browser that went away) is what the caller needs and is kept.
+    const redacted = (text) => {
+      const out = String(text ?? "");
+      return cred.password ? out.split(cred.password).join("•••") : out;
+    };
+    let result;
+    try {
+      result = await autoLogin({
+        page,
+        cred,
+        env: process.env,
+        log: (m) => {
+          stderr(m);
+          trace.push(m);
+        },
+        // The run corrects a stored `otp: none` the moment the site asks for a
+        // code; the vault is ours to write, so the correction lands here.
+        onOtpModeCorrected: async (otp) => {
+          const stored = vault.get(credName);
+          if (!stored) return;
+          stored.otp = otp;
+          vault.add(stored);
+          await vault.save();
+        },
+      });
+    } catch (err) {
+      // A run that threw is a run that ended, and the caller needs the same
+      // `action` it gets for any other ending. Left as a bare error it once
+      // read as a verdict on the credential, and the record the owner had just
+      // typed was deleted for it.
+      result = { ok: false, outcome: "error", finalUrl: null, errorText: redacted(err?.message ?? err) };
+    }
 
     if (!result || !result.ok) {
       const outcome = result ? result.outcome : "unknown";
+      const pageError = result && result.errorText ? redacted(result.errorText) : null;
       // `action` is the contract the calling agent branches on: who has to act,
       // and what they can do about it. See lib/escalation.mjs.
-      const { action, reason, message } = escalationFor(outcome, { credName, profile: credName });
+      const { action, reason, message, credential } = escalationFor(outcome, {
+        credName,
+        profile: credName,
+        pageError,
+      });
       outputJson({
         ok: false,
         error: "AUTO_LOGIN_FAILED",
         outcome,
         action,
         reason,
+        credential,
         finalUrl: result ? result.finalUrl : null,
-        ...(result && result.errorText ? { pageError: result.errorText } : {}),
+        ...(pageError ? { pageError } : {}),
+        ...(result && result.recipeFailed ? { recipeFailed: result.recipeFailed } : {}),
         trace,
         message,
       });
@@ -226,14 +258,20 @@ async function cmdAutoLogin(flags) {
 
     vault.touchLastUsed(credName);
     await vault.save();
+    const recipeFailed = result.recipeFailed || null;
     outputJson({
       ok: true,
       cred: credName,
       outcome: result.outcome,
       finalUrl: result.finalUrl,
+      ...(recipeFailed ? { recipeFailed } : {}),
       message:
         `Signed in as '${credName}'. The browser holds the session; its own profile keeps the ` +
-        "cookies (close it, or flush it, to be sure they are on disk).",
+        "cookies (close it, or flush it, to be sure they are on disk)." +
+        (recipeFailed
+          ? ` The stored recipe failed at '${recipeFailed.step ?? "?"}' and was bypassed; clear it ` +
+            `(\`set-recipe --name ${credName} --clear\`) so the next sign-in does not try it.`
+          : ""),
     });
   } catch (err) {
     handleErr(err);

--- a/plugins/agent-id-browser/lib/auto-login.mjs
+++ b/plugins/agent-id-browser/lib/auto-login.mjs
@@ -216,12 +216,35 @@ export async function runRecipe(
   // would put "c", "o", "d"… across the row. A code embedded in a longer string
   // is not a code screen's row; it goes through the ordinary verbs.
   const carriesOtp = (tpl) => typeof tpl === "string" && tpl.trim() === "{otp}";
+  // The cause survives — a selector that never appeared reads as one — but any
+  // occurrence of the values themselves is struck out first.
+  const redactSecrets = (text) => {
+    let out = String(text ?? "");
+    for (const secret of [password, otp]) {
+      if (typeof secret === "string" && secret.length > 0) out = out.split(secret).join("•••");
+    }
+    return out.slice(0, 200);
+  };
+  // Every page-touching step runs under this. A failure against the page — the
+  // element never appeared, the click found nothing — becomes RECIPE_STEP_FAILED
+  // naming the step, which is what lets the caller tell a broken recipe from a
+  // refused sign-in and fall back. Errors that carry a code of their own (a card
+  // outcome, a refusal) pass through untouched; a code resolution failure never
+  // reaches here at all, it happens in `sub` first.
   const guarded = async (tpl, run) => {
-    if (!carriesSecret(tpl)) return run();
     try {
       return await run();
-    } catch {
-      throw new Error(`recipe step '${tpl}' failed while entering a secret value`);
+    } catch (err) {
+      if (err?.code) throw err;
+      const cause = redactSecrets(err?.message ?? err);
+      const e = new Error(
+        carriesSecret(tpl)
+          ? `recipe step '${tpl}' failed while entering a secret value: ${cause}`
+          : `recipe step '${tpl}' failed: ${cause}`
+      );
+      e.code = "RECIPE_STEP_FAILED";
+      e.step = tpl;
+      throw e;
     }
   };
   // Refuse a secret-bearing step on an origin the credential was never scoped to.
@@ -246,7 +269,7 @@ export async function runRecipe(
         }
         const url = await sub(step.url);
         assertHostAllowed(hostOf(url), domains, "recipe navigate: refusing");
-        await driver.navigate(page, url);
+        await guarded(step.url, () => driver.navigate(page, url));
         break;
       }
       // Each of the four below resolves its values FIRST, re-checks the origin, and
@@ -282,14 +305,14 @@ export async function runRecipe(
         gateSecret(step, "recipe click");
         const selector = await sub(step.selector);
         gateSecret(step, "recipe click");
-        await driver.click(page, selector);
+        await guarded(step.selector, () => driver.click(page, selector));
         break;
       }
       case "press": {
         gateSecret(step, "recipe press");
         const selector = await sub(step.selector);
         gateSecret(step, "recipe press");
-        await driver.press(page, selector, step.key || "Enter");
+        await guarded(step.selector, () => driver.press(page, selector, step.key || "Enter"));
         break;
       }
       case "wait":
@@ -1136,11 +1159,47 @@ async function awaitDeviceConfirmation(page, cred, { log, settleMs, budgetMs }) 
  * with; `page` is the adapter in lib/rpc-page.mjs, or any object offering the
  * same handful of methods.
  */
-export async function autoLogin({
+/**
+ * Drive a full auto-login against `cred`. The recipe, when the record has one,
+ * is a hint: a step that fails hands the page back to the form heuristics that
+ * sign a recipe-less credential in, and the result says so in `recipeFailed`
+ * so the caller can retire the recipe. A card outcome inside the recipe is
+ * still the run's outcome.
+ */
+export async function autoLogin(options) {
+  const marks = {};
+  const result = await driveLogin({ ...options, marks });
+  return marks.recipeFailed ? { ...result, recipeFailed: marks.recipeFailed } : result;
+}
+
+// The default sign-in when no recipe drives it: Microsoft's fixed ids where the
+// page is theirs, the heuristic username/password fill everywhere else.
+async function formLogin(page, cred, log) {
+  if (await detectMicrosoftFlow(page)) {
+    // Microsoft ADFS / Entra: stable element IDs the heuristic can't drive.
+    await microsoftLogin(page, cred, log);
+  } else {
+    await heuristicLogin(page, cred);
+  }
+}
+
+// Which recipe step a RECIPE_STEP_FAILED error names, for the report.
+function recipeStepOf(err) {
+  if (err && typeof err.step === "string") return err.step;
+  const m = /recipe step '([^']+)'/.exec(String(err?.message ?? ""));
+  return m ? m[1] : null;
+}
+
+async function driveLogin({
   page,
   cred,
   env = process.env,
   log = () => {},
+  // Where the recipe fallback and the recipe-less path sign in; injectable so the
+  // fallback tests without a browser.
+  formLoginFn = formLogin,
+  // Written to when the recipe failed and the heuristics took over.
+  marks = {},
   // The identifier step now legitimately spends rounds: a screen asking only for
   // an e-mail or phone classifies as "unknown" until the site advances, where it
   // used to short-circuit to a (wrong) "logged-in" on the first look. Six rounds
@@ -1269,6 +1328,7 @@ export async function autoLogin({
     }
   };
 
+  let recipeDone = false;
   if (Array.isArray(cred.recipe) && cred.recipe.length) {
     try {
       await runRecipe(page, cred.recipe, {
@@ -1277,18 +1337,26 @@ export async function autoLogin({
         getOtp,
         domains: cred.domains,
       });
+      recipeDone = true;
     } catch (err) {
       if (err?.code === "FORM_USE_BROWSER") return ownerWillDrive();
       if (err?.code === "FORM_CANCELLED") return otpDeclined();
-      if (err?.code !== "FORM_TIMEOUT") throw err;
-      return otpTimedOut();
+      if (err?.code === "FORM_TIMEOUT") return otpTimedOut();
+      if (err?.code !== "RECIPE_STEP_FAILED") throw err;
+      // The recipe was written by the model from a snapshot, and a selector it
+      // guessed wrong is not a reason to lose the sign-in — or, as once
+      // happened, the credential: a bare error here left the caller without an
+      // outcome and it deleted the record the owner had just typed. The page
+      // goes back to the start and the heuristics that sign a recipe-less
+      // credential in take over; the report names the step so the recipe can go.
+      const cause = String(err?.message ?? err).slice(0, 200);
+      marks.recipeFailed = { step: recipeStepOf(err), cause };
+      log(`auto-login: the stored recipe failed (${cause}) — falling back to the form heuristics`);
+      await page.goto(cred.loginUrl, { waitUntil: "domcontentloaded", timeout: 30000 });
+      await page.waitForTimeout(settleMs);
     }
-  } else if (await detectMicrosoftFlow(page)) {
-    // Microsoft ADFS / Entra: stable element IDs the heuristic can't drive.
-    await microsoftLogin(page, cred, log);
-  } else {
-    await heuristicLogin(page, cred);
   }
+  if (!recipeDone) await formLoginFn(page, cred, log);
   await page.waitForTimeout(settleMs);
 
   for (let round = 0; round < maxRounds; round++) {

--- a/plugins/agent-id-browser/lib/auto-login.mjs
+++ b/plugins/agent-id-browser/lib/auto-login.mjs
@@ -193,6 +193,16 @@ export const pageDriver = {
 // `driver` maps the action vocabulary to page interactions; it defaults to the
 // page driver above and is injectable so the mapping/{otp}-lazy-resolution
 // logic unit-tests without a browser.
+// The errors `runRecipe` lets out of a step as they are: the card's own endings,
+// and a refusal to leave the credential's domains. Everything else a step throws
+// is a page fault and is reported as one.
+const RECIPE_PASSTHROUGH_CODES = new Set([
+  "FORM_USE_BROWSER",
+  "FORM_CANCELLED",
+  "FORM_TIMEOUT",
+  "HOST_NOT_ALLOWED",
+]);
+
 export async function runRecipe(
   page,
   steps,
@@ -220,22 +230,27 @@ export async function runRecipe(
   // occurrence of the values themselves is struck out first.
   const redactSecrets = (text) => {
     let out = String(text ?? "");
-    for (const secret of [password, otp]) {
+    for (const secret of [password, otp, username]) {
       if (typeof secret === "string" && secret.length > 0) out = out.split(secret).join("•••");
     }
     return out.slice(0, 200);
   };
   // Every page-touching step runs under this. A failure against the page — the
-  // element never appeared, the click found nothing — becomes RECIPE_STEP_FAILED
-  // naming the step, which is what lets the caller tell a broken recipe from a
-  // refused sign-in and fall back. Errors that carry a code of their own (a card
-  // outcome, a refusal) pass through untouched; a code resolution failure never
-  // reaches here at all, it happens in `sub` first.
+  // element never appeared, the click found nothing, the browser refused the
+  // click — becomes RECIPE_STEP_FAILED naming the step, which is what lets the
+  // caller tell a broken recipe from a refused sign-in and fall back. Only the
+  // codes this engine itself branches on (a card outcome, an allowlist refusal)
+  // pass through: the browser's RPC stamps a code of its own on every error it
+  // returns, and letting those through is how a click the page blocked skipped
+  // the fallback. A code resolution failure never reaches here at all, it
+  // happens in `sub` first. `otpConsumed` says whether the owner has already
+  // answered a card by the time the step failed — the caller must not start the
+  // sign-in over from a page that has moved past it.
   const guarded = async (tpl, run) => {
     try {
       return await run();
     } catch (err) {
-      if (err?.code) throw err;
+      if (RECIPE_PASSTHROUGH_CODES.has(err?.code)) throw err;
       const cause = redactSecrets(err?.message ?? err);
       const e = new Error(
         carriesSecret(tpl)
@@ -244,6 +259,7 @@ export async function runRecipe(
       );
       e.code = "RECIPE_STEP_FAILED";
       e.step = tpl;
+      e.otpConsumed = otp !== undefined;
       throw e;
     }
   };
@@ -1168,8 +1184,13 @@ async function awaitDeviceConfirmation(page, cred, { log, settleMs, budgetMs }) 
  */
 export async function autoLogin(options) {
   const marks = {};
-  const result = await driveLogin({ ...options, marks });
-  return marks.recipeFailed ? { ...result, recipeFailed: marks.recipeFailed } : result;
+  try {
+    const result = await driveLogin({ ...options, marks });
+    return marks.recipeFailed ? { ...result, recipeFailed: marks.recipeFailed } : result;
+  } catch (err) {
+    if (marks.recipeFailed && err && typeof err === "object") err.recipeFailed = marks.recipeFailed;
+    throw err;
+  }
 }
 
 // The default sign-in when no recipe drives it: Microsoft's fixed ids where the
@@ -1223,7 +1244,12 @@ async function driveLogin({
   // The whole run — warmup, the login page, every recipe step — happens on the
   // credential's own origins. Checked once here so a loginUrl pointing off the
   // allowlist fails before a browser goes anywhere, not after.
-  assertHostAllowed(hostOf(cred.loginUrl), cred.domains, "loginUrl: refusing");
+  try {
+    assertHostAllowed(hostOf(cred.loginUrl), cred.domains, "loginUrl: refusing");
+  } catch (err) {
+    if (err?.code !== "HOST_NOT_ALLOWED") throw err;
+    return { ok: false, outcome: "domain-not-allowed", finalUrl: null, errorText: err.message };
+  }
   const getOtp = (retry, destination, length) =>
     resolveOtpFn(cred, { env, log, retry, destination, length });
   // One run answers a code challenge twice at most, and the second attempt is
@@ -1328,7 +1354,7 @@ async function driveLogin({
     }
   };
 
-  let recipeDone = false;
+  let skipFormLogin = false;
   if (Array.isArray(cred.recipe) && cred.recipe.length) {
     try {
       await runRecipe(page, cred.recipe, {
@@ -1337,26 +1363,39 @@ async function driveLogin({
         getOtp,
         domains: cred.domains,
       });
-      recipeDone = true;
+      skipFormLogin = true;
     } catch (err) {
       if (err?.code === "FORM_USE_BROWSER") return ownerWillDrive();
       if (err?.code === "FORM_CANCELLED") return otpDeclined();
       if (err?.code === "FORM_TIMEOUT") return otpTimedOut();
+      if (err?.code === "HOST_NOT_ALLOWED") {
+        return { ok: false, outcome: "domain-not-allowed", finalUrl: page.url(), errorText: err.message };
+      }
       if (err?.code !== "RECIPE_STEP_FAILED") throw err;
       // The recipe was written by the model from a snapshot, and a selector it
       // guessed wrong is not a reason to lose the sign-in — or, as once
       // happened, the credential: a bare error here left the caller without an
-      // outcome and it deleted the record the owner had just typed. The page
-      // goes back to the start and the heuristics that sign a recipe-less
-      // credential in take over; the report names the step so the recipe can go.
+      // outcome and it deleted the record the owner had just typed. The report
+      // names the step so the recipe can go. What happens next depends on how
+      // far the recipe got: before any card, the page goes back to the start and
+      // the heuristics that sign a recipe-less credential in take over; once the
+      // owner has answered a code card, the sign-in is past the point a restart
+      // can reach — the code is typed or the page has moved on — and starting
+      // over would raise a second card for the same sign-in. The round loop
+      // reads the page as it stands instead.
       const cause = String(err?.message ?? err).slice(0, 200);
       marks.recipeFailed = { step: recipeStepOf(err), cause };
-      log(`auto-login: the stored recipe failed (${cause}) — falling back to the form heuristics`);
-      await page.goto(cred.loginUrl, { waitUntil: "domcontentloaded", timeout: 30000 });
-      await page.waitForTimeout(settleMs);
+      if (err.otpConsumed) {
+        log(`auto-login: the stored recipe failed after the code was entered (${cause}) — continuing from the current page`);
+        skipFormLogin = true;
+      } else {
+        log(`auto-login: the stored recipe failed (${cause}) — falling back to the form heuristics`);
+        await page.goto(cred.loginUrl, { waitUntil: "domcontentloaded", timeout: 30000 });
+        await page.waitForTimeout(settleMs);
+      }
     }
   }
-  if (!recipeDone) await formLoginFn(page, cred, log);
+  if (!skipFormLogin) await formLoginFn(page, cred, log);
   await page.waitForTimeout(settleMs);
 
   for (let round = 0; round < maxRounds; round++) {

--- a/plugins/agent-id-browser/lib/escalation.mjs
+++ b/plugins/agent-id-browser/lib/escalation.mjs
@@ -194,7 +194,21 @@ function escalationMessage(outcome, { credName = "", profile = "", pageError = n
           `${pageError ? ` (${pageError})` : ""}. The stored credential was not rejected — ` +
           "leave it in the vault and do NOT remove it. Ask the owner to sign in once in the " +
           `browser view for profile '${profile}'. If the message names a recipe step, the ` +
-          "recipe is wrong: clear it (`set-recipe --clear`) before the next auto-login.",
+          "recipe is wrong: clear the stored recipe before the next auto-login.",
+      };
+    // The sign-in reached a host the credential was never scoped to — a redirect
+    // through an identity provider, a recipe step pointing off-site. The secret
+    // was withheld, so nothing about it is in doubt, and no human at the page
+    // changes what the allowlist says: the allowlist has to.
+    case "domain-not-allowed":
+      return {
+        action: FIX_CREDENTIAL,
+        reason: "host_not_in_domains",
+        message:
+          `The sign-in for '${credName}' reached a host outside the credential's domains` +
+          `${pageError ? ` (${pageError})` : ""}, so the secret was withheld. Add that host to ` +
+          "the credential's `domains` (wildcards like *.example.com are allowed) and run " +
+          "auto-login again. The stored values are fine — never remove the credential for this.",
       };
     // Timed out or never resolved: could be a changed form, an unusual flow, or
     // an identity provider that refuses automation. A human at the page both

--- a/plugins/agent-id-browser/lib/escalation.mjs
+++ b/plugins/agent-id-browser/lib/escalation.mjs
@@ -31,7 +31,17 @@ export const FIX_CREDENTIAL = "fix_credential";
  * Returns { action, reason, message }. `reason` is a stable slug for clients;
  * `message` is what the model reads, and says exactly one next step.
  */
-export function escalationFor(outcome, { credName = "", profile = "" } = {}) {
+export function escalationFor(outcome, ctx = {}) {
+  const escalation = escalationMessage(outcome, ctx);
+  // Whether the stored values are in doubt, as a field a host can gate on
+  // without reading the prose. Only a rejection by the site puts them in doubt;
+  // every other way a sign-in ends leaves the credential exactly as typed, and
+  // an agent that read "fix" as "delete" once cost the owner a card they had
+  // just filled in.
+  return { credential: outcome === "failed" ? "rejected" : "intact", ...escalation };
+}
+
+function escalationMessage(outcome, { credName = "", profile = "", pageError = null } = {}) {
   switch (outcome) {
     // The login handshake is exactly where anti-automation bites. No credential
     // clears it — only a human working the page.
@@ -167,8 +177,24 @@ export function escalationFor(outcome, { credName = "", profile = "" } = {}) {
         action: FIX_CREDENTIAL,
         reason: "credentials_rejected",
         message:
-          `The site rejected the stored credentials for '${credName}'. Ask the owner to ` +
-          "re-enter them (`vault_add` with overwrite) rather than retrying the same values.",
+          `The site rejected the stored credentials for '${credName}'. Tell the owner, and ` +
+          "re-store them with `vault_add` and `overwrite: true` only if they confirm the values " +
+          "changed — that call raises the card again and replaces the record in place. Never " +
+          "remove the credential to retry, and do not retry the same values.",
+      };
+    // The run stopped on its own fault — a recipe step that never found its
+    // element, a browser that went away — before the site said anything about the
+    // credential. Nothing about the stored values is in doubt.
+    case "error":
+      return {
+        action: OWNER_MUST_DRIVE,
+        reason: "auto_login_crashed",
+        message:
+          `Auto-login for '${credName}' stopped before it could finish` +
+          `${pageError ? ` (${pageError})` : ""}. The stored credential was not rejected — ` +
+          "leave it in the vault and do NOT remove it. Ask the owner to sign in once in the " +
+          `browser view for profile '${profile}'. If the message names a recipe step, the ` +
+          "recipe is wrong: clear it (`set-recipe --clear`) before the next auto-login.",
       };
     // Timed out or never resolved: could be a changed form, an unusual flow, or
     // an identity provider that refuses automation. A human at the page both
@@ -181,9 +207,11 @@ export function escalationFor(outcome, { credName = "", profile = "" } = {}) {
           `Auto-login for '${credName}' did not complete (${outcome}). This is common for ` +
           "big-IdP sign-in (Google, Microsoft), which refuses automated credential entry. " +
           "Read `trace` and `pageError` first: a rejection message there means the stored " +
-          "credential is wrong (fix it), not that a human is needed. Otherwise ask the owner " +
-          `to sign in once in the browser view for profile '${profile}'; the session then ` +
-          "seals and later visits are headless.",
+          "credential is wrong (tell the owner; re-store with `vault_add` and `overwrite: true` " +
+          "only if they confirm), not that a human is needed. Otherwise ask the owner to sign " +
+          `in once in the browser view for profile '${profile}'; the session then seals and ` +
+          "later visits are headless. Either way the credential stays in the vault — never " +
+          "remove it because a sign-in did not complete.",
       };
   }
 }

--- a/plugins/agent-id-vault/lib/access.mjs
+++ b/plugins/agent-id-vault/lib/access.mjs
@@ -70,11 +70,14 @@ export function hostMatchesAllowlist(host, allowlist) {
 // never interpolated — only the host — so this is safe to hand to an agent.
 export function assertHostAllowed(host, domains, what) {
   if (hostMatchesAllowlist(host, domains)) return;
-  throw new Error(
+  const e = new Error(
     `${what} "${host || "(no host)"}" — not on the credential's domain allowlist ` +
       `(${(domains || []).join(", ") || "none"}). Add the host to the credential's ` +
       "domains (wildcards like *.example.com are allowed), or fix the credential.",
   );
+  e.code = "HOST_NOT_ALLOWED";
+  e.host = host || null;
+  throw e;
 }
 
 // ─── Naming a credential on screen ────────────────────────────────────────────

--- a/tests/test-auto-login.mjs
+++ b/tests/test-auto-login.mjs
@@ -272,19 +272,19 @@ test("runRecipe fails closed when the page cannot report its origin", async () =
 });
 
 test("autoLogin refuses a loginUrl off the credential's allowlist, before opening anything", async () => {
-  await assert.rejects(
-    autoLogin({
-      page: {},
-      cred: {
-        name: "c",
-        username: "u",
-        password: "p",
-        loginUrl: "https://evil.test/login",
-        domains: ["x"],
-      },
-    }),
-    /not on the credential's domain allowlist/
-  );
+  const result = await autoLogin({
+    page: {},
+    cred: {
+      name: "c",
+      username: "u",
+      password: "p",
+      loginUrl: "https://evil.test/login",
+      domains: ["x"],
+    },
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.outcome, "domain-not-allowed");
+  assert.match(result.errorText, /not on the credential's domain allowlist/);
 });
 
 test("resolveOtp generates a code from a stored TOTP seed (RFC vector)", async () => {
@@ -1059,6 +1059,202 @@ test("a secret step's failure keeps the cause and strikes the value out", async 
       assert.match(err.message, /no element matches #pass/);
       assert.match(err.message, /•••/);
       assert.doesNotMatch(err.message, /s3cret-pass/);
+      return true;
+    }
+  );
+});
+
+// ── Only the engine's own codes leave a recipe step as they are ──────────────────
+
+test("a browser error that carries a code of its own is still a failed recipe step", async () => {
+  const driver = {
+    ...recordingDriver([]),
+    click: async () => {
+      throw Object.assign(new Error("something else owns the point (Session.dom.click)"), { code: -32000 });
+    },
+  };
+  await assert.rejects(
+    runRecipe(pageOn("https://x/login"), [{ action: "click", selector: "#submit" }], {
+      username: "daniel@x.test",
+      password: "s3cret-pass",
+      getOtp: async () => "1",
+      domains: ["x"],
+      driver,
+    }),
+    (err) => {
+      assert.equal(err.code, "RECIPE_STEP_FAILED");
+      assert.equal(err.step, "#submit");
+      assert.equal(err.otpConsumed, false);
+      assert.match(err.message, /owns the point/);
+      return true;
+    }
+  );
+});
+
+test("a card ending inside a recipe step passes through untouched", async () => {
+  const timedOut = Object.assign(new Error("the card expired"), { code: "FORM_TIMEOUT" });
+  const driver = {
+    ...recordingDriver([]),
+    click: async () => {
+      throw timedOut;
+    },
+  };
+  await assert.rejects(
+    runRecipe(pageOn("https://x/login"), [{ action: "click", selector: "#submit" }], {
+      username: "u",
+      password: "p",
+      getOtp: async () => "1",
+      domains: ["x"],
+      driver,
+    }),
+    (err) => err === timedOut
+  );
+});
+
+test("a failed step strikes the username out of the cause too", async () => {
+  const driver = {
+    ...recordingDriver([]),
+    fill: async (_p, sel, val) => {
+      throw new Error(`no element matches ${sel} to receive ${val}`);
+    },
+  };
+  await assert.rejects(
+    runRecipe(
+      pageOn("https://x/login"),
+      [{ action: "fill", selector: "#user", value: "{username}" }],
+      { username: "daniel@x.test", password: "p", getOtp: async () => "1", domains: ["x"], driver }
+    ),
+    (err) => {
+      assert.equal(err.code, "RECIPE_STEP_FAILED");
+      assert.match(err.message, /•••/);
+      assert.doesNotMatch(err.message, /daniel@x\.test/);
+      return true;
+    }
+  );
+});
+
+// ── Once the owner has answered a card, the sign-in is not started over ───────────
+
+test("a recipe that fails after the code was entered continues from the current page", async () => {
+  const loginUrl = "https://x.test/login";
+  const page = fallbackPage(loginUrl);
+  const gotos = [];
+  page.goto = async (url) => {
+    gotos.push(url);
+    page.current = url;
+  };
+  // The code screen: the round loop reads a signed-in page (the code went in
+  // before the step that failed), and the code-row probe finds no row.
+  page.evaluate = async (_fn, arg) =>
+    arg
+      ? null
+      : {
+          hasPasswordField: false,
+          hasIdentifierField: false,
+          hasOtpField: false,
+          otpFieldNames: [],
+          bodyText: "Welcome back, Daniel",
+          blocked: false,
+          errorText: null,
+        };
+  page.fill = async (selector) => {
+    if (selector === "#otp") throw new Error("boom");
+    page.current = "https://x.test/account";
+  };
+  let formLogins = 0;
+  let otpAsks = 0;
+  const result = await autoLogin({
+    page,
+    cred: {
+      name: "steam",
+      username: "daniel@x.test",
+      password: "s3cret-pass",
+      otp: "interactive",
+      loginUrl,
+      domains: ["x.test"],
+      recipe: [
+        { action: "fill", selector: "#user", value: "{username}" },
+        { action: "fill", selector: "#pass", value: "{password}" },
+        { action: "fill", selector: "#otp", value: "{otp}" },
+      ],
+    },
+    settleMs: 0,
+    resolveOtpFn: async () => {
+      otpAsks++;
+      return "123456";
+    },
+    formLoginFn: async () => {
+      formLogins++;
+    },
+  });
+
+  assert.equal(result.ok, true, JSON.stringify(result));
+  assert.equal(result.recipeFailed?.step, "{otp}");
+  assert.equal(otpAsks, 1, "the owner was asked once");
+  assert.equal(formLogins, 0, "the heuristics did not retype the values");
+  assert.equal(gotos.filter((url) => url === loginUrl).length, 1, "the page was not sent back to the start");
+});
+
+// ── A host off the allowlist is an outcome, not a crash ───────────────────────────
+
+test("a recipe that leaves the credential's domains ends as domain-not-allowed", async () => {
+  const page = fallbackPage("https://x.test/login");
+  const result = await autoLogin({
+    page,
+    cred: {
+      name: "steam",
+      username: "daniel",
+      password: "p",
+      loginUrl: "https://x.test/login",
+      domains: ["x.test"],
+      recipe: [{ action: "navigate", url: "https://evil.test/steal" }],
+    },
+    settleMs: 0,
+    formLoginFn: async () => assert.fail("the heuristics must not run on a refused recipe"),
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.outcome, "domain-not-allowed");
+  assert.match(result.errorText, /evil\.test/);
+  assert.equal("recipeFailed" in result, false);
+});
+
+test("a loginUrl off the allowlist is the same outcome before the browser moves", async () => {
+  const page = fallbackPage("https://x.test/login");
+  page.goto = async () => assert.fail("no navigation on a refused loginUrl");
+  const result = await autoLogin({
+    page,
+    cred: { name: "steam", username: "u", password: "p", loginUrl: "https://evil.test/login", domains: ["x.test"] },
+    settleMs: 0,
+  });
+
+  assert.equal(result.outcome, "domain-not-allowed");
+  assert.match(result.errorText, /loginUrl: refusing/);
+});
+
+// ── The report survives a fallback that then dies ─────────────────────────────────
+
+test("a fallback that throws still names the recipe step that failed", async () => {
+  const page = fallbackPage("https://x.test/login");
+  await assert.rejects(
+    autoLogin({
+      page,
+      cred: {
+        name: "steam",
+        username: "daniel",
+        password: "p",
+        loginUrl: "https://x.test/login",
+        domains: ["x.test"],
+        recipe: [{ action: "fill", selector: "#does-not-exist", value: "{username}" }],
+      },
+      settleMs: 0,
+      formLoginFn: async () => {
+        throw new Error("locator #i0116 was not visible within 15000ms");
+      },
+    }),
+    (err) => {
+      assert.match(err.message, /#i0116/);
+      assert.equal(err.recipeFailed?.step, "{username}");
       return true;
     }
   );

--- a/tests/test-auto-login.mjs
+++ b/tests/test-auto-login.mjs
@@ -953,3 +953,113 @@ test("the code card names the site and where the code went", () => {
   assert.match(blind.description, /email or messages/i);
   assert.ok(!/sent a code to/.test(blind.description));
 });
+
+// ── A recipe is a hint: a step that fails hands the page to the form heuristics ───
+
+// A page the round loop can read: `evaluate` answers `detectPageState` with a
+// signed-in shape once the fallback has run, and `goto` moves the url.
+function fallbackPage(loginUrl) {
+  const page = {
+    url: () => page.current,
+    current: loginUrl,
+    goto: async (url) => {
+      page.current = url;
+    },
+    waitForTimeout: async () => {},
+    evaluate: async () => ({
+      hasPasswordField: page.current === loginUrl,
+      hasIdentifierField: false,
+      hasOtpField: false,
+      otpFieldNames: [],
+      bodyText: page.current === loginUrl ? "Sign in" : "Welcome back, Daniel",
+      blocked: false,
+      errorText: null,
+    }),
+  };
+  return page;
+}
+
+test("a recipe step that fails falls back to the form heuristics and is reported, not thrown", async () => {
+  const page = fallbackPage("https://x.test/login");
+  const formLogins = [];
+  const result = await autoLogin({
+    page,
+    cred: {
+      name: "steam",
+      username: "daniel",
+      password: "s3cret-pass",
+      loginUrl: "https://x.test/login",
+      domains: ["x.test"],
+      // A selector the model guessed off a snapshot; this page has no `fill`,
+      // so the step fails the way a missing element does.
+      recipe: [
+        { action: "fill", selector: "#does-not-exist", value: "{username}" },
+        { action: "fill", selector: "#nor-this", value: "{password}" },
+      ],
+    },
+    settleMs: 0,
+    formLoginFn: async (p, cred) => {
+      formLogins.push(cred.name);
+      p.current = "https://x.test/account";
+    },
+  });
+
+  assert.equal(result.ok, true, JSON.stringify(result));
+  assert.equal(result.outcome, "logged-in");
+  assert.deepEqual(formLogins, ["steam"], "the heuristics ran once, after the recipe gave up");
+  assert.equal(result.recipeFailed?.step, "{username}");
+  assert.match(result.recipeFailed?.cause ?? "", /recipe step/);
+  assert.doesNotMatch(result.recipeFailed?.cause ?? "", /s3cret-pass/);
+});
+
+test("a recipe that runs clean leaves the heuristics alone and reports no recipe failure", async () => {
+  const page = fallbackPage("https://x.test/login");
+  // The default driver reaches the page through `fill`; give this page one.
+  page.fill = async () => {
+    page.current = "https://x.test/account";
+  };
+  let formLogins = 0;
+  const result = await autoLogin({
+    page,
+    cred: {
+      name: "steam",
+      username: "daniel",
+      password: "p",
+      loginUrl: "https://x.test/login",
+      domains: ["x.test"],
+      recipe: [{ action: "fill", selector: "#user", value: "{username}" }],
+    },
+    settleMs: 0,
+    formLoginFn: async () => {
+      formLogins++;
+    },
+  });
+
+  assert.equal(result.ok, true, JSON.stringify(result));
+  assert.equal(formLogins, 0);
+  assert.equal("recipeFailed" in result, false);
+});
+
+test("a secret step's failure keeps the cause and strikes the value out", async () => {
+  const driver = {
+    ...recordingDriver([]),
+    fill: async (_p, sel, val) => {
+      throw new Error(`no element matches ${sel} to receive ${val}`);
+    },
+  };
+  await assert.rejects(
+    runRecipe(
+      pageOn("https://x/login"),
+      [{ action: "fill", selector: "#pass", value: "{password}" }],
+      { username: "u", password: "s3cret-pass", getOtp: async () => "1", domains: ["x"], driver }
+    ),
+    (err) => {
+      assert.equal(err.code, "RECIPE_STEP_FAILED");
+      assert.equal(err.step, "{password}");
+      assert.match(err.message, /no element matches #pass/);
+      assert.match(err.message, /•••/);
+      assert.doesNotMatch(err.message, /s3cret-pass/);
+      return true;
+    }
+  );
+});

--- a/tests/test-escalation.mjs
+++ b/tests/test-escalation.mjs
@@ -179,11 +179,21 @@ test("a crashed run is an outcome with an action, and the credential is intact",
   assert.equal(e.credential, "intact");
   assert.match(e.message, /do NOT remove it/);
   assert.match(e.message, /recipe step '\{password\}'/);
-  assert.match(e.message, /set-recipe --clear/);
+  assert.match(e.message, /clear the stored recipe/i);
+  assert.doesNotMatch(e.message, /set-recipe/);
 });
 
 test("every outcome says whether the stored values are in doubt", () => {
-  for (const outcome of ["blocked", "timeout", "confirm-timeout", "otp-declined", "otp-timeout", "owner-will-drive", "error"]) {
+  for (const outcome of [
+    "blocked",
+    "timeout",
+    "confirm-timeout",
+    "otp-declined",
+    "otp-timeout",
+    "owner-will-drive",
+    "error",
+    "domain-not-allowed",
+  ]) {
     assert.equal(escalationFor(outcome, ctx).credential, "intact", outcome);
   }
   assert.equal(escalationFor("failed", ctx).credential, "rejected");
@@ -199,4 +209,15 @@ test("a rejected password is re-stored in place, never removed", () => {
 test("an unresolved login also says the credential stays", () => {
   const e = escalationFor("timeout", ctx);
   assert.match(e.message, /never remove it/i);
+});
+
+test("a host off the allowlist is fixed on the credential, not by a human at the page", () => {
+  const e = escalationFor("domain-not-allowed", { ...ctx, pageError: 'recipe navigate: refusing "evil.test"' });
+  assert.equal(e.action, FIX_CREDENTIAL);
+  assert.equal(e.reason, "host_not_in_domains");
+  assert.equal(e.credential, "intact");
+  assert.match(e.message, /evil\.test/);
+  assert.match(e.message, /domains/);
+  assert.match(e.message, /never remove/i);
+  assert.doesNotMatch(e.message, /browser view/);
 });

--- a/tests/test-escalation.mjs
+++ b/tests/test-escalation.mjs
@@ -169,3 +169,34 @@ test("otp-timeout blames nobody's credential — the owner simply was not at the
   assert.match(message, /do not ask for a password/i);
   assert.match(message, /run auto-login again/i);
 });
+
+// ── A run that stopped on its own fault leaves the credential alone ─────────────
+
+test("a crashed run is an outcome with an action, and the credential is intact", () => {
+  const e = escalationFor("error", { ...ctx, pageError: "recipe step '{password}' failed: no element" });
+  assert.equal(e.action, OWNER_MUST_DRIVE);
+  assert.equal(e.reason, "auto_login_crashed");
+  assert.equal(e.credential, "intact");
+  assert.match(e.message, /do NOT remove it/);
+  assert.match(e.message, /recipe step '\{password\}'/);
+  assert.match(e.message, /set-recipe --clear/);
+});
+
+test("every outcome says whether the stored values are in doubt", () => {
+  for (const outcome of ["blocked", "timeout", "confirm-timeout", "otp-declined", "otp-timeout", "owner-will-drive", "error"]) {
+    assert.equal(escalationFor(outcome, ctx).credential, "intact", outcome);
+  }
+  assert.equal(escalationFor("failed", ctx).credential, "rejected");
+});
+
+test("a rejected password is re-stored in place, never removed", () => {
+  const e = escalationFor("failed", ctx);
+  assert.match(e.message, /overwrite: true/);
+  assert.match(e.message, /Never remove the credential/);
+  assert.doesNotMatch(e.message, /re-enter them \(/);
+});
+
+test("an unresolved login also says the credential stays", () => {
+  const e = escalationFor("timeout", ctx);
+  assert.match(e.message, /never remove it/i);
+});


### PR DESCRIPTION
## What happened

Steam sign-in from the app (develop, agent-id-browser 8.4.0): the owner typed username + password into the card; `auto-login` returned

```
{"error":"recipe step '{password}' failed while entering a secret value","ok":false}
```

after 28 s — the model had authored a `recipe` off a page snapshot and the password step never found its element. The error carried no `outcome`, `action` or `trace` (a thrown error skips the escalation branch entirely), so the agent read it as a verdict on the values, called `vault_remove` on the credential the owner had just typed, and handed the browser over. The same values signed in on the next attempt; Steam mailed its Guard code.

## What changes

- **The recipe is a hint.** A step that fails against the page raises `RECIPE_STEP_FAILED` (step + cause, secrets struck out); `autoLogin` sends the page back to `loginUrl` and continues with the form heuristics a recipe-less credential uses. The result carries `recipeFailed: {step, cause}`; the success message says to clear the recipe. `FORM_*` card outcomes and code-resolution errors keep their paths (`autoLogin does not dress every OTP failure up as a timeout` still passes).
- **A thrown run is an outcome.** `cmdAutoLogin` reports it as `AUTO_LOGIN_FAILED` with `outcome: "error"`, `action: owner_must_drive`, `reason: auto_login_crashed`, redacted `pageError`, `trace`.
- **Every escalation says whether the values are in doubt**: `credential: "intact" | "rejected"`. `failed` and the default message no longer read as "re-add it" — re-store in place with `overwrite` only if the owner confirms, never remove.
- **Restores the `otp` write-back** #151 dropped: `cmdAutoLogin` passes `onOtpModeCorrected` again, so #142's in-place correction reaches the vault.

## Verified

- `npm test`: 701/701. The six new tests in `test-auto-login.mjs` / `test-escalation.mjs` are red with the three source files stashed and green with them.
- The write-back restoration is a one-line callback identical to 8.4.0's; it has no unit seam (it lives in the CLI's vault-open scope) and is covered by the stand run below.

Stand run (new browser stack) and the lethe side (`vault_set_recipe`, descriptions, notes) are in alien-id/lethe — linked from the sign-in-cards doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Stand run

With lethe `fix/a-failed-sign-in-keeps-the-credential` (alien-id/lethe#343), agent-browser v0.24.0 on macOS and this branch's CLIs: a credential seeded with `#does-not-exist` selectors, `auto-login --cred stayfinder --rpc …` → `ok: true, outcome: logged-in, recipeFailed: {step: "{username}", cause: "… locator #does-not-exist was not visible within 15000ms"}`; the form heuristics typed the real values and the site served its signed-in page. The agent then cleared the recipe through lethe's `vault_set_recipe` and never touched `vault_remove`.

## Review fixes (827dc5e)

- `guarded` let any error with a `code` out of the recipe; the browser RPC stamps one on every error, so a blocked click skipped the fallback and ended as `owner_must_drive`. Only the codes the engine branches on pass through now.
- A step failing after the owner answered a code card restarted the sign-in and the site mailed a second code. `RECIPE_STEP_FAILED` carries `otpConsumed`; when set, the round loop reads the page as it stands.
- `assertHostAllowed` throws `HOST_NOT_ALLOWED`; a refusal is its own outcome, `domain-not-allowed` (`fix_credential`, `host_not_in_domains`), not a crash.
- `recipeFailed` survives a fallback that then throws; the username is struck out of error causes too; messages no longer spell a CLI command the model cannot run.
